### PR TITLE
Browse corpus graph and scenarios in workbench

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -216,6 +216,15 @@ code {
   gap: 12px;
 }
 
+.docList,
+.objectList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 12px;
+}
+
 .claimCard {
   display: grid;
   gap: 10px;
@@ -227,6 +236,15 @@ code {
 
 .claimCard p {
   margin: 0;
+}
+
+.docCard {
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid var(--border);
 }
 
 .claimHeader,
@@ -283,6 +301,25 @@ code {
 
 .metricCard strong {
   font-size: 1.5rem;
+}
+
+.objectColumns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 18px;
+}
+
+.objectColumns h3 {
+  margin-bottom: 10px;
+}
+
+.objectList li {
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid var(--border);
 }
 
 @media (max-width: 720px) {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -45,29 +45,97 @@ type EvalSummary = {
   notes: string[];
 };
 
+type DocumentRow = {
+  document_id: string;
+  title: string;
+  kind: string;
+  metadata?: Record<string, string>;
+};
+
+type GraphEntity = {
+  entity_id: string;
+  name: string;
+  type: string;
+  evidence_ids: string[];
+};
+
+type GraphRelation = {
+  relation_id: string;
+  source_entity_id: string;
+  relation_type: string;
+  target_entity_id: string;
+  evidence_ids: string[];
+};
+
+type GraphEvent = {
+  event_id: string;
+  name: string;
+  kind: string;
+  participant_entity_ids: string[];
+  evidence_ids: string[];
+};
+
+type GraphPayload = {
+  entities: GraphEntity[];
+  relations: GraphRelation[];
+  events: GraphEvent[];
+  stats: Record<string, number>;
+};
+
+type ScenarioPayload = {
+  scenario_id: string;
+  title: string;
+  description: string;
+  branch_count: number;
+  turn_budget: number;
+  injections: Array<{
+    injection_id: string;
+    kind: string;
+    target_id: string;
+    actor_id: string;
+  }>;
+};
+
 async function readText(relativePath: string) {
   const repoRoot = path.resolve(process.cwd(), "..");
   return readFile(path.join(repoRoot, relativePath), "utf-8");
 }
 
+async function readJson<T>(relativePath: string) {
+  return JSON.parse(await readText(relativePath)) as T;
+}
+
 async function loadWorkbenchData() {
-  const [report, claimsRaw, evalRaw, rubric] = await Promise.all([
+  const [report, claimsRaw, evalRaw, rubric, documentsRaw, graph, baselineScenario, interventionScenario] =
+    await Promise.all([
     readText("artifacts/demo/report/report.md"),
     readText("artifacts/demo/report/claims.json"),
     readText("artifacts/demo/eval/summary.json"),
-    readText("docs/rubrics/human-review.md")
-  ]);
+    readText("docs/rubrics/human-review.md"),
+    readText("artifacts/demo/ingest/documents.jsonl"),
+    readJson<GraphPayload>("artifacts/demo/graph/graph.json"),
+    readJson<ScenarioPayload>("artifacts/demo/scenario/baseline.json"),
+    readJson<ScenarioPayload>("artifacts/demo/scenario/reporter_detained.json")
+    ]);
 
   return {
     report,
     claims: JSON.parse(claimsRaw) as Claim[],
     evalSummary: JSON.parse(evalRaw) as EvalSummary,
-    rubric
+    rubric,
+    documents: documentsRaw
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as DocumentRow),
+    graph,
+    baselineScenario,
+    interventionScenario
   };
 }
 
 export default async function Page() {
-  const { report, claims, evalSummary, rubric } = await loadWorkbenchData();
+  const { report, claims, evalSummary, rubric, documents, graph, baselineScenario, interventionScenario } =
+    await loadWorkbenchData();
 
   return (
     <main className="shell">
@@ -148,6 +216,162 @@ export default async function Page() {
                 </article>
               ))}
             </div>
+          </article>
+        </div>
+      </section>
+
+      <section className="panel">
+        <div className="panelHeader">
+          <p className="eyebrow">Corpus</p>
+          <h2>Canonical source documents remain directly inspectable.</h2>
+        </div>
+        <div className="reportGrid">
+          <article className="artifactCard">
+            <div className="artifactMeta">
+              <span>artifact</span>
+              <code>artifacts/demo/ingest/documents.jsonl</code>
+            </div>
+            <div className="docList">
+              {documents.map((document) => (
+                <article key={document.document_id} className="docCard">
+                  <div className="claimHeader">
+                    <strong>{document.title}</strong>
+                    <span className="pill">{document.kind}</span>
+                  </div>
+                  <div className="claimEvidence">
+                    <code>{document.document_id}</code>
+                    {document.metadata?.author ? <code>{document.metadata.author}</code> : null}
+                    {document.metadata?.channel ? <code>{document.metadata.channel}</code> : null}
+                  </div>
+                </article>
+              ))}
+            </div>
+          </article>
+
+          <article className="artifactCard">
+            <div className="artifactMeta">
+              <span>summary</span>
+              <code>{documents.length} documents</code>
+            </div>
+            <p>
+              The browser shell now exposes the source-document layer directly, so later reviewers
+              can trace claims and graph objects back to the bounded corpus instead of treating the
+              simulation as a black box.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section className="panel">
+        <div className="panelHeader">
+          <p className="eyebrow">World Model</p>
+          <h2>Graph objects stay visible as structured, evidence-bearing records.</h2>
+        </div>
+        <div className="reportGrid">
+          <article className="artifactCard">
+            <div className="artifactMeta">
+              <span>artifact</span>
+              <code>artifacts/demo/graph/graph.json</code>
+            </div>
+            <div className="metricGrid">
+              {Object.entries(graph.stats).map(([key, value]) => (
+                <div key={key} className="metricCard">
+                  <span>{key}</span>
+                  <strong>{value}</strong>
+                </div>
+              ))}
+            </div>
+            <div className="objectColumns">
+              <div>
+                <h3>Entities</h3>
+                <ul className="objectList">
+                  {graph.entities.slice(0, 4).map((entity) => (
+                    <li key={entity.entity_id}>
+                      <strong>{entity.name}</strong>
+                      <code>{entity.entity_id}</code>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <h3>Relations</h3>
+                <ul className="objectList">
+                  {graph.relations.slice(0, 4).map((relation) => (
+                    <li key={relation.relation_id}>
+                      <strong>{relation.relation_type}</strong>
+                      <code>{relation.relation_id}</code>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <h3>Events</h3>
+                <ul className="objectList">
+                  {graph.events.slice(0, 4).map((event) => (
+                    <li key={event.event_id}>
+                      <strong>{event.name}</strong>
+                      <code>{event.event_id}</code>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </article>
+
+          <article className="artifactCard">
+            <div className="artifactMeta">
+              <span>traceability</span>
+              <code>entities / relations / events</code>
+            </div>
+            <p>
+              This view keeps the graph inspectable without introducing a new API or a heavy graph
+              visualization dependency. It is intentionally review-first and contract-light.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section className="panel">
+        <div className="panelHeader">
+          <p className="eyebrow">Scenario</p>
+          <h2>Normalized baseline and intervention scenarios stay visible in the browser.</h2>
+        </div>
+        <div className="reportGrid">
+          <article className="artifactCard">
+            <div className="artifactMeta">
+              <span>artifact</span>
+              <code>artifacts/demo/scenario/baseline.json</code>
+            </div>
+            <div className="claimHeader">
+              <strong>{baselineScenario.title}</strong>
+              <span className="pill">{baselineScenario.scenario_id}</span>
+            </div>
+            <div className="claimEvidence">
+              <code>turn_budget={baselineScenario.turn_budget}</code>
+              <code>branch_count={baselineScenario.branch_count}</code>
+            </div>
+            <pre className="artifactPre artifactPreCompact">
+              {JSON.stringify(baselineScenario, null, 2)}
+            </pre>
+          </article>
+
+          <article className="artifactCard">
+            <div className="artifactMeta">
+              <span>artifact</span>
+              <code>artifacts/demo/scenario/reporter_detained.json</code>
+            </div>
+            <div className="claimHeader">
+              <strong>{interventionScenario.title}</strong>
+              <span className="pill">{interventionScenario.scenario_id}</span>
+            </div>
+            <div className="claimEvidence">
+              <code>turn_budget={interventionScenario.turn_budget}</code>
+              <code>branch_count={interventionScenario.branch_count}</code>
+              <code>injections={interventionScenario.injections.length}</code>
+            </div>
+            <pre className="artifactPre artifactPreCompact">
+              {JSON.stringify(interventionScenario, null, 2)}
+            </pre>
           </article>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- extend the Phase 3 workbench to browse canonical corpus, graph, and scenario artifacts
- keep the UI review-first by rendering current artifact content directly instead of introducing new APIs
- preserve evidence visibility while broadening the browser-based demo surface

Closes #19

## Testing
- `npm run build` (in `frontend/`)
- `python -m backend.app.cli audit-phase phase3`
- `python -m backend.app.cli classify-lane --files frontend/src/app/page.tsx frontend/src/app/globals.css`

## Artifacts
- the workbench now surfaces `artifacts/demo/ingest/documents.jsonl`
- the workbench now surfaces `artifacts/demo/graph/graph.json`
- the workbench now surfaces `artifacts/demo/scenario/baseline.json`
- the workbench now surfaces `artifacts/demo/scenario/reporter_detained.json`

## Contract impact
- none; this PR only reads and renders current artifacts

## Safety impact
- positive; corpus, graph, and scenario views make the demo more traceable without expanding backend contracts

## TODO[verify]
- the final Phase 3 closeout should include demo review sign-off and a decision about whether the docs-sync PR #12 is still worth landing or can be superseded by the newer state
