### PR TITLE
Add inspect-world golden regression fixtures

### DIFF
--- a/backend/tests/fixtures/inspect_world_entity_east_gate.json
+++ b/backend/tests/fixtures/inspect_world_entity_east_gate.json
@@ -1,0 +1,24 @@
+{
+  "world_id": "fog-harbor-east-gate",
+  "kind": "entity",
+  "object": {
+    "entity_id": "entity_east_gate",
+    "name": "East Gate",
+    "type": "infrastructure",
+    "aliases": [
+      "east gate",
+      "flood gate",
+      "gate seam"
+    ],
+    "evidence_ids": [
+      "chunk_doc_budget_minutes_002",
+      "chunk_doc_budget_minutes_004",
+      "chunk_doc_engineering_inspection_001",
+      "chunk_doc_engineering_inspection_002",
+      "chunk_doc_ledger_copy_002",
+      "chunk_doc_storm_bulletin_002",
+      "chunk_doc_storm_bulletin_003",
+      "chunk_doc_tugboat_log_002"
+    ]
+  }
+}

--- a/backend/tests/fixtures/inspect_world_event_gate_failure_risk.json
+++ b/backend/tests/fixtures/inspect_world_event_gate_failure_risk.json
@@ -1,0 +1,21 @@
+{
+  "world_id": "fog-harbor-east-gate",
+  "kind": "event",
+  "object": {
+    "event_id": "event_gate_failure_risk",
+    "name": "East Gate Failure Risk Escalates",
+    "kind": "risk_escalation",
+    "participant_entity_ids": [
+      "entity_su_he",
+      "entity_chen_yu",
+      "entity_east_gate",
+      "entity_east_wharf"
+    ],
+    "evidence_ids": [
+      "chunk_doc_engineering_inspection_002",
+      "chunk_doc_engineering_inspection_004",
+      "chunk_doc_storm_bulletin_003",
+      "chunk_doc_tugboat_log_002"
+    ]
+  }
+}

--- a/backend/tests/fixtures/inspect_world_persona_su_he.json
+++ b/backend/tests/fixtures/inspect_world_persona_su_he.json
@@ -1,0 +1,126 @@
+{
+  "world_id": "fog-harbor-east-gate",
+  "kind": "persona",
+  "object": {
+    "persona_id": "persona_su_he",
+    "entity_id": "entity_su_he",
+    "public_role": "Waterworks engineer responsible for the East Gate inspection.",
+    "goals": [
+      "Get the gate reinforced before the surge window closes.",
+      "Escalate evacuation if evidence confirms leadership is delaying repairs."
+    ],
+    "constraints": [
+      "Cannot repair the gate alone.",
+      "Needs records or public pressure to override festival priorities."
+    ],
+    "known_facts": [
+      "The East Gate brace is already widening under pressure.",
+      "Festival traffic would slow emergency repairs."
+    ],
+    "private_info": [
+      "Su He believes the next surge could trigger a compound failure if leadership waits."
+    ],
+    "relationships": [
+      {
+        "target_id": "persona_lin_lan",
+        "kind": "depends_on"
+      },
+      {
+        "target_id": "persona_chen_yu",
+        "kind": "trusts"
+      }
+    ],
+    "field_provenance": {
+      "public_role": [
+        "chunk_doc_budget_minutes_002",
+        "chunk_doc_budget_minutes_004",
+        "chunk_doc_engineering_inspection_001",
+        "chunk_doc_engineering_inspection_002",
+        "chunk_doc_engineering_inspection_003",
+        "chunk_doc_gate_dispatch_002",
+        "chunk_doc_ledger_copy_002",
+        "chunk_doc_ledger_copy_004",
+        "chunk_doc_storm_bulletin_002",
+        "chunk_doc_storm_bulletin_003",
+        "chunk_doc_tugboat_log_002",
+        "chunk_doc_tugboat_log_004"
+      ],
+      "goals": [
+        "chunk_doc_budget_minutes_002",
+        "chunk_doc_engineering_inspection_002",
+        "chunk_doc_engineering_inspection_004",
+        "chunk_doc_gate_dispatch_002",
+        "chunk_doc_gate_dispatch_003",
+        "chunk_doc_gate_dispatch_004",
+        "chunk_doc_ledger_copy_002",
+        "chunk_doc_ledger_copy_003",
+        "chunk_doc_storm_bulletin_002",
+        "chunk_doc_storm_bulletin_003",
+        "chunk_doc_storm_bulletin_004",
+        "chunk_doc_tugboat_log_002"
+      ],
+      "constraints": [
+        "chunk_doc_budget_minutes_002",
+        "chunk_doc_engineering_inspection_002",
+        "chunk_doc_engineering_inspection_004",
+        "chunk_doc_gate_dispatch_002",
+        "chunk_doc_gate_dispatch_003",
+        "chunk_doc_gate_dispatch_004",
+        "chunk_doc_ledger_copy_002",
+        "chunk_doc_ledger_copy_003",
+        "chunk_doc_storm_bulletin_003",
+        "chunk_doc_tugboat_log_002"
+      ],
+      "known_facts": [
+        "chunk_doc_budget_minutes_002",
+        "chunk_doc_engineering_inspection_002",
+        "chunk_doc_engineering_inspection_004",
+        "chunk_doc_gate_dispatch_002",
+        "chunk_doc_gate_dispatch_003",
+        "chunk_doc_gate_dispatch_004",
+        "chunk_doc_ledger_copy_002",
+        "chunk_doc_ledger_copy_003",
+        "chunk_doc_storm_bulletin_003",
+        "chunk_doc_tugboat_log_002"
+      ],
+      "private_info": [
+        "chunk_doc_budget_minutes_002",
+        "chunk_doc_engineering_inspection_002",
+        "chunk_doc_engineering_inspection_004",
+        "chunk_doc_ledger_copy_002",
+        "chunk_doc_storm_bulletin_003",
+        "chunk_doc_tugboat_log_002"
+      ],
+      "relationships": [
+        "chunk_doc_engineering_inspection_002",
+        "chunk_doc_engineering_inspection_004",
+        "chunk_doc_gate_dispatch_002",
+        "chunk_doc_gate_dispatch_003",
+        "chunk_doc_gate_dispatch_004",
+        "chunk_doc_ledger_copy_002",
+        "chunk_doc_ledger_copy_003",
+        "chunk_doc_storm_bulletin_003",
+        "chunk_doc_tugboat_log_002"
+      ]
+    },
+    "evidence_ids": [
+      "chunk_doc_budget_minutes_002",
+      "chunk_doc_budget_minutes_004",
+      "chunk_doc_engineering_inspection_001",
+      "chunk_doc_engineering_inspection_002",
+      "chunk_doc_engineering_inspection_003",
+      "chunk_doc_engineering_inspection_004",
+      "chunk_doc_gate_dispatch_002",
+      "chunk_doc_gate_dispatch_003",
+      "chunk_doc_gate_dispatch_004",
+      "chunk_doc_ledger_copy_002",
+      "chunk_doc_ledger_copy_003",
+      "chunk_doc_ledger_copy_004",
+      "chunk_doc_storm_bulletin_002",
+      "chunk_doc_storm_bulletin_003",
+      "chunk_doc_storm_bulletin_004",
+      "chunk_doc_tugboat_log_002",
+      "chunk_doc_tugboat_log_004"
+    ]
+  }
+}

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import pytest
 
 from backend.app.cli import main
 from backend.app.config import get_settings
@@ -21,7 +22,25 @@ def test_cli_validate_and_smoke(tmp_path: Path) -> None:
     assert (tmp_path / "baseline.json").exists()
 
 
-def test_cli_inspect_world_outputs_json(tmp_path: Path, capsys) -> None:
+def _load_fixture(name: str) -> dict:
+    return json.loads((Path(__file__).parent / "fixtures" / name).read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize(
+    ("kind", "object_id", "fixture_name"),
+    [
+        ("entity", "entity_east_gate", "inspect_world_entity_east_gate.json"),
+        ("persona", "persona_su_he", "inspect_world_persona_su_he.json"),
+        ("event", "event_gate_failure_risk", "inspect_world_event_gate_failure_risk.json"),
+    ],
+)
+def test_cli_inspect_world_matches_golden_outputs(
+    tmp_path: Path,
+    capsys,
+    kind: str,
+    object_id: str,
+    fixture_name: str,
+) -> None:
     settings = get_settings()
     assert main(["ingest", str(settings.manifest_path), "--out", str(tmp_path / "ingest")]) == 0
     assert main(["build-graph", str(tmp_path / "ingest" / "chunks.jsonl"), "--out", str(tmp_path / "graph")]) == 0
@@ -32,9 +51,9 @@ def test_cli_inspect_world_outputs_json(tmp_path: Path, capsys) -> None:
             [
                 "inspect-world",
                 "--kind",
-                "entity",
+                kind,
                 "--id",
-                "entity_east_gate",
+                object_id,
                 "--graph",
                 str(tmp_path / "graph" / "graph.json"),
                 "--personas",
@@ -44,8 +63,7 @@ def test_cli_inspect_world_outputs_json(tmp_path: Path, capsys) -> None:
         == 0
     )
     payload = json.loads(capsys.readouterr().out)
-    assert payload["kind"] == "entity"
-    assert payload["object"]["entity_id"] == "entity_east_gate"
+    assert payload == _load_fixture(fixture_name)
 
 
 def test_cli_classify_lane_outputs_json(capsys) -> None:


### PR DESCRIPTION
## Summary
- add golden JSON fixtures for the canonical `inspect-world` entity, persona, and event outputs
- strengthen the CLI regression test so it checks exact stable JSON rather than only a few fields
- keep the change in the safe lane by hardening the current query surface without expanding it

Closes #6

## Testing
- `python -m pytest backend/tests/test_cli.py backend/tests/test_pipeline.py -q`
- `./make.ps1 test`
- `python -m backend.app.cli classify-lane --files backend/tests/test_cli.py backend/tests/fixtures/inspect_world_entity_east_gate.json backend/tests/fixtures/inspect_world_persona_su_he.json backend/tests/fixtures/inspect_world_event_gate_failure_risk.json`

## Artifacts
- canonical golden fixtures now live under `backend/tests/fixtures/`

## Contract impact
- none; this PR only freezes the current `inspect-world` output for canonical demo IDs

## Safety impact
- none; output hardening remains within the existing safe-lane query surface

## TODO[verify]
- if the canonical demo world intentionally changes later, refresh these fixtures in the same PR that changes the world-model expectations
