### PR TITLE
Add canonical world model eval expectations

### DIFF
--- a/backend/app/evals/service.py
+++ b/backend/app/evals/service.py
@@ -31,6 +31,16 @@ def _scan_terms(text: str, terms: list[str]) -> list[str]:
     return [term for term in terms if term.lower() in lowered]
 
 
+def _graph_collection_id_field(collection: str) -> str:
+    if collection == "entities":
+        return "entity_id"
+    if collection == "relations":
+        return "relation_id"
+    if collection == "events":
+        return "event_id"
+    raise ValueError(f"Unsupported graph collection: {collection}")
+
+
 def _evaluate_redlines(redlines_path: Path, artifacts_root: Path) -> list[str]:
     rules = load_yaml(redlines_path)
     texts = {
@@ -101,6 +111,15 @@ def evaluate_runs(expectations_path: Path, artifacts_root: Path, out_dir: Path, 
             collections = ("entities", "relations", "events")
             if not all(item.get("evidence_ids") for collection in collections for item in graph_payload[collection]):
                 failures.append(f"{check['name']}: at least one world object is missing evidence_ids")
+            else:
+                passed += 1
+        elif kind == "world_object_ids_present":
+            collection = check["collection"]
+            id_field = _graph_collection_id_field(collection)
+            observed_ids = {item[id_field] for item in graph_payload[collection]}
+            missing = [object_id for object_id in check["ids"] if object_id not in observed_ids]
+            if missing:
+                failures.append(f"{check['name']}: missing {collection} ids {missing}")
             else:
                 passed += 1
         elif kind == "persona_field_provenance_complete":

--- a/backend/tests/test_pipeline.py
+++ b/backend/tests/test_pipeline.py
@@ -35,6 +35,39 @@ def test_graph_and_personas_have_evidence(tmp_path: Path) -> None:
     assert all(persona.field_provenance["relationships"] for persona in personas)
 
 
+def test_graph_contains_canonical_demo_ids(tmp_path: Path) -> None:
+    settings = get_settings()
+    ingest_manifest(settings.manifest_path, tmp_path / "ingest")
+    graph = build_graph(tmp_path / "ingest" / "chunks.jsonl", tmp_path / "graph")
+
+    entity_ids = {item["entity_id"] for item in graph["entities"]}
+    relation_ids = {item["relation_id"] for item in graph["relations"]}
+    event_ids = {item["event_id"] for item in graph["events"]}
+
+    assert {
+        "entity_lin_lan",
+        "entity_zhao_ke",
+        "entity_su_he",
+        "entity_chen_yu",
+        "entity_east_gate",
+        "entity_maintenance_ledger",
+        "entity_sea_lantern_festival",
+        "entity_east_wharf",
+    }.issubset(entity_ids)
+    assert {
+        "relation_lin_lan_controls_ledger",
+        "relation_su_he_inspects_gate",
+        "relation_zhao_ke_protects_festival",
+        "relation_chen_yu_tracks_gate",
+    }.issubset(relation_ids)
+    assert {
+        "event_budget_diversion",
+        "event_gate_failure_risk",
+        "event_dispatch_breakdown",
+        "event_storm_surge_warning",
+    }.issubset(event_ids)
+
+
 def test_world_query_returns_evidence_backed_objects(tmp_path: Path) -> None:
     settings = get_settings()
     ingest_manifest(settings.manifest_path, tmp_path / "ingest")

--- a/data/demo/expectations/demo_eval.yaml
+++ b/data/demo/expectations/demo_eval.yaml
@@ -2,6 +2,34 @@ eval_name: fog_harbor_phase0_demo
 checks:
   - name: graph_has_events
     kind: graph_events_nonempty
+  - name: core_entity_ids_present
+    kind: world_object_ids_present
+    collection: entities
+    ids:
+      - entity_lin_lan
+      - entity_zhao_ke
+      - entity_su_he
+      - entity_chen_yu
+      - entity_east_gate
+      - entity_maintenance_ledger
+      - entity_sea_lantern_festival
+      - entity_east_wharf
+  - name: core_relation_ids_present
+    kind: world_object_ids_present
+    collection: relations
+    ids:
+      - relation_lin_lan_controls_ledger
+      - relation_su_he_inspects_gate
+      - relation_zhao_ke_protects_festival
+      - relation_chen_yu_tracks_gate
+  - name: core_event_ids_present
+    kind: world_object_ids_present
+    collection: events
+    ids:
+      - event_budget_diversion
+      - event_gate_failure_risk
+      - event_dispatch_breakdown
+      - event_storm_surge_warning
   - name: world_objects_have_evidence
     kind: world_evidence_complete
   - name: persona_fields_have_provenance


### PR DESCRIPTION
## Summary
- add a new eval check for required world-object IDs in graph collections
- lock the canonical Fog Harbor entity, relation, and event IDs into `demo_eval.yaml`
- add a matching pipeline regression test so the demo world cannot drift silently

Closes #7

## Testing
- `python -m pytest backend/tests/test_pipeline.py -q`
- `./make.ps1 eval-demo`
- `./make.ps1 test`
- `python -m backend.app.cli classify-lane --files backend/app/evals/service.py data/demo/expectations/demo_eval.yaml backend/tests/test_pipeline.py`

## Artifacts
- `eval-demo` now passes with `16/16 checks passed`

## Contract impact
- none; this PR only hardens the current canonical world-model expectations without changing the world-model contract

## Safety impact
- none; this remains in the safe lane and only strengthens canonical demo assertions

## TODO[verify]
- if the canonical Fog Harbor world intentionally changes later, refresh these required IDs in the same PR that changes the demo world-model config
