### PR TITLE
Bootstrap automation workflow and phase guardrails

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Mirror Blueprint
+    url: https://github.com/YSCJRH/mirror-sim/blob/main/mirror.md
+    about: Read the project blueprint before proposing work that changes core contracts or scope.

--- a/.github/ISSUE_TEMPLATE/phase-exit.yml
+++ b/.github/ISSUE_TEMPLATE/phase-exit.yml
@@ -1,0 +1,39 @@
+name: Mirror Phase Exit Gate
+description: Track the explicit exit criteria that must pass before automation can advance to the next phase.
+title: "[phase-exit] "
+body:
+  - type: dropdown
+    id: phase
+    attributes:
+      label: Phase
+      description: Which phase exit gate is this?
+      options:
+        - Phase 1 - World/Persona Modeling
+        - Phase 2 - Scenario/Simulation Loop
+        - Phase 3 - Eval/UI/Demo
+    validations:
+      required: true
+  - type: textarea
+    id: gate_criteria
+    attributes:
+      label: Gate criteria
+      description: Copy the blueprint exit criteria that must all be satisfied.
+      placeholder: List each required exit criterion on its own line.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence and artifacts
+      description: What local artifacts, eval summaries, docs, or PR states prove the gate is met?
+      placeholder: Point to artifacts/demo, eval summaries, ADRs, or milestone status.
+    validations:
+      required: true
+  - type: textarea
+    id: minimal_test
+    attributes:
+      label: Minimal audit command
+      description: The phase-audit command or other check that should be run.
+      placeholder: python -m backend.app.cli audit-phase phase1
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -1,0 +1,76 @@
+name: Mirror Work Item
+description: Create a Codex-friendly implementation task with explicit inputs, outputs, and tests.
+title: "[work-item] "
+body:
+  - type: dropdown
+    id: phase
+    attributes:
+      label: Phase
+      description: Which blueprint phase does this work belong to?
+      options:
+        - Phase 1 - World/Persona Modeling
+        - Phase 2 - Scenario/Simulation Loop
+        - Phase 3 - Eval/UI/Demo
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which subsystem is primarily affected?
+      options:
+        - backend
+        - frontend
+        - docs-evals
+    validations:
+      required: true
+  - type: dropdown
+    id: touches_contract
+    attributes:
+      label: Touches contract
+      description: Does this work touch a protected-core contract, ADR, or schema?
+      options:
+        - "No"
+        - "Yes"
+    validations:
+      required: true
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: One primary objective only.
+      placeholder: Describe the single most important outcome.
+    validations:
+      required: true
+  - type: textarea
+    id: input
+    attributes:
+      label: Input
+      description: Required files, artifacts, docs, or assumptions.
+      placeholder: List the concrete inputs this task depends on.
+    validations:
+      required: true
+  - type: textarea
+    id: output
+    attributes:
+      label: Output
+      description: Concrete implementation or artifact outputs.
+      placeholder: List the code, docs, tests, or artifacts this task should produce.
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: Boundaries that keep the task small and Codex-safe.
+      placeholder: Describe what must not be changed in this task.
+    validations:
+      required: true
+  - type: textarea
+    id: minimal_test
+    attributes:
+      label: Minimal test
+      description: The smallest command or test that proves the task works.
+      placeholder: ./make.ps1 test
+    validations:
+      required: true

--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -1,0 +1,135 @@
+{
+  "milestones": [
+    {
+      "title": "Phase 1 - World/Persona Modeling",
+      "description": "Produce a stable, evidence-backed world model and persona layer for the Fog Harbor demo."
+    },
+    {
+      "title": "Phase 2 - Scenario/Simulation Loop",
+      "description": "Stabilize baseline/intervention simulation, trace, report, and eval loops."
+    },
+    {
+      "title": "Phase 3 - Eval/UI/Demo",
+      "description": "Finish the workbench, final demo loop, and review-grade presentation layer."
+    }
+  ],
+  "labels": [
+    {
+      "name": "phase:1",
+      "color": "0e8a16",
+      "description": "Phase 1 world and persona modeling work."
+    },
+    {
+      "name": "phase:2",
+      "color": "1d76db",
+      "description": "Phase 2 scenario and simulation work."
+    },
+    {
+      "name": "phase:3",
+      "color": "5319e7",
+      "description": "Phase 3 UI, eval, and demo work."
+    },
+    {
+      "name": "area:backend",
+      "color": "0052cc",
+      "description": "Backend, CLI, contracts, or artifact pipeline work."
+    },
+    {
+      "name": "area:frontend",
+      "color": "fbca04",
+      "description": "Frontend or workbench UI work."
+    },
+    {
+      "name": "area:docs-evals",
+      "color": "c2e0c6",
+      "description": "Docs, ADRs, rubrics, or eval-harness work."
+    },
+    {
+      "name": "risk:core-contract",
+      "color": "b60205",
+      "description": "Touches protected-core contracts and cannot auto-merge."
+    },
+    {
+      "name": "risk:safety",
+      "color": "d93f0b",
+      "description": "Touches safety, redlines, or policy boundaries."
+    },
+    {
+      "name": "risk:ci",
+      "color": "e99695",
+      "description": "Touches CI, automation, or workflow reliability."
+    },
+    {
+      "name": "lane:auto-safe",
+      "color": "0e8a16",
+      "description": "Eligible for autonomous safe-lane execution and merge."
+    },
+    {
+      "name": "lane:protected-core",
+      "color": "b60205",
+      "description": "Protected-core lane; may be automated but must not auto-merge."
+    },
+    {
+      "name": "status:ready",
+      "color": "0e8a16",
+      "description": "Ready for Codex triage or execution."
+    },
+    {
+      "name": "status:blocked",
+      "color": "d73a4a",
+      "description": "Blocked and should not be picked by builder automation."
+    },
+    {
+      "name": "status:needs-adr",
+      "color": "5319e7",
+      "description": "Needs an ADR or contract decision before merge."
+    }
+  ],
+  "issues": [
+    {
+      "title": "Day 0 bootstrap: create a clean automation baseline",
+      "milestone": "Phase 1 - World/Persona Modeling",
+      "labels": [
+        "phase:1",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nCreate the clean baseline required before long-running automation can write code or auto-merge.\n\n## input\n- Current dirty main worktree\n- Existing Phase 0/Phase 1 repo state\n- Automation plan in docs/plans/automation-roadmap.md\n\n## output\n- A clean baseline snapshot or baseline PR\n- Confirmed milestones and label taxonomy\n- CI upgraded from phase0-only checks to long-running automation gates\n\n## out-of-scope\n- Building new product features\n- Expanding the simulation contract\n\n## minimal test\n- `git -c safe.directory=D:/mirror status --short`\n- `./make.ps1 test`\n- `./make.ps1 eval-demo`\n\n## touches contract\nYes. This work changes automation governance and merge policy.\n\n## phase\nPhase 1 bootstrap gate"
+    },
+    {
+      "title": "Phase 1 exit gate",
+      "milestone": "Phase 1 - World/Persona Modeling",
+      "labels": [
+        "phase:1",
+        "area:docs-evals",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nValidate that all Phase 1 exit criteria are met before automation advances to Phase 2.\n\n## input\n- Current artifacts/demo outputs\n- Current Phase 1 milestone state\n- ADR and contract notes\n\n## output\n- Phase audit summary\n- Gap issues if anything is missing\n- Go/no-go decision for Phase 2\n\n## out-of-scope\n- Implementing new features unrelated to exit criteria\n\n## minimal test\n- `python -m backend.app.cli audit-phase phase1`\n\n## touches contract\nYes. Exit gating can block or permit phase progression.\n\n## phase\nPhase 1"
+    },
+    {
+      "title": "Phase 2 exit gate",
+      "milestone": "Phase 2 - Scenario/Simulation Loop",
+      "labels": [
+        "phase:2",
+        "area:docs-evals",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nVerify Phase 2 exit criteria before the automation system opens Phase 3.\n\n## input\n- run/report/eval artifacts\n- open protected-core PR state\n- milestone completion state\n\n## output\n- phase audit summary\n- explicit go/no-go decision\n- follow-up gap issues when needed\n\n## out-of-scope\n- new scenario work beyond unmet criteria\n\n## minimal test\n- `python -m backend.app.cli audit-phase phase2`\n\n## touches contract\nYes. Exit gates are protected-core.\n\n## phase\nPhase 2"
+    },
+    {
+      "title": "Phase 3 exit gate",
+      "milestone": "Phase 3 - Eval/UI/Demo",
+      "labels": [
+        "phase:3",
+        "area:docs-evals",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nConfirm that all blueprint Phase 3 criteria are satisfied and the automation system can pause permanently.\n\n## input\n- final artifacts and frontend workbench\n- current milestone and PR state\n- human review rubric output\n\n## output\n- final completion report\n- PAUSED automation state\n- documented stop condition\n\n## out-of-scope\n- follow-on enterprise productization\n\n## minimal test\n- `python -m backend.app.cli audit-phase phase3`\n\n## touches contract\nYes. This issue controls the project stop condition.\n\n## phase\nPhase 3"
+    }
+  ]
+}

--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -96,7 +96,7 @@
         "status:ready",
         "lane:protected-core"
       ],
-      "body": "## goal\nCreate the clean baseline required before long-running automation can write code or auto-merge.\n\n## input\n- Current dirty main worktree\n- Existing Phase 0/Phase 1 repo state\n- Automation plan in docs/plans/automation-roadmap.md\n\n## output\n- A clean baseline snapshot or baseline PR\n- Confirmed milestones and label taxonomy\n- CI upgraded from phase0-only checks to long-running automation gates\n\n## out-of-scope\n- Building new product features\n- Expanding the simulation contract\n\n## minimal test\n- `git -c safe.directory=D:/mirror status --short`\n- `./make.ps1 test`\n- `./make.ps1 eval-demo`\n\n## touches contract\nYes. This work changes automation governance and merge policy.\n\n## phase\nPhase 1 bootstrap gate"
+      "body": "## goal\nCreate the clean baseline required before long-running automation can write code or auto-merge.\n\n## input\n- Current repository baseline state\n- Existing Phase 0/Phase 1 repo state\n- Automation plan in docs/plans/automation-roadmap.md\n\n## output\n- A clean baseline snapshot or baseline PR\n- Confirmed milestones and label taxonomy\n- CI upgraded from phase0-only checks to long-running automation gates\n\n## out-of-scope\n- Building new product features\n- Expanding the simulation contract\n\n## minimal test\n- `git -c safe.directory=D:/mirror status --short`\n- `./make.ps1 test`\n- `./make.ps1 eval-demo`\n\n## touches contract\nYes. This work changes automation governance and merge policy.\n\n## phase\nPhase 1 bootstrap gate"
     },
     {
       "title": "Phase 1 exit gate",

--- a/.github/automation/lane-policy.json
+++ b/.github/automation/lane-policy.json
@@ -1,0 +1,21 @@
+{
+  "autonomous_safe_label": "lane:auto-safe",
+  "protected_core_label": "lane:protected-core",
+  "protected_core_labels": [
+    "lane:protected-core",
+    "risk:core-contract"
+  ],
+  "automerge_blocking_labels": [
+    "risk:core-contract",
+    "status:needs-adr",
+    "risk:safety"
+  ],
+  "protected_core_prefixes": [
+    "docs/architecture/contracts.md",
+    "docs/decisions/",
+    "backend/app/domain/",
+    "backend/app/scenarios/",
+    "backend/app/simulation/",
+    "backend/app/reports/"
+  ]
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## What Changed
+
+- Describe the concrete implementation or documentation changes.
+
+## Tests
+
+- [ ] `./make.ps1 test`
+- [ ] `./make.ps1 smoke`
+- [ ] `./make.ps1 eval-demo`
+- [ ] Additional focused test(s) listed below
+
+## Artifacts
+
+- List any `artifacts/demo/**` paths, screenshots, or summaries reviewed for this PR.
+
+## Contract Impact
+
+- Does this touch schema, scenario DSL, simulation, report, claim/evidence rules, or ADRs?
+- If yes, link the relevant ADR or explain why a new ADR is required.
+
+## Safety Impact
+
+- Does this affect redlines, safety checks, or wording boundaries?
+
+## TODO[verify]
+
+- List any remaining uncertainties explicitly. If none, write `None`.

--- a/.github/workflows/phase0.yml
+++ b/.github/workflows/phase0.yml
@@ -1,11 +1,15 @@
-name: phase0
+name: mirror-ci
 
 on:
   push:
   pull_request:
 
+concurrency:
+  group: mirror-ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  linux-smoke-and-test:
+  linux-quality-gate:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,7 +29,17 @@ jobs:
       - name: Run smoke
         run: make smoke
 
-  windows-smoke-and-test:
+      - name: Run eval-demo
+        run: make eval-demo
+
+      - name: Upload demo artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-artifacts-linux
+          path: artifacts/demo
+
+  windows-quality-gate:
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -46,3 +60,7 @@ jobs:
       - name: Run smoke
         shell: pwsh
         run: .\make.ps1 smoke
+
+      - name: Run eval-demo
+        shell: pwsh
+        run: .\make.ps1 eval-demo

--- a/.github/workflows/pull-request-lane.yml
+++ b/.github/workflows/pull-request-lane.yml
@@ -1,0 +1,68 @@
+name: pull-request-lane
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  classify-lane:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout default branch policy
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Apply lane labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const policy = JSON.parse(fs.readFileSync(".github/automation/lane-policy.json", "utf8"));
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull_number = context.payload.pull_request.number;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number,
+              per_page: 100
+            });
+            const changed = files.map(file => file.filename);
+            const protectedHits = changed.filter(file =>
+              policy.protected_core_prefixes.some(prefix => file.startsWith(prefix))
+            );
+            const existingLabels = context.payload.pull_request.labels.map(label => label.name);
+            const labelsToAdd = protectedHits.length
+              ? policy.protected_core_labels.filter(label => !existingLabels.includes(label))
+              : [policy.autonomous_safe_label].filter(label => !existingLabels.includes(label));
+            for (const label of labelsToAdd) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: pull_number,
+                labels: [label]
+              });
+            }
+            if (!protectedHits.length && existingLabels.includes(policy.protected_core_label)) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: pull_number,
+                  name: policy.protected_core_label
+                });
+              } catch (error) {
+                core.warning(`Could not remove protected-core lane label: ${error.message}`);
+              }
+            }
+            core.setOutput("lane", protectedHits.length ? policy.protected_core_label : policy.autonomous_safe_label);
+            core.setOutput("protected_hits", JSON.stringify(protectedHits));

--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 # Mirror Engine
 
-Mirror Engine 是一个面向虚构或明确授权知识环境的、带证据约束的条件化推演沙盘。它用于回答 “如果某个扰动发生，关键角色、信息流和结局会怎样变化”，而不是声称能预测真实未来。
+Mirror Engine is a constrained, evidence-backed conditional simulation sandbox for fictional or explicitly authorized knowledge environments. It is designed to answer questions like "if this disturbance occurs, how do key actors, information flows, and outcomes change?" without presenting itself as a real-world future prediction machine.
 
-## Phase 0 Status
+## Current Status
 
-当前仓库已搭起 Phase 0 地基：
+The repository has completed its Phase 0 foundation and is now in Phase 1 world-model hardening.
 
-- 项目治理文档与 Codex 执行规则
-- demo 世界 “雾港东闸危机”
-- 核心 domain models 与 schema 假设
-- 最小 CLI pipeline：ingest、graph、personas、scenario、simulate、report、eval
-- smoke / test / eval-demo 命令入口
+- Governance documents and Codex execution rules are in place.
+- The canonical demo world is `Fog Harbor East Gate`.
+- The backend can ingest, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
+- The repo now also includes the bootstrap pieces for long-running automation:
+  - GitHub issue and PR templates
+  - lane policy and bootstrap spec
+  - CI upgraded to a long-running quality gate
+  - local lane-classification and phase-audit commands
 
 ## Quick Start
 
@@ -39,22 +42,29 @@ python -m backend.app.cli personas artifacts/demo/graph/graph.json --out artifac
 python -m backend.app.cli validate-scenario data/demo/scenarios/reporter_detained.yaml --out artifacts/demo/scenario/reporter_detained.json
 python -m backend.app.cli simulate data/demo/scenarios/reporter_detained.yaml --graph artifacts/demo/graph/graph.json --personas artifacts/demo/personas/personas.json --out artifacts/demo/run/reporter_detained
 python -m backend.app.cli report artifacts/demo/run/reporter_detained --baseline artifacts/demo/run/baseline --out artifacts/demo/report
+python -m backend.app.cli inspect-world --kind entity --id entity_east_gate --graph artifacts/demo/graph/graph.json --personas artifacts/demo/personas/personas.json
+python -m backend.app.cli classify-lane --files README.md backend/app/cli.py
+python -m backend.app.cli audit-phase phase1
 ```
 
 ## Repo Map
 
-- [mirror.md](/D:/mirror/mirror.md): 顶层蓝图 / harness
-- [AGENTS.md](/D:/mirror/AGENTS.md): Codex 执行规则
-- [docs/plans/phase-0-foundation.md](/D:/mirror/docs/plans/phase-0-foundation.md): 当前 Phase 0 实施说明
-- [docs/architecture/contracts.md](/D:/mirror/docs/architecture/contracts.md): 核心契约与假设
-- [data/demo](/D:/mirror/data/demo): demo world、scenarios、expectations
-- [backend](/D:/mirror/backend): FastAPI app、CLI、domain models、pipeline
-- [evals/assertions](/D:/mirror/evals/assertions): 自动化断言
-- [frontend](/D:/mirror/frontend): 延后实现的 workbench shell 占位
+- [mirror.md](/D:/mirror/mirror.md): top-level blueprint and harness
+- [AGENTS.md](/D:/mirror/AGENTS.md): Codex execution rules
+- [docs/plans/phase-0-foundation.md](/D:/mirror/docs/plans/phase-0-foundation.md): Phase 0 implementation note
+- [docs/plans/automation-roadmap.md](/D:/mirror/docs/plans/automation-roadmap.md): long-running automation bootstrap and operating plan
+- [docs/architecture/contracts.md](/D:/mirror/docs/architecture/contracts.md): durable contracts and assumptions
+- [data/demo/config/world_model.yaml](/D:/mirror/data/demo/config/world_model.yaml): demo world model and persona blueprint
+- [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
+- [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
+- [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
+- [frontend](/D:/mirror/frontend): deferred workbench shell
+- [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
+- [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
 ## Architecture Shape
 
-Phase 0 只实现最短闭环：
+The current deterministic backbone remains:
 
 ```text
 Corpus
@@ -68,29 +78,41 @@ Corpus
   -> Eval Summary
 ```
 
-设计原则：
+Key principles:
 
-- 主干确定性，LLM 在边缘
-- 先单机文件流，再考虑复杂 infra
-- report 必须带 claim labels 和 `evidence_ids`
-- safety 与 eval 不是附录，而是主流程
+- Deterministic backbone first; LLMs stay at the edge.
+- Local files and transparent artifacts first; heavy infra later.
+- Reports must carry claim labels and `evidence_ids`.
+- World model outputs must remain queryable.
+- Safety and eval are part of the main loop, not an appendix.
 
-## Known Assumptions
+## Automation Bootstrap
 
-- `RunTrace` 被实现为 run 级摘要模型；`TurnAction` 是 `run_trace.jsonl` 中的逐行动记录。
-- `reporter_detained` 是场景 ID，不是 injection kind；其注入类型实现为 `delay_document`。
-- 保留 `Makefile` 作为规范接口，同时提供 `make.ps1` / `make.cmd` 兼容当前 Windows 环境。
+Mirror now treats GitHub as the operational source of truth for long-running automation.
 
-## Non-goals For This Repo
+Repository-side automation assets:
 
-- 开放世界 ingest
-- 真实人物或真实社会建模
-- 自由 agent swarm
-- 重型图数据库
-- fancy UI 先行
-- 外部 LLM 深绑定
+- `.github/ISSUE_TEMPLATE/`
+- `.github/pull_request_template.md`
+- `.github/workflows/phase0.yml`
+- `.github/workflows/pull-request-lane.yml`
+- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`
+- `python -m backend.app.cli classify-lane ...`
+- `python -m backend.app.cli audit-phase ...`
+
+Important constraint:
+
+- Day 0 bootstrap still requires a clean baseline snapshot before autonomous code-writing loops should run on worktrees.
+
+## Non-goals
+
+- Open-world ingest
+- Real-person or real-society modeling
+- Free-form agent swarm
+- Heavy graph databases as the default
+- Fancy UI before artifacts and evals are stable
+- Deep binding to external LLM APIs in the core loop
 
 ## License
 
-This repository is licensed under `MIT`.  
-The public remote currently needs to be brought into alignment on the next push.
+This repository is licensed under `MIT`.

--- a/backend/app/automation/__init__.py
+++ b/backend/app/automation/__init__.py
@@ -1,0 +1,9 @@
+from backend.app.automation.service import PhaseAudit, classify_git_refs, classify_paths, load_lane_policy, run_phase_audit
+
+__all__ = [
+    "PhaseAudit",
+    "classify_git_refs",
+    "classify_paths",
+    "load_lane_policy",
+    "run_phase_audit",
+]

--- a/backend/app/automation/service.py
+++ b/backend/app/automation/service.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+from backend.app.config import Settings, get_settings
+from backend.app.utils import read_json
+from backend.app.world_query import inspect_world
+
+
+REQUIRED_PERSONA_FIELDS = (
+    "public_role",
+    "goals",
+    "constraints",
+    "known_facts",
+    "private_info",
+    "relationships",
+)
+
+
+@dataclass(frozen=True)
+class LaneDecision:
+    lane: str
+    labels: list[str]
+    blocking_labels: list[str]
+    protected_hits: list[str]
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class AuditCheck:
+    name: str
+    passed: bool
+    details: str
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class PhaseAudit:
+    phase: str
+    status: str
+    checks: list[AuditCheck] = field(default_factory=list)
+    failures: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict:
+        return {
+            "phase": self.phase,
+            "status": self.status,
+            "checks": [check.as_dict() for check in self.checks],
+            "failures": self.failures,
+            "notes": self.notes,
+        }
+
+
+def _repo_root_from_path(path: Path | None = None) -> Path:
+    if path is not None:
+        return path
+    return Path(__file__).resolve().parents[3]
+
+
+def load_lane_policy(policy_path: Path | None = None) -> dict:
+    path = policy_path or (_repo_root_from_path() / ".github" / "automation" / "lane-policy.json")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def classify_paths(paths: list[str], policy_path: Path | None = None) -> LaneDecision:
+    policy = load_lane_policy(policy_path)
+    protected_hits = sorted(
+        {
+            path
+            for path in paths
+            for prefix in policy["protected_core_prefixes"]
+            if path.startswith(prefix)
+        }
+    )
+    if protected_hits:
+        return LaneDecision(
+            lane=policy["protected_core_label"],
+            labels=policy["protected_core_labels"],
+            blocking_labels=policy["automerge_blocking_labels"],
+            protected_hits=protected_hits,
+        )
+    return LaneDecision(
+        lane=policy["autonomous_safe_label"],
+        labels=[policy["autonomous_safe_label"]],
+        blocking_labels=[],
+        protected_hits=[],
+    )
+
+
+def classify_git_refs(base: str, head: str, repo_root: Path | None = None, policy_path: Path | None = None) -> LaneDecision:
+    root = _repo_root_from_path(repo_root)
+    result = subprocess.run(
+        [
+            "git",
+            "-c",
+            f"safe.directory={root}",
+            "diff",
+            "--name-only",
+            f"{base}...{head}",
+        ],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    paths = [line.strip().replace("\\", "/") for line in result.stdout.splitlines() if line.strip()]
+    return classify_paths(paths, policy_path=policy_path)
+
+
+def _make_check(name: str, passed: bool, details: str) -> AuditCheck:
+    return AuditCheck(name=name, passed=passed, details=details)
+
+
+def _phase1_checks(settings: Settings, artifacts_root: Path) -> list[AuditCheck]:
+    graph_path = artifacts_root / "graph" / "graph.json"
+    personas_path = artifacts_root / "personas" / "personas.json"
+    ingest_documents = artifacts_root / "ingest" / "documents.jsonl"
+    ingest_chunks = artifacts_root / "ingest" / "chunks.jsonl"
+    checks: list[AuditCheck] = [
+        _make_check(
+            "artifacts_exist",
+            all(path.exists() for path in (ingest_documents, ingest_chunks, graph_path, personas_path)),
+            f"Expected ingest, graph, and persona artifacts under {artifacts_root}.",
+        ),
+        _make_check(
+            "world_model_config_exists",
+            settings.world_model_path.exists(),
+            f"Expected config-driven world model at {settings.world_model_path}.",
+        ),
+    ]
+    if not graph_path.exists() or not personas_path.exists():
+        return checks
+
+    graph_payload = read_json(graph_path)
+    persona_payload = read_json(personas_path)
+    world_objects = graph_payload.get("entities", []) + graph_payload.get("relations", []) + graph_payload.get("events", [])
+    checks.extend(
+        [
+            _make_check(
+                "events_present",
+                bool(graph_payload.get("events")),
+                "graph.json must include non-empty events[].",
+            ),
+            _make_check(
+                "world_objects_have_evidence",
+                all(item.get("evidence_ids") for item in world_objects),
+                "entities, relations, and events must all carry evidence_ids.",
+            ),
+        ]
+    )
+    persona_failures: list[str] = []
+    for persona in persona_payload.get("personas", []):
+        provenance = persona.get("field_provenance", {})
+        for field_name in REQUIRED_PERSONA_FIELDS:
+            if persona.get(field_name) and not provenance.get(field_name):
+                persona_failures.append(f"{persona['persona_id']}.{field_name}")
+    checks.append(
+        _make_check(
+            "persona_field_provenance",
+            not persona_failures,
+            "Missing provenance: " + (", ".join(persona_failures) if persona_failures else "none"),
+        )
+    )
+    try:
+        inspect_world("entity", "entity_east_gate", graph_path, personas_path)
+        inspect_world("persona", "persona_su_he", graph_path, personas_path)
+        inspect_world("event", "event_gate_failure_risk", graph_path, personas_path)
+    except ValueError as exc:
+        checks.append(_make_check("query_surface", False, str(exc)))
+    else:
+        checks.append(
+            _make_check(
+                "query_surface",
+                True,
+                "inspect-world can query entity_east_gate, persona_su_he, and event_gate_failure_risk.",
+            )
+        )
+
+    graph_service_text = (settings.repo_root / "backend" / "app" / "graph" / "service.py").read_text(encoding="utf-8")
+    persona_service_text = (settings.repo_root / "backend" / "app" / "personas" / "service.py").read_text(encoding="utf-8")
+    checks.append(
+        _make_check(
+            "hardcoded_world_model_removed",
+            "ENTITY_DEFINITIONS" not in graph_service_text and "PERSONA_BLUEPRINTS" not in persona_service_text,
+            "Legacy hardcoded graph/persona constants should not remain in service modules.",
+        )
+    )
+    return checks
+
+
+def _phase2_checks(artifacts_root: Path) -> list[AuditCheck]:
+    baseline_dir = artifacts_root / "run" / "baseline"
+    intervention_dir = artifacts_root / "run" / "reporter_detained"
+    report_dir = artifacts_root / "report"
+    eval_path = artifacts_root / "eval" / "summary.json"
+    required_paths = (
+        baseline_dir / "summary.json",
+        intervention_dir / "summary.json",
+        baseline_dir / "run_trace.jsonl",
+        intervention_dir / "run_trace.jsonl",
+        report_dir / "report.md",
+        report_dir / "claims.json",
+        eval_path,
+    )
+    checks: list[AuditCheck] = [
+        _make_check(
+            "phase2_artifacts_exist",
+            all(path.exists() for path in required_paths),
+            f"Expected baseline/intervention run outputs, report, and eval summary under {artifacts_root}.",
+        )
+    ]
+    if not all(path.exists() for path in required_paths):
+        return checks
+
+    baseline_summary = read_json(baseline_dir / "summary.json")
+    intervention_summary = read_json(intervention_dir / "summary.json")
+    claims = read_json(report_dir / "claims.json")
+    eval_summary = read_json(eval_path)
+    checks.extend(
+        [
+            _make_check(
+                "deterministic_seed_stable",
+                baseline_summary["seed"] == intervention_summary["seed"],
+                "Baseline and intervention summaries must use the same seed for branch comparison.",
+            ),
+            _make_check(
+                "claims_labeled_and_grounded",
+                all(claim.get("label") and claim.get("evidence_ids") for claim in claims),
+                "All report claims must have labels and evidence_ids.",
+            ),
+            _make_check(
+                "eval_demo_passes",
+                eval_summary.get("status") == "pass",
+                f"eval status was {eval_summary.get('status')}.",
+            ),
+            _make_check(
+                "snapshots_present",
+                all((run_dir / "snapshots").exists() for run_dir in (baseline_dir, intervention_dir)),
+                "Each run directory must contain snapshots/ for replayability.",
+            ),
+        ]
+    )
+    return checks
+
+
+def _phase3_checks(settings: Settings, artifacts_root: Path) -> list[AuditCheck]:
+    frontend_root = settings.repo_root / "frontend"
+    return [
+        _make_check(
+            "frontend_workbench_exists",
+            (frontend_root / "src" / "app" / "page.tsx").exists(),
+            "Phase 3 requires a concrete browser workbench entrypoint at frontend/src/app/page.tsx.",
+        ),
+        _make_check(
+            "demo_command_ready",
+            (settings.repo_root / "scripts" / "demo.ps1").exists() and (settings.repo_root / "scripts" / "demo.sh").exists(),
+            "A one-command demo entrypoint should exist in scripts/demo.*.",
+        ),
+        _make_check(
+            "eval_summary_available",
+            (artifacts_root / "eval" / "summary.json").exists(),
+            "Phase 3 still depends on a current eval summary artifact.",
+        ),
+        _make_check(
+            "human_review_rubric_exists",
+            (settings.repo_root / "docs" / "rubrics" / "human-review.md").exists(),
+            "Human review rubric must remain available for Phase 3.",
+        ),
+    ]
+
+
+def run_phase_audit(
+    phase: str,
+    *,
+    settings: Settings | None = None,
+    artifacts_root: Path | None = None,
+) -> PhaseAudit:
+    settings = settings or get_settings()
+    artifacts_root = artifacts_root or settings.artifacts_root
+
+    if phase == "phase1":
+        checks = _phase1_checks(settings, artifacts_root)
+        notes = ["TODO[verify]: GitHub milestone closure and protected-core PR state must still be checked by the orchestrator."]
+    elif phase == "phase2":
+        checks = _phase2_checks(artifacts_root)
+        notes = ["TODO[verify]: Deterministic replay across independent reruns is enforced by eval-demo, not by this artifact-only audit."]
+    elif phase == "phase3":
+        checks = _phase3_checks(settings, artifacts_root)
+        notes = ["TODO[verify]: Phase 3 stop-condition still requires GitHub milestone closure and demo review sign-off."]
+    else:
+        raise ValueError(f"Unsupported phase: {phase}")
+
+    failures = [f"{check.name}: {check.details}" for check in checks if not check.passed]
+    return PhaseAudit(
+        phase=phase,
+        status="pass" if not failures else "fail",
+        checks=checks,
+        failures=failures,
+        notes=notes,
+    )

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 
+from backend.app.automation.service import classify_git_refs, classify_paths, run_phase_audit
 from backend.app.config import get_settings
 from backend.app.evals.service import run_phase0_demo
 from backend.app.graph.service import build_graph
@@ -11,6 +13,7 @@ from backend.app.personas.service import build_personas
 from backend.app.reports.service import generate_report
 from backend.app.scenarios.service import validate_scenario
 from backend.app.simulation.service import simulate_scenario
+from backend.app.world_query import inspect_world
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -43,6 +46,22 @@ def build_parser() -> argparse.ArgumentParser:
     report.add_argument("run")
     report.add_argument("--baseline")
     report.add_argument("--out", required=True)
+
+    inspect = subparsers.add_parser("inspect-world", help="Inspect a world object from graph/persona artifacts")
+    inspect.add_argument("--kind", required=True, choices=["entity", "persona", "event"])
+    inspect.add_argument("--id", required=True)
+    inspect.add_argument("--graph", required=True)
+    inspect.add_argument("--personas", required=True)
+
+    classify = subparsers.add_parser("classify-lane", help="Classify a file set into the autonomous-safe or protected-core lane")
+    classify_group = classify.add_mutually_exclusive_group(required=True)
+    classify_group.add_argument("--files", nargs="+")
+    classify_group.add_argument("--base")
+    classify.add_argument("--head")
+
+    audit = subparsers.add_parser("audit-phase", help="Run the local phase exit audit")
+    audit.add_argument("phase", choices=["phase1", "phase2", "phase3"])
+    audit.add_argument("--artifacts-root")
 
     subparsers.add_parser("eval-demo", help="Run the full Phase 0 demo pipeline")
     subparsers.add_parser("smoke", help="Run the end-to-end smoke pipeline")
@@ -83,6 +102,30 @@ def main(argv: list[str] | None = None) -> int:
         claims = generate_report(Path(args.run), Path(args.out), baseline_dir=Path(args.baseline) if args.baseline else None)
         print(f"Generated report with {len(claims)} claims.")
         return 0
+
+    if args.command == "inspect-world":
+        payload = inspect_world(args.kind, args.id, Path(args.graph), Path(args.personas))
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        return 0
+
+    if args.command == "classify-lane":
+        if args.files:
+            payload = classify_paths([path.replace("\\", "/") for path in args.files]).as_dict()
+        else:
+            if not args.head:
+                raise ValueError("`classify-lane --base` also requires --head.")
+            payload = classify_git_refs(args.base, args.head, repo_root=settings.repo_root).as_dict()
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        return 0
+
+    if args.command == "audit-phase":
+        audit = run_phase_audit(
+            args.phase,
+            settings=settings,
+            artifacts_root=Path(args.artifacts_root) if args.artifacts_root else None,
+        )
+        print(json.dumps(audit.as_dict(), indent=2, ensure_ascii=False))
+        return 0 if audit.status == "pass" else 1
 
     if args.command in {"eval-demo", "smoke"}:
         result = run_phase0_demo(settings=settings)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -10,9 +10,11 @@ class Settings:
     data_root: Path
     artifacts_root: Path
     manifest_path: Path
+    world_model_path: Path
     baseline_scenario_path: Path
     intervention_scenario_path: Path
     expectations_path: Path
+    redlines_path: Path
 
 
 def get_settings() -> Settings:
@@ -24,7 +26,9 @@ def get_settings() -> Settings:
         data_root=data_root,
         artifacts_root=artifacts_root,
         manifest_path=data_root / "corpus" / "manifest.yaml",
+        world_model_path=data_root / "config" / "world_model.yaml",
         baseline_scenario_path=data_root / "scenarios" / "baseline.yaml",
         intervention_scenario_path=data_root / "scenarios" / "reporter_detained.yaml",
         expectations_path=data_root / "expectations" / "demo_eval.yaml",
+        redlines_path=repo_root / "evals" / "assertions" / "redlines.yaml",
     )

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -49,6 +49,14 @@ class Relation(MirrorBaseModel):
     evidence_ids: list[str] = Field(default_factory=list)
 
 
+class Event(MirrorBaseModel):
+    event_id: str
+    name: str
+    kind: str
+    participant_entity_ids: list[str] = Field(default_factory=list)
+    evidence_ids: list[str] = Field(default_factory=list)
+
+
 class Persona(MirrorBaseModel):
     persona_id: str
     entity_id: str
@@ -58,6 +66,7 @@ class Persona(MirrorBaseModel):
     known_facts: list[str] = Field(default_factory=list)
     private_info: list[str] = Field(default_factory=list)
     relationships: list[dict[str, str]] = Field(default_factory=list)
+    field_provenance: dict[str, list[str]] = Field(default_factory=dict)
     evidence_ids: list[str] = Field(default_factory=list)
 
 

--- a/backend/app/evals/service.py
+++ b/backend/app/evals/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -12,6 +13,7 @@ from backend.app.reports.service import generate_report
 from backend.app.scenarios.service import validate_scenario
 from backend.app.simulation.service import simulate_scenario
 from backend.app.utils import load_yaml, read_json, write_json
+from backend.app.world_query import inspect_world
 
 
 def _compare(op: str, left: Any, right: Any) -> bool:
@@ -24,10 +26,39 @@ def _compare(op: str, left: Any, right: Any) -> bool:
     raise ValueError(f"Unsupported comparison op: {op}")
 
 
-def evaluate_runs(expectations_path: Path, artifacts_root: Path, out_dir: Path) -> EvalResult:
+def _scan_terms(text: str, terms: list[str]) -> list[str]:
+    lowered = text.lower()
+    return [term for term in terms if term.lower() in lowered]
+
+
+def _evaluate_redlines(redlines_path: Path, artifacts_root: Path) -> list[str]:
+    rules = load_yaml(redlines_path)
+    texts = {
+        "report": (artifacts_root / "report" / "report.md").read_text(encoding="utf-8"),
+        "claims": json.dumps(read_json(artifacts_root / "report" / "claims.json"), ensure_ascii=False),
+        "baseline_scenario": json.dumps(read_json(artifacts_root / "scenario" / "baseline.json"), ensure_ascii=False),
+        "intervention_scenario": json.dumps(
+            read_json(artifacts_root / "scenario" / "reporter_detained.json"),
+            ensure_ascii=False,
+        ),
+    }
+    failures: list[str] = []
+    for label, text in texts.items():
+        topic_hits = _scan_terms(text, rules["blocked_topics"])
+        if topic_hits:
+            failures.append(f"redlines[{label}]: blocked topics {topic_hits}")
+        phrase_hits = _scan_terms(text, rules["blocked_phrases"])
+        if phrase_hits:
+            failures.append(f"redlines[{label}]: blocked phrases {phrase_hits}")
+    return failures
+
+
+def evaluate_runs(expectations_path: Path, artifacts_root: Path, out_dir: Path, redlines_path: Path) -> EvalResult:
     expectations = load_yaml(expectations_path)
     baseline_summary = read_json(artifacts_root / "run" / "baseline" / "summary.json")
     intervention_summary = read_json(artifacts_root / "run" / "reporter_detained" / "summary.json")
+    graph_payload = read_json(artifacts_root / "graph" / "graph.json")
+    persona_payload = read_json(artifacts_root / "personas" / "personas.json")
     claims = read_json(artifacts_root / "report" / "claims.json")
     runs = {
         "baseline": {**baseline_summary, **baseline_summary["final_state"]},
@@ -61,20 +92,64 @@ def evaluate_runs(expectations_path: Path, artifacts_root: Path, out_dir: Path) 
                 failures.append(f"{check['name']}: at least one claim is missing evidence_ids")
             else:
                 passed += 1
+        elif kind == "graph_events_nonempty":
+            if not graph_payload.get("events"):
+                failures.append(f"{check['name']}: graph.json did not contain any events")
+            else:
+                passed += 1
+        elif kind == "world_evidence_complete":
+            collections = ("entities", "relations", "events")
+            if not all(item.get("evidence_ids") for collection in collections for item in graph_payload[collection]):
+                failures.append(f"{check['name']}: at least one world object is missing evidence_ids")
+            else:
+                passed += 1
+        elif kind == "persona_field_provenance_complete":
+            required_fields = check["fields"]
+            missing: list[str] = []
+            for persona in persona_payload["personas"]:
+                field_provenance = persona.get("field_provenance", {})
+                for field_name in required_fields:
+                    if persona.get(field_name) and not field_provenance.get(field_name):
+                        missing.append(f"{persona['persona_id']}.{field_name}")
+            if missing:
+                failures.append(f"{check['name']}: missing provenance for {missing}")
+            else:
+                passed += 1
+        elif kind == "inspect_world":
+            try:
+                payload = inspect_world(
+                    check["object_kind"],
+                    check["object_id"],
+                    artifacts_root / "graph" / "graph.json",
+                    artifacts_root / "personas" / "personas.json",
+                )
+            except ValueError as exc:
+                failures.append(f"{check['name']}: {exc}")
+            else:
+                if not payload["object"].get("evidence_ids"):
+                    failures.append(f"{check['name']}: inspected object is missing evidence_ids")
+                else:
+                    passed += 1
         else:
             failures.append(f"{check['name']}: unsupported check kind {kind}")
+
+    redline_failures = _evaluate_redlines(redlines_path, artifacts_root)
+    if not redline_failures:
+        passed += 1
+    failures.extend(redline_failures)
 
     result = EvalResult(
         eval_name=expectations["eval_name"],
         status="pass" if not failures else "fail",
         metrics={
-            "checks_total": len(expectations["checks"]),
+            "checks_total": len(expectations["checks"]) + 1,
             "checks_passed": passed,
             "baseline_evacuation_turn": baseline_summary["evacuation_turn"],
             "intervention_evacuation_turn": intervention_summary["evacuation_turn"],
+            "event_count": graph_payload["stats"]["event_count"],
         },
         failures=failures,
-        notes=["Phase 0 eval covers deterministic demo behavior and claim provenance."],
+        notes=["Phase 1 eval covers deterministic demo behavior, world-model provenance, and redline checks."],
     )
     write_json(out_dir / "summary.json", result.model_dump())
     return result
@@ -85,8 +160,8 @@ def run_phase0_demo(settings: Settings | None = None, artifacts_root: Path | Non
     artifacts_root = artifacts_root or settings.artifacts_root
 
     ingest_manifest(settings.manifest_path, artifacts_root / "ingest")
-    build_graph(artifacts_root / "ingest" / "chunks.jsonl", artifacts_root / "graph")
-    build_personas(artifacts_root / "graph" / "graph.json", artifacts_root / "personas")
+    build_graph(artifacts_root / "ingest" / "chunks.jsonl", artifacts_root / "graph", settings.world_model_path)
+    build_personas(artifacts_root / "graph" / "graph.json", artifacts_root / "personas", settings.world_model_path)
     validate_scenario(settings.baseline_scenario_path, artifacts_root / "scenario" / "baseline.json")
     validate_scenario(settings.intervention_scenario_path, artifacts_root / "scenario" / "reporter_detained.json")
     simulate_scenario(
@@ -106,4 +181,4 @@ def run_phase0_demo(settings: Settings | None = None, artifacts_root: Path | Non
         artifacts_root / "report",
         baseline_dir=artifacts_root / "run" / "baseline",
     )
-    return evaluate_runs(settings.expectations_path, artifacts_root, artifacts_root / "eval")
+    return evaluate_runs(settings.expectations_path, artifacts_root, artifacts_root / "eval", settings.redlines_path)

--- a/backend/app/graph/service.py
+++ b/backend/app/graph/service.py
@@ -2,79 +2,86 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from backend.app.domain.models import Entity, Relation
+from backend.app.config import get_settings
+from backend.app.domain.models import Entity, Event, Relation
 from backend.app.utils import read_jsonl, write_json
+from backend.app.world_model import MatchRule, load_world_model
 
 
-ENTITY_DEFINITIONS = [
-    {"entity_id": "entity_lin_lan", "name": "Lin Lan", "type": "person", "aliases": ["lin lan", "archive clerk", "archive room"]},
-    {"entity_id": "entity_zhao_ke", "name": "Zhao Ke", "type": "person", "aliases": ["zhao ke", "deputy mayor", "mayor's office"]},
-    {"entity_id": "entity_su_he", "name": "Su He", "type": "person", "aliases": ["su he", "engineer su he", "public works office"]},
-    {"entity_id": "entity_chen_yu", "name": "Chen Yu", "type": "person", "aliases": ["chen yu", "captain chen yu", "tug lantern three"]},
-    {"entity_id": "entity_east_gate", "name": "East Gate", "type": "infrastructure", "aliases": ["east gate", "flood gate", "gate seam"]},
-    {"entity_id": "entity_maintenance_ledger", "name": "Maintenance Ledger", "type": "document", "aliases": ["maintenance ledger", "ledger copy", "copied pages"]},
-    {"entity_id": "entity_sea_lantern_festival", "name": "Sea Lantern Festival", "type": "event", "aliases": ["sea lantern festival", "festival", "opening ceremony"]},
-    {"entity_id": "entity_east_wharf", "name": "East Wharf", "type": "location", "aliases": ["east wharf", "harbor square", "quay"]},
-]
-
-RELATION_RULES = [
-    {"relation_id": "relation_lin_lan_controls_ledger", "source_entity_id": "entity_lin_lan", "relation_type": "controls", "target_entity_id": "entity_maintenance_ledger", "keywords": ["lin lan", "ledger"]},
-    {"relation_id": "relation_su_he_inspects_gate", "source_entity_id": "entity_su_he", "relation_type": "inspects", "target_entity_id": "entity_east_gate", "keywords": ["su he", "east gate"]},
-    {"relation_id": "relation_zhao_ke_protects_festival", "source_entity_id": "entity_zhao_ke", "relation_type": "protects", "target_entity_id": "entity_sea_lantern_festival", "keywords": ["zhao ke", "festival"]},
-    {"relation_id": "relation_chen_yu_observes_tides", "source_entity_id": "entity_chen_yu", "relation_type": "observes", "target_entity_id": "entity_east_gate", "keywords": ["chen yu", "tide"]},
-    {"relation_id": "relation_festival_diverts_maintenance_budget", "source_entity_id": "entity_sea_lantern_festival", "relation_type": "draws_funding_from", "target_entity_id": "entity_east_gate", "keywords": ["festival", "maintenance", "reassigned"]},
-]
+def _matches_rule(text: str, rule: MatchRule) -> bool:
+    if rule.all and not all(keyword in text for keyword in rule.all):
+        return False
+    if rule.any and not any(keyword in text for keyword in rule.any):
+        return False
+    return bool(rule.all or rule.any)
 
 
-def build_graph(chunks_path: Path, out_dir: Path) -> dict:
+def _match_aliases(text: str, aliases: list[str]) -> bool:
+    return any(alias in text for alias in aliases)
+
+
+def _evidence_for_aliases(chunk_rows: list[dict], aliases: list[str]) -> list[str]:
+    return sorted({chunk["chunk_id"] for chunk in chunk_rows if _match_aliases(chunk["text"].lower(), aliases)})
+
+
+def _evidence_for_rule(chunk_rows: list[dict], rule: MatchRule) -> list[str]:
+    return sorted({chunk["chunk_id"] for chunk in chunk_rows if _matches_rule(chunk["text"].lower(), rule)})
+
+
+def build_graph(chunks_path: Path, out_dir: Path, world_model_path: Path | None = None) -> dict:
     chunk_rows = read_jsonl(chunks_path)
+    world_model = load_world_model(world_model_path or get_settings().world_model_path)
     entities: list[Entity] = []
     relations: list[Relation] = []
+    events: list[Event] = []
 
-    for definition in ENTITY_DEFINITIONS:
-        evidence_ids = sorted(
-            {
-                chunk["chunk_id"]
-                for chunk in chunk_rows
-                if any(alias in chunk["text"].lower() for alias in definition["aliases"])
-            }
-        )
+    for definition in world_model.entities:
+        evidence_ids = _evidence_for_aliases(chunk_rows, definition.aliases)
         entities.append(
             Entity(
-                entity_id=definition["entity_id"],
-                name=definition["name"],
-                type=definition["type"],
-                aliases=definition["aliases"],
+                entity_id=definition.entity_id,
+                name=definition.name,
+                type=definition.type,
+                aliases=definition.aliases,
                 evidence_ids=evidence_ids,
             )
         )
 
-    for rule in RELATION_RULES:
-        evidence_ids = sorted(
-            {
-                chunk["chunk_id"]
-                for chunk in chunk_rows
-                if all(keyword in chunk["text"].lower() for keyword in rule["keywords"])
-            }
-        )
+    for rule in world_model.relations:
+        evidence_ids = _evidence_for_rule(chunk_rows, rule.match)
         if evidence_ids:
             relations.append(
                 Relation(
-                    relation_id=rule["relation_id"],
-                    source_entity_id=rule["source_entity_id"],
-                    relation_type=rule["relation_type"],
-                    target_entity_id=rule["target_entity_id"],
+                    relation_id=rule.relation_id,
+                    source_entity_id=rule.source_entity_id,
+                    relation_type=rule.relation_type,
+                    target_entity_id=rule.target_entity_id,
+                    evidence_ids=evidence_ids,
+                )
+            )
+
+    for definition in world_model.events:
+        evidence_ids = _evidence_for_rule(chunk_rows, definition.match)
+        if evidence_ids:
+            events.append(
+                Event(
+                    event_id=definition.event_id,
+                    name=definition.name,
+                    kind=definition.kind,
+                    participant_entity_ids=definition.participant_entity_ids,
                     evidence_ids=evidence_ids,
                 )
             )
 
     payload = {
-        "world_id": "fog-harbor-east-gate",
+        "world_id": world_model.world_id,
         "entities": [entity.model_dump() for entity in entities],
         "relations": [relation.model_dump() for relation in relations],
+        "events": [event.model_dump() for event in events],
         "stats": {
             "entity_count": len(entities),
             "relation_count": len(relations),
+            "event_count": len(events),
             "chunk_count": len(chunk_rows),
         },
     }

--- a/backend/app/personas/service.py
+++ b/backend/app/personas/service.py
@@ -2,75 +2,91 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from backend.app.config import get_settings
 from backend.app.domain.models import Persona
 from backend.app.utils import read_json, write_json
+from backend.app.world_model import EvidenceReference, TextFieldDefinition, load_world_model
 
 
-PERSONA_BLUEPRINTS = [
-    {
-        "persona_id": "persona_lin_lan",
-        "entity_id": "entity_lin_lan",
-        "public_role": "Archive clerk guarding the maintenance record trail.",
-        "goals": ["Surface the diverted maintenance funds before the storm hits.", "Keep a durable copy of the ledger available to trusted messengers."],
-        "constraints": ["Has little executive authority.", "Needs others to amplify the archive evidence."],
-        "known_facts": ["The copied ledger links festival spending to missing repair money.", "Su He's latest inspection references the same delayed work order."],
-        "private_info": ["Lin Lan made a private copy of the ledger before the archive room closed."],
-        "relationships": [{"target_id": "persona_su_he", "kind": "coordinates_with"}, {"target_id": "persona_zhao_ke", "kind": "distrusts"}],
-    },
-    {
-        "persona_id": "persona_su_he",
-        "entity_id": "entity_su_he",
-        "public_role": "Waterworks engineer responsible for the East Gate inspection.",
-        "goals": ["Get the gate reinforced before the surge window closes.", "Escalate evacuation if evidence confirms leadership is delaying repairs."],
-        "constraints": ["Cannot repair the gate alone.", "Needs records or public pressure to override festival priorities."],
-        "known_facts": ["The East Gate brace is already widening under pressure.", "Festival traffic would slow emergency repairs."],
-        "private_info": ["Su He believes the next surge could trigger a compound failure if leadership waits."],
-        "relationships": [{"target_id": "persona_lin_lan", "kind": "depends_on"}, {"target_id": "persona_chen_yu", "kind": "trusts"}],
-    },
-    {
-        "persona_id": "persona_chen_yu",
-        "entity_id": "entity_chen_yu",
-        "public_role": "Tugboat captain tracking tide behavior in the eastern channel.",
-        "goals": ["Warn the harbor before carts and festival barges block evacuation lanes.", "Push officials to respect tide observations from the quay."],
-        "constraints": ["Has operational knowledge but no policy authority.", "Depends on dispatch routes to move warnings quickly."],
-        "known_facts": ["The gate seam is already throwing spray under strain.", "A late evacuation order will trap equipment on the quay road."],
-        "private_info": ["Chen Yu trusts Su He's risk assessment more than the mayor's office messaging."],
-        "relationships": [{"target_id": "persona_su_he", "kind": "trusts"}, {"target_id": "persona_zhao_ke", "kind": "pressures"}],
-    },
-    {
-        "persona_id": "persona_zhao_ke",
-        "entity_id": "entity_zhao_ke",
-        "public_role": "Deputy mayor trying to preserve the Sea Lantern Festival schedule.",
-        "goals": ["Avoid a public cancellation before the opening ceremony.", "Keep control of the narrative around the gate delay."],
-        "constraints": ["Needs some factual basis before ordering a visible evacuation.", "Faces public backlash if the budget diversion becomes undeniable."],
-        "known_facts": ["Festival spending already consumed money earmarked for gate repairs.", "Visible documentary proof could force an emergency reversal."],
-        "private_info": ["Zhao Ke worries more about public embarrassment than engineering nuance until pressure becomes undeniable."],
-        "relationships": [{"target_id": "persona_lin_lan", "kind": "fears_disclosure_from"}, {"target_id": "persona_su_he", "kind": "deflects"}],
-    },
-]
+def _resolve_evidence(reference: EvidenceReference, entity_index: dict, relation_index: dict, event_index: dict) -> list[str]:
+    evidence_ids: set[str] = set()
+    for entity_id in reference.entity_ids:
+        evidence_ids.update(entity_index[entity_id]["evidence_ids"])
+    for relation_id in reference.relation_ids:
+        evidence_ids.update(relation_index[relation_id]["evidence_ids"])
+    for event_id in reference.event_ids:
+        evidence_ids.update(event_index[event_id]["evidence_ids"])
+    return sorted(evidence_ids)
 
 
-def build_personas(graph_path: Path, out_dir: Path) -> list[Persona]:
+def _field_provenance(
+    items: list[TextFieldDefinition],
+    entity_index: dict,
+    relation_index: dict,
+    event_index: dict,
+) -> tuple[list[str], list[str]]:
+    texts = [item.text for item in items]
+    evidence_ids: set[str] = set()
+    for item in items:
+        evidence_ids.update(_resolve_evidence(item.evidence, entity_index, relation_index, event_index))
+    return texts, sorted(evidence_ids)
+
+
+def build_personas(graph_path: Path, out_dir: Path, world_model_path: Path | None = None) -> list[Persona]:
     graph_payload = read_json(graph_path)
+    world_model = load_world_model(world_model_path or get_settings().world_model_path)
     entity_index = {entity["entity_id"]: entity for entity in graph_payload["entities"]}
-    relations = graph_payload["relations"]
+    relation_index = {relation["relation_id"]: relation for relation in graph_payload["relations"]}
+    event_index = {event["event_id"]: event for event in graph_payload["events"]}
     personas: list[Persona] = []
 
-    for blueprint in PERSONA_BLUEPRINTS:
-        evidence_ids = set(entity_index[blueprint["entity_id"]]["evidence_ids"])
-        for relation in relations:
-            if relation["source_entity_id"] == blueprint["entity_id"] or relation["target_entity_id"] == blueprint["entity_id"]:
-                evidence_ids.update(relation["evidence_ids"])
+    for blueprint in world_model.personas:
+        goals, goals_evidence = _field_provenance(blueprint.goals, entity_index, relation_index, event_index)
+        constraints, constraints_evidence = _field_provenance(blueprint.constraints, entity_index, relation_index, event_index)
+        known_facts, known_facts_evidence = _field_provenance(blueprint.known_facts, entity_index, relation_index, event_index)
+        private_info, private_info_evidence = _field_provenance(blueprint.private_info, entity_index, relation_index, event_index)
+        public_role_evidence = _resolve_evidence(blueprint.public_role.evidence, entity_index, relation_index, event_index)
+        relationships = [{"target_id": item.target_id, "kind": item.kind} for item in blueprint.relationships]
+        relationships_evidence = sorted(
+            {
+                evidence_id
+                for item in blueprint.relationships
+                for evidence_id in _resolve_evidence(item.evidence, entity_index, relation_index, event_index)
+            }
+        )
+        field_provenance = {
+            "public_role": public_role_evidence,
+            "goals": goals_evidence,
+            "constraints": constraints_evidence,
+            "known_facts": known_facts_evidence,
+            "private_info": private_info_evidence,
+            "relationships": relationships_evidence,
+        }
+        for field_name, field_value in (
+            ("public_role", blueprint.public_role.text),
+            ("goals", goals),
+            ("constraints", constraints),
+            ("known_facts", known_facts),
+            ("private_info", private_info),
+            ("relationships", relationships),
+        ):
+            if field_value and not field_provenance[field_name]:
+                raise ValueError(f"Persona field is missing provenance: {blueprint.persona_id}.{field_name}")
+
+        evidence_ids = set(entity_index[blueprint.entity_id]["evidence_ids"])
+        for field_ids in field_provenance.values():
+            evidence_ids.update(field_ids)
         personas.append(
             Persona(
-                persona_id=blueprint["persona_id"],
-                entity_id=blueprint["entity_id"],
-                public_role=blueprint["public_role"],
-                goals=blueprint["goals"],
-                constraints=blueprint["constraints"],
-                known_facts=blueprint["known_facts"],
-                private_info=blueprint["private_info"],
-                relationships=blueprint["relationships"],
+                persona_id=blueprint.persona_id,
+                entity_id=blueprint.entity_id,
+                public_role=blueprint.public_role.text,
+                goals=goals,
+                constraints=constraints,
+                known_facts=known_facts,
+                private_info=private_info,
+                relationships=relationships,
+                field_provenance=field_provenance,
                 evidence_ids=sorted(evidence_ids),
             )
         )

--- a/backend/app/world_model.py
+++ b/backend/app/world_model.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import Field
+
+from backend.app.domain.models import MirrorBaseModel
+from backend.app.utils import load_yaml
+
+
+class MatchRule(MirrorBaseModel):
+    all: list[str] = Field(default_factory=list)
+    any: list[str] = Field(default_factory=list)
+
+
+class EntityDefinition(MirrorBaseModel):
+    entity_id: str
+    name: str
+    type: str
+    aliases: list[str] = Field(default_factory=list)
+
+
+class RelationDefinition(MirrorBaseModel):
+    relation_id: str
+    source_entity_id: str
+    relation_type: str
+    target_entity_id: str
+    match: MatchRule = Field(default_factory=MatchRule)
+
+
+class EventDefinition(MirrorBaseModel):
+    event_id: str
+    name: str
+    kind: str
+    participant_entity_ids: list[str] = Field(default_factory=list)
+    match: MatchRule = Field(default_factory=MatchRule)
+
+
+class EvidenceReference(MirrorBaseModel):
+    entity_ids: list[str] = Field(default_factory=list)
+    relation_ids: list[str] = Field(default_factory=list)
+    event_ids: list[str] = Field(default_factory=list)
+
+
+class TextFieldDefinition(MirrorBaseModel):
+    text: str
+    evidence: EvidenceReference = Field(default_factory=EvidenceReference)
+
+
+class RelationshipDefinition(MirrorBaseModel):
+    target_id: str
+    kind: str
+    evidence: EvidenceReference = Field(default_factory=EvidenceReference)
+
+
+class PersonaDefinition(MirrorBaseModel):
+    persona_id: str
+    entity_id: str
+    public_role: TextFieldDefinition
+    goals: list[TextFieldDefinition] = Field(default_factory=list)
+    constraints: list[TextFieldDefinition] = Field(default_factory=list)
+    known_facts: list[TextFieldDefinition] = Field(default_factory=list)
+    private_info: list[TextFieldDefinition] = Field(default_factory=list)
+    relationships: list[RelationshipDefinition] = Field(default_factory=list)
+
+
+class WorldModelConfig(MirrorBaseModel):
+    world_id: str
+    entities: list[EntityDefinition] = Field(default_factory=list)
+    relations: list[RelationDefinition] = Field(default_factory=list)
+    events: list[EventDefinition] = Field(default_factory=list)
+    personas: list[PersonaDefinition] = Field(default_factory=list)
+
+
+def load_world_model(path: Path) -> WorldModelConfig:
+    return WorldModelConfig.model_validate(load_yaml(path))

--- a/backend/app/world_query.py
+++ b/backend/app/world_query.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from backend.app.utils import read_json
+
+
+WorldObjectKind = Literal["entity", "persona", "event"]
+
+
+def inspect_world(kind: WorldObjectKind, object_id: str, graph_path: Path, personas_path: Path) -> dict:
+    graph_payload = read_json(graph_path)
+    persona_payload = read_json(personas_path)
+
+    if kind == "entity":
+        collection = graph_payload["entities"]
+        id_field = "entity_id"
+    elif kind == "event":
+        collection = graph_payload["events"]
+        id_field = "event_id"
+    else:
+        collection = persona_payload["personas"]
+        id_field = "persona_id"
+
+    for item in collection:
+        if item[id_field] == object_id:
+            return {
+                "world_id": graph_payload["world_id"],
+                "kind": kind,
+                "object": item,
+            }
+
+    raise ValueError(f"Unknown {kind} id: {object_id}")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+  "httpx>=0.27,<1.0",
   "pytest>=8.0,<9.0",
   "uvicorn>=0.30,<1.0",
 ]

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -25,9 +25,11 @@ def test_demo_report_endpoint_reflects_artifact_state(tmp_path: Path, monkeypatc
         data_root=settings.data_root,
         artifacts_root=tmp_path / "demo",
         manifest_path=settings.manifest_path,
+        world_model_path=settings.world_model_path,
         baseline_scenario_path=settings.baseline_scenario_path,
         intervention_scenario_path=settings.intervention_scenario_path,
         expectations_path=settings.expectations_path,
+        redlines_path=settings.redlines_path,
     )
     monkeypatch.setattr(main_module, "get_settings", lambda: patched_settings)
 

--- a/backend/tests/test_automation.py
+++ b/backend/tests/test_automation.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.app.automation.service import classify_paths, run_phase_audit
+from backend.app.config import get_settings
+from backend.app.evals.service import run_phase0_demo
+
+
+def test_classify_paths_marks_protected_core_changes() -> None:
+    decision = classify_paths(["backend/app/simulation/service.py", "README.md"])
+    assert decision.lane == "lane:protected-core"
+    assert "risk:core-contract" in decision.labels
+    assert "backend/app/simulation/service.py" in decision.protected_hits
+
+
+def test_classify_paths_marks_safe_lane_changes() -> None:
+    decision = classify_paths(["README.md", ".github/pull_request_template.md"])
+    assert decision.lane == "lane:auto-safe"
+    assert decision.protected_hits == []
+
+
+def test_phase1_and_phase2_audit_pass_with_demo_artifacts(tmp_path: Path) -> None:
+    settings = get_settings()
+    run_phase0_demo(settings=settings, artifacts_root=tmp_path / "demo")
+    phase1 = run_phase_audit("phase1", settings=settings, artifacts_root=tmp_path / "demo")
+    phase2 = run_phase_audit("phase2", settings=settings, artifacts_root=tmp_path / "demo")
+    assert phase1.status == "pass"
+    assert phase2.status == "pass"
+
+
+def test_phase3_audit_fails_without_workbench() -> None:
+    settings = get_settings()
+    phase3 = run_phase_audit("phase3", settings=settings, artifacts_root=settings.artifacts_root)
+    assert phase3.status == "fail"

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from backend.app.cli import main
@@ -18,6 +19,50 @@ def test_cli_validate_and_smoke(tmp_path: Path) -> None:
     settings = get_settings()
     assert main(["validate-scenario", str(settings.baseline_scenario_path), "--out", str(tmp_path / "baseline.json")]) == 0
     assert (tmp_path / "baseline.json").exists()
+
+
+def test_cli_inspect_world_outputs_json(tmp_path: Path, capsys) -> None:
+    settings = get_settings()
+    assert main(["ingest", str(settings.manifest_path), "--out", str(tmp_path / "ingest")]) == 0
+    assert main(["build-graph", str(tmp_path / "ingest" / "chunks.jsonl"), "--out", str(tmp_path / "graph")]) == 0
+    assert main(["personas", str(tmp_path / "graph" / "graph.json"), "--out", str(tmp_path / "personas")]) == 0
+    capsys.readouterr()
+    assert (
+        main(
+            [
+                "inspect-world",
+                "--kind",
+                "entity",
+                "--id",
+                "entity_east_gate",
+                "--graph",
+                str(tmp_path / "graph" / "graph.json"),
+                "--personas",
+                str(tmp_path / "personas" / "personas.json"),
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "entity"
+    assert payload["object"]["entity_id"] == "entity_east_gate"
+
+
+def test_cli_classify_lane_outputs_json(capsys) -> None:
+    assert main(["classify-lane", "--files", "README.md", "backend/app/cli.py"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["lane"] == "lane:auto-safe"
+
+
+def test_cli_audit_phase_outputs_json(tmp_path: Path, capsys) -> None:
+    settings = get_settings()
+    assert main(["eval-demo"]) == 0
+    capsys.readouterr()
+    result = main(["audit-phase", "phase1", "--artifacts-root", str(settings.artifacts_root)])
+    payload = json.loads(capsys.readouterr().out)
+    assert result == 0
+    assert payload["phase"] == "phase1"
+    assert payload["status"] == "pass"
 
 
 def test_safety_blocks_redline_payload() -> None:

--- a/backend/tests/test_pipeline.py
+++ b/backend/tests/test_pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from backend.app.world_query import inspect_world
 from pathlib import Path
 
 from backend.app.config import get_settings
@@ -27,7 +28,24 @@ def test_graph_and_personas_have_evidence(tmp_path: Path) -> None:
     graph = build_graph(tmp_path / "ingest" / "chunks.jsonl", tmp_path / "graph")
     personas = build_personas(tmp_path / "graph" / "graph.json", tmp_path / "personas")
     assert graph["stats"]["relation_count"] >= 4
+    assert graph["stats"]["event_count"] >= 4
+    assert graph["events"]
     assert all(persona.evidence_ids for persona in personas)
+    assert all(persona.field_provenance["public_role"] for persona in personas)
+    assert all(persona.field_provenance["relationships"] for persona in personas)
+
+
+def test_world_query_returns_evidence_backed_objects(tmp_path: Path) -> None:
+    settings = get_settings()
+    ingest_manifest(settings.manifest_path, tmp_path / "ingest")
+    build_graph(tmp_path / "ingest" / "chunks.jsonl", tmp_path / "graph")
+    build_personas(tmp_path / "graph" / "graph.json", tmp_path / "personas")
+    entity = inspect_world("entity", "entity_east_gate", tmp_path / "graph" / "graph.json", tmp_path / "personas" / "personas.json")
+    persona = inspect_world("persona", "persona_su_he", tmp_path / "graph" / "graph.json", tmp_path / "personas" / "personas.json")
+    event = inspect_world("event", "event_gate_failure_risk", tmp_path / "graph" / "graph.json", tmp_path / "personas" / "personas.json")
+    assert entity["object"]["evidence_ids"]
+    assert persona["object"]["field_provenance"]["known_facts"]
+    assert event["object"]["participant_entity_ids"]
 
 
 def test_scenario_validation_and_simulation_are_deterministic(tmp_path: Path) -> None:
@@ -79,3 +97,4 @@ def test_eval_demo_passes(tmp_path: Path) -> None:
     settings = get_settings()
     result = run_phase0_demo(settings=settings, artifacts_root=tmp_path / "demo")
     assert result.status == "pass"
+    assert result.metrics["event_count"] >= 4

--- a/backlog/sprint-01.md
+++ b/backlog/sprint-01.md
@@ -1,5 +1,8 @@
 # Sprint 01 Backlog
 
+This file remains the historical seed backlog for Phase 0 and early Phase 1.
+Once Day 0 automation bootstrap is complete, GitHub milestones/issues become the operational source of truth for ongoing work.
+
 1. Scaffold repo structure, wrappers, and governance docs
 2. Land demo world corpus, scenarios, and expectations
 3. Freeze core domain contracts and artifact paths

--- a/data/demo/config/world_model.yaml
+++ b/data/demo/config/world_model.yaml
@@ -1,0 +1,455 @@
+world_id: fog-harbor-east-gate
+entities:
+  - entity_id: entity_lin_lan
+    name: Lin Lan
+    type: person
+    aliases:
+      - lin lan
+      - archive clerk
+      - archive room
+  - entity_id: entity_zhao_ke
+    name: Zhao Ke
+    type: person
+    aliases:
+      - zhao ke
+      - deputy mayor
+      - mayor's office
+  - entity_id: entity_su_he
+    name: Su He
+    type: person
+    aliases:
+      - su he
+      - engineer su he
+      - public works office
+  - entity_id: entity_chen_yu
+    name: Chen Yu
+    type: person
+    aliases:
+      - chen yu
+      - captain chen yu
+      - tug lantern three
+  - entity_id: entity_east_gate
+    name: East Gate
+    type: infrastructure
+    aliases:
+      - east gate
+      - flood gate
+      - gate seam
+  - entity_id: entity_maintenance_ledger
+    name: Maintenance Ledger
+    type: document
+    aliases:
+      - maintenance ledger
+      - ledger copy
+      - copied pages
+  - entity_id: entity_sea_lantern_festival
+    name: Sea Lantern Festival
+    type: event
+    aliases:
+      - sea lantern festival
+      - festival
+      - opening ceremony
+  - entity_id: entity_east_wharf
+    name: East Wharf
+    type: location
+    aliases:
+      - east wharf
+      - harbor square
+      - quay
+
+relations:
+  - relation_id: relation_lin_lan_controls_ledger
+    source_entity_id: entity_lin_lan
+    relation_type: controls
+    target_entity_id: entity_maintenance_ledger
+    match:
+      all:
+        - lin lan
+        - ledger
+      any:
+        - copy
+        - copied
+        - courier
+  - relation_id: relation_su_he_inspects_gate
+    source_entity_id: entity_su_he
+    relation_type: inspects
+    target_entity_id: entity_east_gate
+    match:
+      all:
+        - su he
+        - east gate
+      any:
+        - inspected
+        - inspection
+        - requested
+        - latest inspection
+  - relation_id: relation_zhao_ke_protects_festival
+    source_entity_id: entity_zhao_ke
+    relation_type: protects
+    target_entity_id: entity_sea_lantern_festival
+    match:
+      all:
+        - zhao ke
+      any:
+        - festival
+        - opening ceremony
+        - morale and trade
+  - relation_id: relation_chen_yu_tracks_gate
+    source_entity_id: entity_chen_yu
+    relation_type: observes
+    target_entity_id: entity_east_gate
+    match:
+      all:
+        - chen yu
+        - east gate
+      any:
+        - tide
+        - channel
+        - shuddered
+        - sunrise
+
+events:
+  - event_id: event_budget_diversion
+    name: Maintenance Budget Diverted To Festival
+    kind: budget_diversion
+    participant_entity_ids:
+      - entity_zhao_ke
+      - entity_sea_lantern_festival
+      - entity_east_gate
+      - entity_maintenance_ledger
+      - entity_lin_lan
+    match:
+      all:
+        - east gate
+      any:
+        - reassigned
+        - redirected
+        - construction invoices
+        - missing maintenance
+  - event_id: event_gate_failure_risk
+    name: East Gate Failure Risk Escalates
+    kind: risk_escalation
+    participant_entity_ids:
+      - entity_su_he
+      - entity_chen_yu
+      - entity_east_gate
+      - entity_east_wharf
+    match:
+      any:
+        - widening fracture
+        - compound failure
+        - shuddered harder
+        - gate is compromised
+        - flood with very little warning
+        - surge window
+  - event_id: event_dispatch_breakdown
+    name: Dispatch And Courier Friction Slows The Response
+    kind: communication_breakdown
+    participant_entity_ids:
+      - entity_lin_lan
+      - entity_su_he
+      - entity_zhao_ke
+      - entity_east_wharf
+      - entity_maintenance_ledger
+    match:
+      any:
+        - confusion between the public works office
+        - taking longer routes
+        - communication slows
+        - local reporter could publish
+        - courier
+  - event_id: event_storm_surge_warning
+    name: Storm Surge Warning Narrows The Evacuation Window
+    kind: storm_warning
+    participant_entity_ids:
+      - entity_east_gate
+      - entity_east_wharf
+      - entity_sea_lantern_festival
+    match:
+      any:
+        - storm front
+        - high tide surges
+        - evacuation routes
+        - storm surge
+        - suspend public gatherings
+
+personas:
+  - persona_id: persona_lin_lan
+    entity_id: entity_lin_lan
+    public_role:
+      text: Archive clerk guarding the maintenance record trail.
+      evidence:
+        entity_ids:
+          - entity_lin_lan
+          - entity_maintenance_ledger
+        relation_ids:
+          - relation_lin_lan_controls_ledger
+    goals:
+      - text: Surface the diverted maintenance funds before the storm hits.
+        evidence:
+          event_ids:
+            - event_budget_diversion
+            - event_storm_surge_warning
+      - text: Keep a durable copy of the ledger available to trusted messengers.
+        evidence:
+          relation_ids:
+            - relation_lin_lan_controls_ledger
+          event_ids:
+            - event_dispatch_breakdown
+    constraints:
+      - text: Has little executive authority.
+        evidence:
+          event_ids:
+            - event_budget_diversion
+            - event_dispatch_breakdown
+          entity_ids:
+            - entity_zhao_ke
+      - text: Needs others to amplify the archive evidence.
+        evidence:
+          relation_ids:
+            - relation_lin_lan_controls_ledger
+            - relation_su_he_inspects_gate
+          event_ids:
+            - event_dispatch_breakdown
+    known_facts:
+      - text: The copied ledger links festival spending to missing repair money.
+        evidence:
+          event_ids:
+            - event_budget_diversion
+          relation_ids:
+            - relation_lin_lan_controls_ledger
+      - text: Su He's latest inspection references the same delayed work order.
+        evidence:
+          relation_ids:
+            - relation_su_he_inspects_gate
+          event_ids:
+            - event_gate_failure_risk
+    private_info:
+      - text: Lin Lan made a private copy of the ledger before the archive room closed.
+        evidence:
+          relation_ids:
+            - relation_lin_lan_controls_ledger
+          event_ids:
+            - event_dispatch_breakdown
+    relationships:
+      - target_id: persona_su_he
+        kind: coordinates_with
+        evidence:
+          relation_ids:
+            - relation_su_he_inspects_gate
+            - relation_lin_lan_controls_ledger
+          event_ids:
+            - event_dispatch_breakdown
+      - target_id: persona_zhao_ke
+        kind: distrusts
+        evidence:
+          event_ids:
+            - event_budget_diversion
+            - event_dispatch_breakdown
+
+  - persona_id: persona_su_he
+    entity_id: entity_su_he
+    public_role:
+      text: Waterworks engineer responsible for the East Gate inspection.
+      evidence:
+        entity_ids:
+          - entity_su_he
+          - entity_east_gate
+        relation_ids:
+          - relation_su_he_inspects_gate
+    goals:
+      - text: Get the gate reinforced before the surge window closes.
+        evidence:
+          relation_ids:
+            - relation_su_he_inspects_gate
+          event_ids:
+            - event_gate_failure_risk
+            - event_storm_surge_warning
+      - text: Escalate evacuation if evidence confirms leadership is delaying repairs.
+        evidence:
+          event_ids:
+            - event_budget_diversion
+            - event_storm_surge_warning
+            - event_dispatch_breakdown
+    constraints:
+      - text: Cannot repair the gate alone.
+        evidence:
+          relation_ids:
+            - relation_su_he_inspects_gate
+          event_ids:
+            - event_gate_failure_risk
+      - text: Needs records or public pressure to override festival priorities.
+        evidence:
+          event_ids:
+            - event_budget_diversion
+            - event_dispatch_breakdown
+    known_facts:
+      - text: The East Gate brace is already widening under pressure.
+        evidence:
+          relation_ids:
+            - relation_su_he_inspects_gate
+          event_ids:
+            - event_gate_failure_risk
+      - text: Festival traffic would slow emergency repairs.
+        evidence:
+          event_ids:
+            - event_budget_diversion
+            - event_dispatch_breakdown
+    private_info:
+      - text: Su He believes the next surge could trigger a compound failure if leadership waits.
+        evidence:
+          event_ids:
+            - event_gate_failure_risk
+            - event_budget_diversion
+    relationships:
+      - target_id: persona_lin_lan
+        kind: depends_on
+        evidence:
+          relation_ids:
+            - relation_lin_lan_controls_ledger
+          event_ids:
+            - event_dispatch_breakdown
+      - target_id: persona_chen_yu
+        kind: trusts
+        evidence:
+          relation_ids:
+            - relation_chen_yu_tracks_gate
+            - relation_su_he_inspects_gate
+          event_ids:
+            - event_gate_failure_risk
+
+  - persona_id: persona_chen_yu
+    entity_id: entity_chen_yu
+    public_role:
+      text: Tugboat captain tracking tide behavior in the eastern channel.
+      evidence:
+        entity_ids:
+          - entity_chen_yu
+          - entity_east_gate
+        relation_ids:
+          - relation_chen_yu_tracks_gate
+    goals:
+      - text: Warn the harbor before carts and festival barges block evacuation lanes.
+        evidence:
+          event_ids:
+            - event_dispatch_breakdown
+            - event_storm_surge_warning
+      - text: Push officials to respect tide observations from the quay.
+        evidence:
+          relation_ids:
+            - relation_chen_yu_tracks_gate
+          event_ids:
+            - event_gate_failure_risk
+    constraints:
+      - text: Has operational knowledge but no policy authority.
+        evidence:
+          event_ids:
+            - event_dispatch_breakdown
+            - event_budget_diversion
+      - text: Depends on dispatch routes to move warnings quickly.
+        evidence:
+          event_ids:
+            - event_dispatch_breakdown
+            - event_storm_surge_warning
+    known_facts:
+      - text: The gate seam is already throwing spray under strain.
+        evidence:
+          relation_ids:
+            - relation_chen_yu_tracks_gate
+          event_ids:
+            - event_gate_failure_risk
+      - text: A late evacuation order will trap equipment on the quay road.
+        evidence:
+          event_ids:
+            - event_dispatch_breakdown
+            - event_storm_surge_warning
+    private_info:
+      - text: Chen Yu trusts Su He's risk assessment more than the mayor's office messaging.
+        evidence:
+          relation_ids:
+            - relation_chen_yu_tracks_gate
+            - relation_su_he_inspects_gate
+          event_ids:
+            - event_gate_failure_risk
+    relationships:
+      - target_id: persona_su_he
+        kind: trusts
+        evidence:
+          relation_ids:
+            - relation_chen_yu_tracks_gate
+            - relation_su_he_inspects_gate
+      - target_id: persona_zhao_ke
+        kind: pressures
+        evidence:
+          event_ids:
+            - event_budget_diversion
+            - event_dispatch_breakdown
+
+  - persona_id: persona_zhao_ke
+    entity_id: entity_zhao_ke
+    public_role:
+      text: Deputy mayor trying to preserve the Sea Lantern Festival schedule.
+      evidence:
+        entity_ids:
+          - entity_zhao_ke
+          - entity_sea_lantern_festival
+        relation_ids:
+          - relation_zhao_ke_protects_festival
+    goals:
+      - text: Avoid a public cancellation before the opening ceremony.
+        evidence:
+          relation_ids:
+            - relation_zhao_ke_protects_festival
+          event_ids:
+            - event_budget_diversion
+      - text: Keep control of the narrative around the gate delay.
+        evidence:
+          relation_ids:
+            - relation_zhao_ke_protects_festival
+          event_ids:
+            - event_dispatch_breakdown
+    constraints:
+      - text: Needs some factual basis before ordering a visible evacuation.
+        evidence:
+          event_ids:
+            - event_budget_diversion
+            - event_gate_failure_risk
+      - text: Faces public backlash if the budget diversion becomes undeniable.
+        evidence:
+          event_ids:
+            - event_budget_diversion
+            - event_dispatch_breakdown
+    known_facts:
+      - text: Festival spending already consumed money earmarked for gate repairs.
+        evidence:
+          relation_ids:
+            - relation_zhao_ke_protects_festival
+          event_ids:
+            - event_budget_diversion
+      - text: Visible documentary proof could force an emergency reversal.
+        evidence:
+          event_ids:
+            - event_budget_diversion
+            - event_dispatch_breakdown
+    private_info:
+      - text: Zhao Ke worries more about public embarrassment than engineering nuance until pressure becomes undeniable.
+        evidence:
+          relation_ids:
+            - relation_zhao_ke_protects_festival
+          event_ids:
+            - event_budget_diversion
+            - event_gate_failure_risk
+    relationships:
+      - target_id: persona_lin_lan
+        kind: fears_disclosure_from
+        evidence:
+          event_ids:
+            - event_budget_diversion
+            - event_dispatch_breakdown
+      - target_id: persona_su_he
+        kind: deflects
+        evidence:
+          relation_ids:
+            - relation_su_he_inspects_gate
+          event_ids:
+            - event_dispatch_breakdown

--- a/data/demo/expectations/demo_eval.yaml
+++ b/data/demo/expectations/demo_eval.yaml
@@ -1,5 +1,30 @@
 eval_name: fog_harbor_phase0_demo
 checks:
+  - name: graph_has_events
+    kind: graph_events_nonempty
+  - name: world_objects_have_evidence
+    kind: world_evidence_complete
+  - name: persona_fields_have_provenance
+    kind: persona_field_provenance_complete
+    fields:
+      - public_role
+      - goals
+      - constraints
+      - known_facts
+      - private_info
+      - relationships
+  - name: inspect_entity_east_gate
+    kind: inspect_world
+    object_kind: entity
+    object_id: entity_east_gate
+  - name: inspect_persona_su_he
+    kind: inspect_world
+    object_kind: persona
+    object_id: persona_su_he
+  - name: inspect_event_gate_failure_risk
+    kind: inspect_world
+    object_kind: event
+    object_id: event_gate_failure_risk
   - name: baseline_exposes_budget
     kind: run_field
     run: baseline

--- a/docs/architecture/contracts.md
+++ b/docs/architecture/contracts.md
@@ -1,6 +1,6 @@
 # Core Contracts
 
-This file freezes the Phase 0 assumptions that other modules should build against.
+This file freezes the current post-Phase-0 contracts that Phase 1 hardening now depends on.
 
 ## Stable Object IDs
 
@@ -8,6 +8,7 @@ This file freezes the Phase 0 assumptions that other modules should build agains
 - `chunk_id`
 - `entity_id`
 - `relation_id`
+- `event_id`
 - `persona_id`
 - `scenario_id`
 - `run_id`
@@ -18,17 +19,47 @@ All IDs must be serializable, stable across files, and traceable in `artifacts/`
 
 ## Evidence And Claims
 
-- `Entity`, `Relation`, `Persona`, `TurnAction`, and `Claim` always carry `evidence_ids`, or an explicit non-evidence label.
+- `Entity`, `Relation`, `Event`, `Persona`, `TurnAction`, and `Claim` always carry non-empty `evidence_ids`, or an explicit non-evidence label.
+- `Persona.field_provenance` is a field-level map of `field_name -> evidence_ids`.
+- `Persona.field_provenance` must be non-empty for every non-empty core field:
+  - `public_role`
+  - `goals`
+  - `constraints`
+  - `known_facts`
+  - `private_info`
+  - `relationships`
 - Claim labels are restricted to:
   - `evidence_backed`
   - `inferred`
   - `speculative`
 
+## World Model Contract
+
+- Demo world modeling is driven by `data/demo/config/world_model.yaml`.
+- `graph.json` is the durable world-model artifact and now contains:
+  - `entities`
+  - `relations`
+  - `events`
+  - `stats`
+- `personas.json` keeps the same top-level shape, but each persona now includes:
+  - aggregate `evidence_ids`
+  - field-level `field_provenance`
+
+## Query Contract
+
+- The Phase 1 query surface is CLI-first.
+- The canonical query entrypoint is:
+  - `python -m backend.app.cli inspect-world --kind <entity|persona|event> --id <stable-id> --graph <graph.json> --personas <personas.json>`
+- `inspect-world` returns stable JSON with:
+  - `world_id`
+  - `kind`
+  - `object`
+
 ## Scenario Contract
 
 - `scenario_id` names the full scenario package.
 - Each injection has its own `injection_id` and `kind`.
-- Phase 0 supports only:
+- Phase 0 and this Phase 1 hardening pass still support only:
   - `delay_document`
   - `block_contact`
   - `resource_failure`
@@ -37,21 +68,24 @@ All IDs must be serializable, stable across files, and traceable in `artifacts/`
 
 - `TurnAction` is the line format stored in `run_trace.jsonl`.
 - `RunTrace` is the run-level summary model stored in `summary.json`.
-- Simulation is seeded, bounded, deterministic, and writes snapshots per turn.
+- Simulation remains seeded, bounded, deterministic, and writes snapshots per turn.
+- `branch_count` remains reserved for future runner generalization and does not gain new execution semantics in this sprint.
 
 ## Artifact Contract
 
 ```text
 artifacts/demo/
-├─ ingest/
-├─ graph/
-├─ personas/
-├─ scenario/
-├─ run/
-│  ├─ baseline/
-│  └─ reporter_detained/
-├─ report/
-└─ eval/
+├── ingest/
+├── graph/
+│   └── graph.json
+├── personas/
+│   └── personas.json
+├── scenario/
+├── run/
+│   ├── baseline/
+│   └── reporter_detained/
+├── report/
+└── eval/
 ```
 
 ## Platform Assumption

--- a/docs/decisions/ADR-0003-phase1-world-model-contracts.md
+++ b/docs/decisions/ADR-0003-phase1-world-model-contracts.md
@@ -1,0 +1,48 @@
+# ADR-0003: Phase 1 World Model Contracts
+
+## Status
+
+- Accepted
+
+## Context
+
+Phase 0 proved the canonical Fog Harbor demo can run end-to-end, but it still relied on demo-specific hardcoded graph and persona definitions. The next sprint hardens the world model so later scenario and simulation work can build on a stable, queryable, evidence-backed layer instead of piling more logic onto code constants.
+
+This change touches long-lived contracts in two places:
+
+- domain schema now needs a first-class `Event`
+- persona provenance must move from object-level only to field-level
+- the repo now exposes a durable query surface through `inspect-world`
+
+Per the project decision rules, domain schema changes and command interface changes require an ADR instead of only updating the contract notes.
+
+## Decision
+
+- Introduce `Event` as a first-class domain object with:
+  - `event_id`
+  - `name`
+  - `kind`
+  - `participant_entity_ids`
+  - `evidence_ids`
+- Extend `Persona` with `field_provenance: dict[str, list[str]]`.
+- Freeze the initial field-level provenance requirement for:
+  - `public_role`
+  - `goals`
+  - `constraints`
+  - `known_facts`
+  - `private_info`
+  - `relationships`
+- Move demo-specific world definitions out of Python constants and into `data/demo/config/world_model.yaml`.
+- Add a CLI-first query surface:
+  - `python -m backend.app.cli inspect-world ...`
+- Keep simulation semantics unchanged in this sprint:
+  - no `branch_count` expansion
+  - no GraphRAG-lite
+  - no external LLM extraction
+
+## Consequences
+
+- World-model artifacts become more durable and easier to inspect across future sprints.
+- Tests and evals must now protect `events` and `field_provenance`, not only aggregate claim evidence.
+- Querying stays intentionally simple and local-first, which keeps the contract stable while avoiding premature API expansion.
+- Future changes to `Event` shape, field provenance semantics, or `inspect-world` output should be treated as contract changes and recorded in a follow-up ADR.

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -1,0 +1,57 @@
+# Mirror Automation Roadmap
+
+## Objective
+
+Turn Mirror into a long-running, repo-native automation loop that uses GitHub as the task source of truth, Codex as the execution plane, CI/eval as gates, and phase audits as the stop condition.
+
+## Day 0 Bootstrap
+
+Before builder automation is allowed to write code or auto-merge:
+
+1. Clean or snapshot the current worktree into a baseline PR.
+2. Bootstrap labels, milestones, and phase issues from `.github/automation/bootstrap-spec.json`.
+3. Upgrade CI from Phase 0 smoke/test only to the long-running quality gate.
+4. Confirm the protected-core lane policy in `.github/automation/lane-policy.json`.
+5. Start Codex automations only after the baseline issue is no longer blocked.
+
+## Local Commands
+
+- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`
+  - dry-run the GitHub bootstrap plan
+- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim --apply`
+  - create missing milestones, labels, and bootstrap issues
+- `python -m backend.app.cli classify-lane --files README.md backend/app/cli.py`
+  - classify a change set into `lane:auto-safe` or `lane:protected-core`
+- `python -m backend.app.cli audit-phase phase1`
+  - run the Phase 1 local exit audit
+
+## Execution Roles
+
+- `mirror-orchestrator`
+  - daily triage
+  - metadata repair
+  - task splitting
+  - protected-core detection
+- `mirror-builder`
+  - one writer at a time
+  - one issue at a time
+  - push PRs into safe or protected lanes
+- `mirror-evaluator`
+  - re-run tests, smoke, eval-demo
+  - summarize artifacts and failures
+- `mirror-phase-auditor`
+  - run local phase audits
+  - compare against milestone state
+  - pause automation when Phase 3 is complete
+
+## Guardrails
+
+- Protected-core files are defined in `.github/automation/lane-policy.json`.
+- Path hits under that policy force `lane:protected-core`.
+- Protected-core PRs may be automated, but they must not auto-merge.
+- Any open `status:needs-adr` or `risk:safety` label blocks auto-merge.
+
+## TODO[verify]
+
+- TODO[verify]: GitHub branch protection and repository auto-merge settings still need to be applied on the remote repository.
+- TODO[verify]: Codex cron automations should target worktrees, not the current dirty `main` checkout.

--- a/scripts/bootstrap_github.py
+++ b/scripts/bootstrap_github.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+
+def _gh_json(args: list[str], *, cwd: Path) -> object:
+    try:
+        result = subprocess.run(
+            ["gh", *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.strip() if exc.stderr else "unknown gh failure"
+        raise RuntimeError(
+            "GitHub bootstrap requires an authenticated `gh` context with repo/workflow access. "
+            f"Command failed: gh {' '.join(args)}. stderr: {stderr}"
+        ) from exc
+    return json.loads(result.stdout) if result.stdout.strip() else None
+
+
+def _label_exists(existing: list[dict], name: str) -> bool:
+    return any(label["name"] == name for label in existing)
+
+
+def _milestone_by_title(existing: list[dict], title: str) -> dict | None:
+    for milestone in existing:
+        if milestone["title"] == title:
+            return milestone
+    return None
+
+
+def _issue_exists(existing: list[dict], title: str) -> bool:
+    return any(issue["title"] == title for issue in existing)
+
+
+def bootstrap_github(repo: str, spec_path: Path, *, apply: bool) -> None:
+    cwd = spec_path.resolve().parents[2]
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    existing_labels = _gh_json(["api", f"repos/{repo}/labels", "--paginate"], cwd=cwd)
+    existing_milestones = _gh_json(["api", f"repos/{repo}/milestones"], cwd=cwd)
+    existing_issues = _gh_json(["api", f"repos/{repo}/issues?state=all", "--paginate"], cwd=cwd)
+    milestone_numbers: dict[str, int] = {}
+
+    for milestone in spec["milestones"]:
+        existing = _milestone_by_title(existing_milestones, milestone["title"])
+        if existing:
+            milestone_numbers[milestone["title"]] = existing["number"]
+            print(f"[exists] milestone {milestone['title']}")
+            continue
+        print(f"[create] milestone {milestone['title']}")
+        if apply:
+            created = _gh_json(
+                [
+                    "api",
+                    f"repos/{repo}/milestones",
+                    "--method",
+                    "POST",
+                    "-f",
+                    f"title={milestone['title']}",
+                    "-f",
+                    f"description={milestone['description']}",
+                ],
+                cwd=cwd,
+            )
+            milestone_numbers[milestone["title"]] = created["number"]
+
+    if apply:
+        refreshed_milestones = _gh_json(["api", f"repos/{repo}/milestones"], cwd=cwd)
+        for milestone in refreshed_milestones:
+            milestone_numbers[milestone["title"]] = milestone["number"]
+
+    for label in spec["labels"]:
+        if _label_exists(existing_labels, label["name"]):
+            print(f"[exists] label {label['name']}")
+            continue
+        print(f"[create] label {label['name']}")
+        if apply:
+            _gh_json(
+                [
+                    "api",
+                    f"repos/{repo}/labels",
+                    "--method",
+                    "POST",
+                    "-f",
+                    f"name={label['name']}",
+                    "-f",
+                    f"color={label['color']}",
+                    "-f",
+                    f"description={label['description']}",
+                ],
+                cwd=cwd,
+            )
+
+    for issue in spec["issues"]:
+        if _issue_exists(existing_issues, issue["title"]):
+            print(f"[exists] issue {issue['title']}")
+            continue
+        print(f"[create] issue {issue['title']}")
+        if apply:
+            args = [
+                "issue",
+                "create",
+                "--repo",
+                repo,
+                "--title",
+                issue["title"],
+                "--body",
+                issue["body"],
+            ]
+            if issue.get("milestone") and issue["milestone"] in milestone_numbers:
+                args.extend(["--milestone", issue["milestone"]])
+            for label in issue.get("labels", []):
+                args.extend(["--label", label])
+            subprocess.run(["gh", *args], cwd=cwd, check=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Bootstrap GitHub milestones, labels, and issues for Mirror automation.")
+    parser.add_argument("--repo", required=True, help="GitHub repo in owner/name form.")
+    parser.add_argument("--spec", default=".github/automation/bootstrap-spec.json", help="Path to the bootstrap JSON spec.")
+    parser.add_argument("--apply", action="store_true", help="Actually create missing resources. Without this flag, run in dry-run mode.")
+    args = parser.parse_args()
+
+    bootstrap_github(args.repo, Path(args.spec), apply=args.apply)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- bootstrap Phase 1 world-model hardening and automation repo guardrails
- add GitHub issue/PR templates, lane policy, bootstrap spec, and bootstrap script
- upgrade CI and add PR lane labeling workflow
- add local classify-lane and audit-phase commands plus tests
- create the Day 0/Phase exit GitHub issues and Codex automations

## Verification
- ./make.ps1 test
- ./make.ps1 smoke
- ./make.ps1 eval-demo
- python -m backend.app.cli classify-lane --files README.md backend/app/cli.py
- python -m backend.app.cli audit-phase phase1

## Notes
- safe-lane automation is enabled, but protected-core changes still stop for review by design
- branch protection and repo auto-merge settings remain TODO[verify] on the remote repository