### PR TITLE
Sync post-Day-0 queue docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,21 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed its Phase 0 foundation and is now in Phase 1 world-model hardening.
+The repository has completed Day 0 bootstrap and now has an automation-ready baseline.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
 - The backend can ingest, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
-- The repo now also includes the bootstrap pieces for long-running automation:
+- The repo now also includes the active bootstrap pieces for long-running automation:
   - GitHub issue and PR templates
   - lane policy and bootstrap spec
   - CI upgraded to a long-running quality gate
   - local lane-classification and phase-audit commands
+  - remote `main` branch protection and repository auto-merge
+- Local phase audits currently show:
+  - Phase 1: pass
+  - Phase 2: pass
+  - Phase 3: blocked on the browser workbench entrypoint
 
 ## Quick Start
 
@@ -102,7 +107,8 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap still requires a clean baseline snapshot before autonomous code-writing loops should run on worktrees.
+- Day 0 bootstrap is complete; the next active queue is tracked in [docs/plans/phase-execution-queue.md](/D:/mirror/docs/plans/phase-execution-queue.md).
+- Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals
 

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -4,6 +4,15 @@
 
 Turn Mirror into a long-running, repo-native automation loop that uses GitHub as the task source of truth, Codex as the execution plane, CI/eval as gates, and phase audits as the stop condition.
 
+## Current State
+
+Day 0 bootstrap is complete as of 2026-04-15.
+
+- The bootstrap baseline has been merged into `main`.
+- GitHub milestones, labels, and phase issues exist.
+- `main` is protected by required Linux and Windows quality gates.
+- Repository auto-merge is enabled for safe-lane use.
+
 ## Day 0 Bootstrap
 
 Before builder automation is allowed to write code or auto-merge:
@@ -53,5 +62,4 @@ Before builder automation is allowed to write code or auto-merge:
 
 ## TODO[verify]
 
-- TODO[verify]: GitHub branch protection and repository auto-merge settings still need to be applied on the remote repository.
 - TODO[verify]: Codex cron automations should target worktrees, not the current dirty `main` checkout.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,0 +1,89 @@
+# Phase Execution Queue
+
+This note turns the current post-Day-0 repository state into an automation-ready queue.
+
+## Current Gate State
+
+- Phase 1 local audit: `pass`
+- Phase 2 local audit: `pass`
+- Phase 3 local audit: `fail`
+  - current blocker: `frontend/src/app/page.tsx` does not exist
+
+## Implication
+
+Automation should no longer spend time on Day 0 bootstrap.
+
+- Phase 1 and Phase 2 local audits are green, but the active backlog should still prefer Phase 1 hardening over Phase 3 UI expansion.
+- The next queue should focus on locking query stability, world-model expectations, and evidence/redline regressions.
+- Phase 3 remains intentionally parked behind those hardening tasks, even though its only explicit local audit failure is the missing workbench entrypoint.
+
+## Recommended Queue
+
+### P1-1 Query Golden Assertions
+
+- Goal: add stable golden assertions for `inspect-world` on one canonical entity, persona, and event
+- Lane: `lane:auto-safe`
+- Area: `area:backend`
+- Minimal test:
+  - `./make.ps1 test`
+  - `python -m backend.app.cli inspect-world --kind entity --id entity_east_gate --graph ... --personas ...`
+
+### P1-2 Canonical World Expectations
+
+- Goal: add expectations for core demo entities, relations, and events beyond simple non-empty evidence checks
+- Lane: `lane:auto-safe`
+- Area: `area:docs-evals`
+- Minimal test:
+  - `./make.ps1 eval-demo`
+  - expectation set verifies stable world-model IDs and core structure
+
+### P1-3 Query And Report Safety Wording
+
+- Goal: extend redline-style assertions to cover query and report wording boundaries
+- Lane: `lane:auto-safe`
+- Area: `area:docs-evals`
+- Minimal test:
+  - `./make.ps1 test`
+  - `./make.ps1 eval-demo`
+
+### P1-4 Phase Audit In CI
+
+- Goal: pull `audit-phase phase1` and `audit-phase phase2` into the long-running validation path so regressions fail earlier
+- Lane: `lane:auto-safe`
+- Area: `area:docs-evals`
+- Minimal test:
+  - CI or smoke path fails if a phase audit regresses
+
+### P1-5 Persona Over-Inference Review
+
+- Goal: review whether persona generation currently exceeds evidence-backed boundaries and tighten only if needed
+- Lane: `lane:protected-core`
+- Area: `area:backend`
+- Minimal test:
+  - `./make.ps1 smoke`
+  - `./make.ps1 test`
+  - any contract-affecting change must update docs and, if needed, an ADR
+
+### P3-parked Workbench Shell
+
+- Goal: replace the deferred frontend shell with a concrete browser entrypoint at `frontend/src/app/page.tsx`
+- Lane: `lane:auto-safe`
+- Area: `area:frontend`
+- Minimal test:
+  - `python -m backend.app.cli audit-phase phase3`
+
+## Protected-Core Reminder
+
+Even after Day 0, the following remain protected-core and must not auto-merge just because checks are green:
+
+- `docs/architecture/contracts.md`
+- `docs/decisions/`
+- `backend/app/domain/`
+- `backend/app/scenarios/`
+- `backend/app/simulation/`
+- `backend/app/reports/`
+
+## TODO[verify]
+
+- TODO[verify]: Codex cron automations should target worktrees rather than a long-lived checkout.
+- TODO[verify]: If Phase 3 needs a backend artifact API instead of direct file reads, confirm that the chosen route does not quietly expand the protected-core contract surface.


### PR DESCRIPTION
## Summary
- update the roadmap and README to reflect that Day 0 bootstrap is complete
- add a local execution-queue note that matches the new GitHub Phase 1 hardening queue
- keep protected-core and safe-lane guidance explicit after branch protection landed

## Testing
- not run (docs-only change)

## Artifacts
- GitHub issues #6-#11 now define the next active Phase 1 queue

## Contract impact
- none; this PR only syncs docs with the current repo and GitHub state

## Safety impact
- none; guidance remains aligned with existing lane-policy and redline constraints

## TODO[verify]
- Codex cron automations should still target worktrees rather than a long-lived checkout
