### PR TITLE
Run phase audits in CI

### DIFF
--- a/.github/workflows/phase0.yml
+++ b/.github/workflows/phase0.yml
@@ -32,6 +32,12 @@ jobs:
       - name: Run eval-demo
         run: make eval-demo
 
+      - name: Audit Phase 1
+        run: python -m backend.app.cli audit-phase phase1
+
+      - name: Audit Phase 2
+        run: python -m backend.app.cli audit-phase phase2
+
       - name: Upload demo artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -64,3 +70,11 @@ jobs:
       - name: Run eval-demo
         shell: pwsh
         run: .\make.ps1 eval-demo
+
+      - name: Audit Phase 1
+        shell: pwsh
+        run: python -m backend.app.cli audit-phase phase1
+
+      - name: Audit Phase 2
+        shell: pwsh
+        run: python -m backend.app.cli audit-phase phase2


### PR DESCRIPTION
## Summary
- add `audit-phase phase1` and `audit-phase phase2` to the existing long-running CI workflow
- make phase-level regressions fail the same validation path that already runs tests, smoke, and eval-demo
- keep the change in the safe lane by strengthening validation without touching contracts or simulation logic

Closes #9

## Testing
- `./make.ps1 eval-demo`
- `python -m backend.app.cli audit-phase phase1`
- `python -m backend.app.cli audit-phase phase2`
- `python -m backend.app.cli classify-lane --files .github/workflows/phase0.yml`

## Artifacts
- CI now checks the phase1 and phase2 audit commands after eval-demo

## Contract impact
- none; this PR only strengthens validation around the existing phase-audit commands

## Safety impact
- positive; phase-level regressions will now fail earlier in the main CI path

## TODO[verify]
- once PRs #13-#15 merge, CI will naturally pick up the expanded audit/eval coverage already added on those branches
