### PR TITLE
Extend redlines to inspect-world outputs

### DIFF
--- a/backend/app/evals/service.py
+++ b/backend/app/evals/service.py
@@ -31,9 +31,10 @@ def _scan_terms(text: str, terms: list[str]) -> list[str]:
     return [term for term in terms if term.lower() in lowered]
 
 
-def _evaluate_redlines(redlines_path: Path, artifacts_root: Path) -> list[str]:
-    rules = load_yaml(redlines_path)
-    texts = {
+def _redline_texts(artifacts_root: Path) -> dict[str, str]:
+    graph_path = artifacts_root / "graph" / "graph.json"
+    personas_path = artifacts_root / "personas" / "personas.json"
+    return {
         "report": (artifacts_root / "report" / "report.md").read_text(encoding="utf-8"),
         "claims": json.dumps(read_json(artifacts_root / "report" / "claims.json"), ensure_ascii=False),
         "baseline_scenario": json.dumps(read_json(artifacts_root / "scenario" / "baseline.json"), ensure_ascii=False),
@@ -41,7 +42,24 @@ def _evaluate_redlines(redlines_path: Path, artifacts_root: Path) -> list[str]:
             read_json(artifacts_root / "scenario" / "reporter_detained.json"),
             ensure_ascii=False,
         ),
+        "query_entity_east_gate": json.dumps(
+            inspect_world("entity", "entity_east_gate", graph_path, personas_path),
+            ensure_ascii=False,
+        ),
+        "query_persona_su_he": json.dumps(
+            inspect_world("persona", "persona_su_he", graph_path, personas_path),
+            ensure_ascii=False,
+        ),
+        "query_event_gate_failure_risk": json.dumps(
+            inspect_world("event", "event_gate_failure_risk", graph_path, personas_path),
+            ensure_ascii=False,
+        ),
     }
+
+
+def _evaluate_redlines(redlines_path: Path, artifacts_root: Path) -> list[str]:
+    rules = load_yaml(redlines_path)
+    texts = _redline_texts(artifacts_root)
     failures: list[str] = []
     for label, text in texts.items():
         topic_hits = _scan_terms(text, rules["blocked_topics"])

--- a/backend/tests/test_pipeline.py
+++ b/backend/tests/test_pipeline.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import backend.app.evals.service as evals_service
 from backend.app.world_query import inspect_world
 from pathlib import Path
 
 from backend.app.config import get_settings
-from backend.app.evals.service import run_phase0_demo
+from backend.app.evals.service import evaluate_runs, run_phase0_demo
 from backend.app.graph.service import build_graph
 from backend.app.ingest.service import ingest_manifest
 from backend.app.personas.service import build_personas
@@ -98,3 +99,28 @@ def test_eval_demo_passes(tmp_path: Path) -> None:
     result = run_phase0_demo(settings=settings, artifacts_root=tmp_path / "demo")
     assert result.status == "pass"
     assert result.metrics["event_count"] >= 4
+
+
+def test_eval_redlines_cover_query_outputs(tmp_path: Path, monkeypatch) -> None:
+    settings = get_settings()
+    artifacts_root = tmp_path / "demo"
+    baseline = run_phase0_demo(settings=settings, artifacts_root=artifacts_root)
+    assert baseline.status == "pass"
+
+    original_inspect_world = evals_service.inspect_world
+
+    def patched_inspect_world(kind: str, object_id: str, graph_path: Path, personas_path: Path) -> dict:
+        payload = original_inspect_world(kind, object_id, graph_path, personas_path)
+        if kind == "persona":
+            payload["object"]["unsafe_note"] = "This system proves the real world will comply."
+        return payload
+
+    monkeypatch.setattr(evals_service, "inspect_world", patched_inspect_world)
+    result = evaluate_runs(
+        settings.expectations_path,
+        artifacts_root,
+        artifacts_root / "eval-redline-query",
+        settings.redlines_path,
+    )
+    assert result.status == "fail"
+    assert any("redlines[query_persona_su_he]" in failure for failure in result.failures)


### PR DESCRIPTION
## Summary
- extend eval redline scanning to cover the canonical `inspect-world` outputs in addition to reports, claims, and scenarios
- add a regression test that proves unsafe query wording now fails eval
- keep the change in the safe lane by hardening current output validation rather than changing contracts

Closes #8

## Testing
- `python -m pytest backend/tests/test_pipeline.py -q`
- `./make.ps1 eval-demo`
- `./make.ps1 test`
- `python -m backend.app.cli classify-lane --files backend/app/evals/service.py backend/tests/test_pipeline.py`

## Artifacts
- `eval-demo` remains green and now scans canonical query outputs for redline wording drift

## Contract impact
- none; this PR only expands validation coverage for existing output surfaces

## Safety impact
- positive; query outputs now share the same redline scan path as reports and scenarios

## TODO[verify]
- if new canonical query surfaces are added later, add them to the redline scan in the same PR that introduces them
