### PR TITLE
Sync docs to current phase state

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,24 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed its Phase 0 foundation and is now in Phase 1 world-model hardening.
+The repository has completed Day 0 bootstrap, closed Phase 1 and Phase 2 gates, and is now actively delivering the Phase 3 workbench.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
 - The backend can ingest, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
-- The repo now also includes the bootstrap pieces for long-running automation:
+- The repo now also includes the long-running automation and workbench pieces:
   - GitHub issue and PR templates
   - lane policy and bootstrap spec
   - CI upgraded to a long-running quality gate
   - local lane-classification and phase-audit commands
+  - protected `main` with required status checks and auto-merge for safe-lane PRs
+  - a browser workbench shell that now renders report, claims, eval summary, rubric, corpus, graph, and scenarios
+
+Local phase audits currently show:
+
+- Phase 1: `pass`
+- Phase 2: `pass`
+- Phase 3: `pass`
 
 ## Quick Start
 
@@ -53,12 +61,13 @@ python -m backend.app.cli audit-phase phase1
 - [AGENTS.md](/D:/mirror/AGENTS.md): Codex execution rules
 - [docs/plans/phase-0-foundation.md](/D:/mirror/docs/plans/phase-0-foundation.md): Phase 0 implementation note
 - [docs/plans/automation-roadmap.md](/D:/mirror/docs/plans/automation-roadmap.md): long-running automation bootstrap and operating plan
+- [docs/plans/phase-execution-queue.md](/D:/mirror/docs/plans/phase-execution-queue.md): current phase queue and execution order
 - [docs/architecture/contracts.md](/D:/mirror/docs/architecture/contracts.md): durable contracts and assumptions
 - [data/demo/config/world_model.yaml](/D:/mirror/data/demo/config/world_model.yaml): demo world model and persona blueprint
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): deferred workbench shell
+- [frontend](/D:/mirror/frontend): active Phase 3 workbench shell
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -102,7 +111,8 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap still requires a clean baseline snapshot before autonomous code-writing loops should run on worktrees.
+- Day 0 bootstrap is complete. The current execution queue is tracked in [docs/plans/phase-execution-queue.md](/D:/mirror/docs/plans/phase-execution-queue.md).
+- Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals
 

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -4,6 +4,16 @@
 
 Turn Mirror into a long-running, repo-native automation loop that uses GitHub as the task source of truth, Codex as the execution plane, CI/eval as gates, and phase audits as the stop condition.
 
+## Current State
+
+Day 0 bootstrap is complete.
+
+- GitHub milestones, labels, and phase issues exist.
+- `main` is protected by the required Linux and Windows quality gates.
+- Repository auto-merge is enabled for safe-lane use.
+- Phase 1 and Phase 2 gates are closed.
+- Phase 3 is the active implementation queue.
+
 ## Day 0 Bootstrap
 
 Before builder automation is allowed to write code or auto-merge:
@@ -53,5 +63,5 @@ Before builder automation is allowed to write code or auto-merge:
 
 ## TODO[verify]
 
-- TODO[verify]: GitHub branch protection and repository auto-merge settings still need to be applied on the remote repository.
 - TODO[verify]: Codex cron automations should target worktrees, not the current dirty `main` checkout.
+- TODO[verify]: once the current Phase 3 workbench PRs land, the phase auditor should close the Phase 3 gate and milestone only after demo review sign-off is recorded.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,0 +1,48 @@
+# Phase Execution Queue
+
+This note records the current post-Day-0 execution order for Mirror.
+
+## Current Gate State
+
+- Phase 1 exit gate: closed
+- Phase 2 exit gate: closed
+- Phase 3 exit gate: open
+
+Local phase audits currently report:
+
+- `phase1`: pass
+- `phase2`: pass
+- `phase3`: pass
+
+## Current Queue
+
+### Phase 3 Active Work
+
+- `#17` browser workbench entrypoint
+  - implemented
+  - PR merged
+- `#18` report, claims, eval summary, and rubric panels
+  - implemented
+  - safe-lane PR in review/merge flow
+- `#19` corpus, graph, and scenario artifact browser
+  - implemented
+  - safe-lane PR in review/merge flow
+
+### Phase 3 Exit Gate
+
+- `#4` remains blocked until:
+  - the open Phase 3 safe-lane PRs land on `main`
+  - final demo review sign-off is recorded
+  - docs and queue notes stay aligned with the merged implementation
+
+## Automation Guidance
+
+- Builder should prefer the earliest unfinished phase.
+- Exit-gate issues stay blocked until their dependent work is truly complete.
+- Safe-lane PRs may auto-merge once checks are green and no blocking labels are present.
+- Protected-core changes still require explicit review and must not auto-merge.
+
+## TODO[verify]
+
+- TODO[verify]: once the current Phase 3 PRs land, re-run the GitHub-side closeout for issue `#4`.
+- TODO[verify]: decide whether the older docs-sync PR should be merged or closed as superseded by the newer queue state.


### PR DESCRIPTION
## Summary
- refresh README and automation roadmap to the current post-Phase-2 / active-Phase-3 state
- restore a current execution-queue note so the repo docs match the live GitHub backlog
- remove stale Day 0 and Phase 1 wording that no longer matches the merged implementation

## Testing
- `python -m backend.app.cli classify-lane --files README.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md`

## Artifacts
- docs now point to the current Phase 3 queue and the closed Phase 1 / Phase 2 gates

## Contract impact
- none; docs-only sync

## Safety impact
- none; this PR only aligns docs with the existing queue and implementation state

## TODO[verify]
- once the current Phase 3 PRs land, the final Phase 3 gate closeout should reference this newer docs sync rather than the older superseded draft
