### PR TITLE
[codex] Sync post-Phase-3 handoff baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed Phase 1 and Phase 2 gates, and is now actively delivering the Phase 3 workbench.
+The repository has completed Day 0 bootstrap and closed the Phase 1, Phase 2, and Phase 3 gates. The current `main` branch is in a post-Phase-3 handoff and maintenance state rather than an active implementation queue.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -20,6 +20,10 @@ The repository has completed Day 0 bootstrap, closed Phase 1 and Phase 2 gates, 
   - local lane-classification and phase-audit commands
   - protected `main` with required status checks and auto-merge for safe-lane PRs
   - a browser workbench shell that now renders report, claims, eval summary, rubric, corpus, graph, and scenarios
+- GitHub closeout is aligned with the local baseline:
+  - Phase 3 exit issue `#4` is closed
+  - milestone `Phase 3 - Eval/UI/Demo` is closed
+  - future work should open a fresh GitHub issue and milestone instead of reusing the Phase 3 queue
 
 Local phase audits currently show:
 
@@ -66,6 +70,7 @@ python -m backend.app.cli audit-phase phase1
 - [docs/plans/phase-0-foundation.md](/D:/mirror/docs/plans/phase-0-foundation.md): Phase 0 implementation note
 - [docs/plans/automation-roadmap.md](/D:/mirror/docs/plans/automation-roadmap.md): long-running automation bootstrap and operating plan
 - [docs/plans/phase-execution-queue.md](/D:/mirror/docs/plans/phase-execution-queue.md): current phase queue and execution order
+- [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md): current handoff baseline and trusted source-of-truth checks
 - [docs/architecture/contracts.md](/D:/mirror/docs/architecture/contracts.md): durable contracts and assumptions
 - [data/demo/config/world_model.yaml](/D:/mirror/data/demo/config/world_model.yaml): demo world model and persona blueprint
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
@@ -115,7 +120,8 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap is complete. The current execution queue is tracked in [docs/plans/phase-execution-queue.md](/D:/mirror/docs/plans/phase-execution-queue.md).
+- Day 0 bootstrap and Phase 3 closeout are complete. Any future execution queue should be opened in GitHub before builder automation resumes.
+- The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/backend/app/automation/service.py
+++ b/backend/app/automation/service.py
@@ -294,7 +294,7 @@ def run_phase_audit(
         notes = ["TODO[verify]: Deterministic replay across independent reruns is enforced by eval-demo, not by this artifact-only audit."]
     elif phase == "phase3":
         checks = _phase3_checks(settings, artifacts_root)
-        notes = ["TODO[verify]: Phase 3 stop-condition still requires GitHub milestone closure and demo review sign-off."]
+        notes = ["TODO[verify]: Open a fresh GitHub milestone and exit-gate issue before resuming builder automation beyond the closed Phase 3 queue."]
     else:
         raise ValueError(f"Unsupported phase: {phase}")
 

--- a/backend/tests/test_automation.py
+++ b/backend/tests/test_automation.py
@@ -29,7 +29,8 @@ def test_phase1_and_phase2_audit_pass_with_demo_artifacts(tmp_path: Path) -> Non
     assert phase2.status == "pass"
 
 
-def test_phase3_audit_fails_without_workbench() -> None:
+def test_phase3_audit_passes_with_current_workbench_contract(tmp_path: Path) -> None:
     settings = get_settings()
-    phase3 = run_phase_audit("phase3", settings=settings, artifacts_root=settings.artifacts_root)
-    assert phase3.status == "fail"
+    run_phase0_demo(settings=settings, artifacts_root=tmp_path / "demo")
+    phase3 = run_phase_audit("phase3", settings=settings, artifacts_root=tmp_path / "demo")
+    assert phase3.status == "pass"

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -12,7 +12,9 @@ Day 0 bootstrap is complete.
 - `main` is protected by the required Linux and Windows quality gates.
 - Repository auto-merge is enabled for safe-lane use.
 - Phase 1 and Phase 2 gates are closed.
-- Phase 3 is the active implementation queue.
+- Phase 3 is closed locally and in GitHub.
+- Phase 3 exit issue `#4` is closed and milestone `Phase 3 - Eval/UI/Demo` is closed.
+- No active implementation queue is currently open; builder automation should remain paused until a fresh issue and milestone are opened.
 
 ## Day 0 Bootstrap
 
@@ -52,7 +54,7 @@ Before builder automation is allowed to write code or auto-merge:
 - `mirror-phase-auditor`
   - run local phase audits
   - compare against milestone state
-  - pause automation when Phase 3 is complete
+  - keep automation paused once the active phase is complete and no new milestone has been opened
 
 ## Guardrails
 
@@ -64,4 +66,4 @@ Before builder automation is allowed to write code or auto-merge:
 ## TODO[verify]
 
 - TODO[verify]: Codex cron automations should target worktrees, not the current dirty `main` checkout.
-- TODO[verify]: once the current Phase 3 workbench PRs land, the phase auditor should close the Phase 3 gate and milestone only after demo review sign-off is recorded.
+- TODO[verify]: if a new milestone opens after Phase 3, create a fresh exit-gate issue instead of reusing the closed Phase 3 closeout thread.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,0 +1,42 @@
+# Current State Baseline
+
+This note is the handoff baseline for the current `main` branch after the Phase 3 closeout.
+
+## Snapshot
+
+- Local quality baseline:
+  - `./make.ps1 smoke`
+  - `./make.ps1 test`
+  - `./make.ps1 eval-demo`
+  - `python -m backend.app.cli audit-phase phase1`
+  - `python -m backend.app.cli audit-phase phase2`
+  - `python -m backend.app.cli audit-phase phase3`
+- GitHub source-of-truth baseline:
+  - `gh api repos/YSCJRH/mirror-sim`
+    - `default_branch`: `main`
+    - `license`: `MIT`
+    - `open_issues_count`: `0`
+  - `gh api repos/YSCJRH/mirror-sim/issues/4`
+    - Phase 3 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/3`
+    - milestone `Phase 3 - Eval/UI/Demo` is `closed`
+
+## Trusted Source Of Truth
+
+- GitHub issue and milestone state remain the operational source of truth for current and future work.
+- Local phase audits remain the contract-aligned source of truth for whether the current repo state is runnable and reviewable.
+- `backlog/sprint-01.md` is historical seed material only and should not be used as the live queue.
+- Remote `origin/codex/*` branches should be treated as historical and superseded by `main` unless a future issue explicitly revives one.
+
+## Current Main Capabilities
+
+- The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
+- The frontend workbench shell renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
+- The current repository state is post-Phase-3 closeout, not an active Phase 3 implementation queue.
+
+## Next Entry Point
+
+- No Phase 4 or successor milestone is open yet.
+- New implementation work should start by opening a fresh GitHub issue and milestone, then updating `docs/plans/phase-execution-queue.md` to match that new queue.
+- Protected-core changes still require explicit review even when safe-lane automation is available.
+- TODO[verify]: delete or archive the superseded remote `codex/*` branches during the next repository cleanup window.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,12 +1,12 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution order for Mirror.
+This note records the current post-Day-0 execution status for Mirror after the Phase 3 closeout.
 
 ## Current Gate State
 
 - Phase 1 exit gate: closed
 - Phase 2 exit gate: closed
-- Phase 3 exit gate: open
+- Phase 3 exit gate: closed
 
 Local phase audits currently report:
 
@@ -14,35 +14,43 @@ Local phase audits currently report:
 - `phase2`: pass
 - `phase3`: pass
 
-## Current Queue
-
-### Phase 3 Active Work
+## Closeout Snapshot
 
 - `#17` browser workbench entrypoint
   - implemented
-  - PR merged
+  - merged via PR `#20`
 - `#18` report, claims, eval summary, and rubric panels
   - implemented
-  - safe-lane PR in review/merge flow
+  - merged via PR `#21`
 - `#19` corpus, graph, and scenario artifact browser
   - implemented
-  - safe-lane PR in review/merge flow
+  - merged via PR `#22`
+- docs sync
+  - merged via PR `#23`
+- Phase 3 exit issue `#4`
+  - closed
+- milestone `Phase 3 - Eval/UI/Demo`
+  - closed
+- GitHub remote state
+  - no open issues
+  - no open pull requests
 
-### Phase 3 Exit Gate
+## Current Queue
 
-- `#4` remains blocked until:
-  - the open Phase 3 safe-lane PRs land on `main`
-  - final demo review sign-off is recorded
-  - docs and queue notes stay aligned with the merged implementation
+- No active implementation queue is open on `main`.
+- GitHub remains the operational source of truth for any future queue.
+- `backlog/sprint-01.md` remains a historical seed backlog only.
+- Future implementation should start from a fresh GitHub issue and milestone instead of reopening the closed Phase 3 queue.
 
 ## Automation Guidance
 
-- Builder should prefer the earliest unfinished phase.
-- Exit-gate issues stay blocked until their dependent work is truly complete.
+- Builder should prefer the earliest unfinished open milestone once a new queue exists.
+- Closed exit-gate issues and milestones should remain archived history, not be reused as active work trackers.
 - Safe-lane PRs may auto-merge once checks are green and no blocking labels are present.
 - Protected-core changes still require explicit review and must not auto-merge.
 
-## TODO[verify]
+## Historical Branch Status
 
-- TODO[verify]: once the current Phase 3 PRs land, re-run the GitHub-side closeout for issue `#4`.
-- TODO[verify]: decide whether the older docs-sync PR should be merged or closed as superseded by the newer queue state.
+- The visible `origin/codex/*` branches correspond to closed or merged work.
+- Treat those branches as historical and superseded by `main`, not as an active queue.
+- TODO[verify]: delete or archive the superseded remote branches during the next repository cleanup window.


### PR DESCRIPTION
## Summary
- align the local test baseline with the current Phase 3 audit contract
- update README and planning docs to reflect that Phase 3 is closed locally and in GitHub
- add a short current-state baseline note for future PM and engineering handoff

## Testing
- `python -m backend.app.cli classify-lane --files README.md backend/app/automation/service.py backend/tests/test_automation.py docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/current-state-baseline.md`
- `./make.ps1 smoke`
- `./make.ps1 test`
- `./make.ps1 eval-demo`
- `python -m backend.app.cli audit-phase phase1`
- `python -m backend.app.cli audit-phase phase2`
- `python -m backend.app.cli audit-phase phase3`

## Notes
- `mirror.png` is already present on `main` through merged PR #24 and is intentionally not part of this branch
- the first `eval-demo` attempt failed only because `smoke` and `eval-demo` were run in parallel against the same artifact tree; the sequential rerun passed