### PR TITLE
Render report and eval panels in workbench

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -137,6 +137,12 @@ code {
   gap: 16px;
 }
 
+.reportGrid {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  gap: 18px;
+}
+
 .card {
   padding: 18px;
   border-radius: 22px;
@@ -153,6 +159,132 @@ code {
   gap: 10px;
 }
 
+.checklist.compact {
+  margin-top: 16px;
+}
+
+.artifactCard {
+  padding: 18px;
+  border-radius: 24px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(247, 240, 232, 0.96));
+  border: 1px solid var(--border);
+  display: grid;
+  gap: 16px;
+  min-height: 100%;
+}
+
+.artifactCardWide {
+  min-width: 0;
+}
+
+.artifactMeta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.artifactMeta span {
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 11px;
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
+.artifactPre {
+  margin: 0;
+  padding: 18px;
+  border-radius: 20px;
+  background: #1f1d1a;
+  color: #f5efe4;
+  font-size: 0.92rem;
+  line-height: 1.55;
+  overflow-x: auto;
+  white-space: pre-wrap;
+}
+
+.artifactPreCompact {
+  max-height: 460px;
+  overflow-y: auto;
+}
+
+.claimList {
+  display: grid;
+  gap: 12px;
+}
+
+.claimCard {
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid var(--border);
+}
+
+.claimCard p {
+  margin: 0;
+}
+
+.claimHeader,
+.statusRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.claimEvidence {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.claimNote {
+  font-size: 0.92rem;
+  color: var(--muted);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(15, 107, 99, 0.12);
+  color: var(--accent-strong);
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.metricGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+}
+
+.metricCard {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+  border-radius: 18px;
+  background: rgba(15, 107, 99, 0.08);
+  border: 1px solid rgba(15, 107, 99, 0.12);
+}
+
+.metricCard span {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.metricCard strong {
+  font-size: 1.5rem;
+}
+
 @media (max-width: 720px) {
   body {
     padding-inline: 14px;
@@ -167,5 +299,9 @@ code {
   .heroMeta {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .reportGrid {
+    grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,3 +1,6 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
 const sections = [
   {
     title: "Corpus",
@@ -26,7 +29,46 @@ const sections = [
   }
 ];
 
-export default function Page() {
+type Claim = {
+  claim_id: string;
+  text: string;
+  label: string;
+  evidence_ids: string[];
+  confidence_note: string;
+};
+
+type EvalSummary = {
+  eval_name: string;
+  status: string;
+  metrics: Record<string, number>;
+  failures: string[];
+  notes: string[];
+};
+
+async function readText(relativePath: string) {
+  const repoRoot = path.resolve(process.cwd(), "..");
+  return readFile(path.join(repoRoot, relativePath), "utf-8");
+}
+
+async function loadWorkbenchData() {
+  const [report, claimsRaw, evalRaw, rubric] = await Promise.all([
+    readText("artifacts/demo/report/report.md"),
+    readText("artifacts/demo/report/claims.json"),
+    readText("artifacts/demo/eval/summary.json"),
+    readText("docs/rubrics/human-review.md")
+  ]);
+
+  return {
+    report,
+    claims: JSON.parse(claimsRaw) as Claim[],
+    evalSummary: JSON.parse(evalRaw) as EvalSummary,
+    rubric
+  };
+}
+
+export default async function Page() {
+  const { report, claims, evalSummary, rubric } = await loadWorkbenchData();
+
   return (
     <main className="shell">
       <section className="hero">
@@ -69,6 +111,87 @@ export default function Page() {
           <li>Expose corpus, graph, and scenario artifacts without changing their contracts.</li>
           <li>Keep evidence and traceability visible in every later Phase 3 view.</li>
         </ul>
+      </section>
+
+      <section className="panel">
+        <div className="panelHeader">
+          <p className="eyebrow">Report</p>
+          <h2>Current branch report and evidence-labeled claims.</h2>
+        </div>
+        <div className="reportGrid">
+          <article className="artifactCard artifactCardWide">
+            <div className="artifactMeta">
+              <span>artifact</span>
+              <code>artifacts/demo/report/report.md</code>
+            </div>
+            <pre className="artifactPre">{report}</pre>
+          </article>
+          <article className="artifactCard">
+            <div className="artifactMeta">
+              <span>artifact</span>
+              <code>artifacts/demo/report/claims.json</code>
+            </div>
+            <div className="claimList">
+              {claims.map((claim) => (
+                <article key={claim.claim_id} className="claimCard">
+                  <div className="claimHeader">
+                    <strong>{claim.claim_id}</strong>
+                    <span className="pill">{claim.label}</span>
+                  </div>
+                  <p>{claim.text}</p>
+                  <div className="claimEvidence">
+                    {claim.evidence_ids.map((evidenceId) => (
+                      <code key={evidenceId}>{evidenceId}</code>
+                    ))}
+                  </div>
+                  <p className="claimNote">{claim.confidence_note}</p>
+                </article>
+              ))}
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section className="panel">
+        <div className="panelHeader">
+          <p className="eyebrow">Eval And Review</p>
+          <h2>Machine summary and human rubric stay visible side-by-side.</h2>
+        </div>
+        <div className="reportGrid">
+          <article className="artifactCard">
+            <div className="artifactMeta">
+              <span>artifact</span>
+              <code>artifacts/demo/eval/summary.json</code>
+            </div>
+            <div className="metricGrid">
+              {Object.entries(evalSummary.metrics).map(([key, value]) => (
+                <div key={key} className="metricCard">
+                  <span>{key}</span>
+                  <strong>{value}</strong>
+                </div>
+              ))}
+            </div>
+            <div className="statusRow">
+              <span className="pill">{evalSummary.status}</span>
+              <span>{evalSummary.eval_name}</span>
+            </div>
+            {evalSummary.notes.length > 0 ? (
+              <ul className="checklist compact">
+                {evalSummary.notes.map((note) => (
+                  <li key={note}>{note}</li>
+                ))}
+              </ul>
+            ) : null}
+          </article>
+
+          <article className="artifactCard">
+            <div className="artifactMeta">
+              <span>artifact</span>
+              <code>docs/rubrics/human-review.md</code>
+            </div>
+            <pre className="artifactPre artifactPreCompact">{rubric}</pre>
+          </article>
+        </div>
       </section>
     </main>
   );


### PR DESCRIPTION
## Summary
- render the current report markdown, claims, eval summary, and human-review rubric inside the Phase 3 workbench shell
- keep evidence labels and artifact paths visible instead of hiding them behind generic UI
- extend the browser shell without changing backend or artifact contracts

Closes #18

## Testing
- `npm run build` (in `frontend/`)
- `python -m backend.app.cli audit-phase phase3`
- `python -m backend.app.cli classify-lane --files frontend/src/app/page.tsx frontend/src/app/globals.css`

## Artifacts
- the workbench now surfaces `artifacts/demo/report/report.md`
- the workbench now surfaces `artifacts/demo/report/claims.json`
- the workbench now surfaces `artifacts/demo/eval/summary.json`
- the workbench now surfaces `docs/rubrics/human-review.md`

## Contract impact
- none; this PR only reads current artifacts and renders them in the frontend shell

## Safety impact
- positive; evidence labels, eval status, and review rubric remain explicit in the UI

## TODO[verify]
- the next Phase 3 issue should wire corpus, graph, and scenario browsing into the same shell without obscuring evidence boundaries
