### PR TITLE
[codex] Implement Phase 4 review workflow and queue hardening

### DIFF
--- a/.github/ISSUE_TEMPLATE/phase-exit.yml
+++ b/.github/ISSUE_TEMPLATE/phase-exit.yml
@@ -11,6 +11,7 @@ body:
         - Phase 1 - World/Persona Modeling
         - Phase 2 - Scenario/Simulation Loop
         - Phase 3 - Eval/UI/Demo
+        - Phase 4 - Review Workflow and Ops Hardening
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -11,6 +11,7 @@ body:
         - Phase 1 - World/Persona Modeling
         - Phase 2 - Scenario/Simulation Loop
         - Phase 3 - Eval/UI/Demo
+        - Phase 4 - Review Workflow and Ops Hardening
     validations:
       required: true
   - type: dropdown

--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -11,6 +11,10 @@
     {
       "title": "Phase 3 - Eval/UI/Demo",
       "description": "Finish the workbench, final demo loop, and review-grade presentation layer."
+    },
+    {
+      "title": "Phase 4 - Review Workflow and Ops Hardening",
+      "description": "Restart the GitHub execution queue, harden successor-phase automation, and upgrade the workbench into a review workflow without expanding core simulation/report contracts."
     }
   ],
   "labels": [
@@ -28,6 +32,11 @@
       "name": "phase:3",
       "color": "5319e7",
       "description": "Phase 3 UI, eval, and demo work."
+    },
+    {
+      "name": "phase:4",
+      "color": "8a63d2",
+      "description": "Phase 4 review workflow and ops hardening work."
     },
     {
       "name": "area:backend",
@@ -130,6 +139,51 @@
         "lane:protected-core"
       ],
       "body": "## goal\nConfirm that all blueprint Phase 3 criteria are satisfied and the automation system can pause permanently.\n\n## input\n- final artifacts and frontend workbench\n- current milestone and PR state\n- human review rubric output\n\n## output\n- final completion report\n- PAUSED automation state\n- documented stop condition\n\n## out-of-scope\n- follow-on enterprise productization\n\n## minimal test\n- `python -m backend.app.cli audit-phase phase3`\n\n## touches contract\nYes. This issue controls the project stop condition.\n\n## phase\nPhase 3"
+    },
+    {
+      "title": "Phase 4 exit gate",
+      "milestone": "Phase 4 - Review Workflow and Ops Hardening",
+      "labels": [
+        "phase:4",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nConfirm that the Phase 4 review workflow and ops hardening criteria are satisfied before the automation system advances again.\n\n## input\n- Phase 4 milestone state\n- merged PR state for bootstrap/governance and workbench review workflow work\n- local validation commands and reviewed artifacts\n\n## output\n- explicit Phase 4 closeout decision\n- documented stop condition for the Phase 4 queue\n- gap issues if any execution issue remains incomplete\n\n## out-of-scope\n- opening the next successor milestone\n- engine/schema/report contract expansion beyond the approved Phase 4 slice\n\n## minimal test\n- `./make.ps1 smoke`\n- `./make.ps1 test`\n- `./make.ps1 eval-demo`\n- `python -m backend.app.cli audit-phase phase3`\n\n## touches contract\nYes. Exit gating controls whether the automation queue may advance.\n\n## phase\nPhase 4"
+    },
+    {
+      "title": "Phase 4: harden successor-milestone bootstrap and builder pause/resume rules",
+      "milestone": "Phase 4 - Review Workflow and Ops Hardening",
+      "labels": [
+        "phase:4",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nHarden successor-milestone bootstrap and builder pause/resume rules so post-Phase-3 work is governed by executable repo rules instead of docs-only convention.\n\n## input\n- `.github/automation/bootstrap-spec.json`\n- `.github/ISSUE_TEMPLATE/work-item.yml`\n- `.github/ISSUE_TEMPLATE/phase-exit.yml`\n- `backend/app/automation/service.py`\n- current post-Phase-3 handoff docs\n\n## output\n- `phase:4` added to repo taxonomy and bootstrap spec\n- issue templates updated to support Phase 4\n- local automation/CLI rule that treats missing open successor milestone or exit gate as paused-by-rule\n- docs aligned to the hardened successor-phase flow\n\n## out-of-scope\n- changing simulation/report/claim/evidence/scenario contracts\n- building product-facing review workflow UI\n\n## minimal test\n- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`\n- `python -m backend.app.cli classify-lane --files .github/ISSUE_TEMPLATE/work-item.yml .github/ISSUE_TEMPLATE/phase-exit.yml .github/automation/bootstrap-spec.json backend/app/automation/service.py`\n- `./make.ps1 test`\n- `python -m backend.app.cli audit-phase phase3`\n\n## touches contract\nYes. This work changes automation governance and successor-phase execution rules.\n\n## phase\nPhase 4"
+    },
+    {
+      "title": "Phase 4: add claim -> evidence drill-down in the workbench",
+      "milestone": "Phase 4 - Review Workflow and Ops Hardening",
+      "labels": [
+        "phase:4",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd claim -> evidence drill-down in the workbench so reviewers can move from a claim card to the supporting corpus, graph, scenario, and trace context without leaving the UI.\n\n## input\n- `artifacts/demo/report/claims.json`\n- `artifacts/demo/ingest/chunks.jsonl`\n- `artifacts/demo/ingest/documents.jsonl`\n- `artifacts/demo/graph/graph.json`\n- `artifacts/demo/scenario/*.json`\n- `artifacts/demo/run/*/run_trace.jsonl`\n- current `frontend/src/app/page.tsx`\n\n## output\n- actionable claim review panel in the workbench\n- evidence drill-down using existing artifact files only\n- no backend API expansion and no artifact schema changes\n\n## out-of-scope\n- editing or regenerating artifacts from the browser\n- changing report, claim, scenario, or run-trace contracts\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n\n## touches contract\nNo. This issue must stay frontend-only and consume current artifacts unchanged.\n\n## phase\nPhase 4"
+    },
+    {
+      "title": "Phase 4: add baseline/intervention trace timeline in the workbench",
+      "milestone": "Phase 4 - Review Workflow and Ops Hardening",
+      "labels": [
+        "phase:4",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a baseline/intervention trace timeline in the workbench so reviewers can compare branch evolution turn by turn using existing run artifacts.\n\n## input\n- `artifacts/demo/run/baseline/run_trace.jsonl`\n- `artifacts/demo/run/reporter_detained/run_trace.jsonl`\n- `artifacts/demo/run/*/snapshots/*.json`\n- `artifacts/demo/report/claims.json`\n- current workbench frontend\n\n## output\n- reviewer-readable branch timeline and turn comparison view\n- timeline links that connect related claim turns to baseline/intervention run context\n- no new derived artifact files and no simulation output changes in the first slice\n\n## out-of-scope\n- changing simulation semantics\n- adding new backend endpoints or new persistent artifact formats\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n\n## touches contract\nNo. This issue must remain a UI-only consumer of existing run artifacts.\n\n## phase\nPhase 4"
     }
   ]
 }

--- a/.github/automation/lane-policy.json
+++ b/.github/automation/lane-policy.json
@@ -11,8 +11,12 @@
     "risk:safety"
   ],
   "protected_core_prefixes": [
+    ".github/ISSUE_TEMPLATE/",
+    ".github/automation/",
     "docs/architecture/contracts.md",
     "docs/decisions/",
+    "scripts/bootstrap_github.py",
+    "backend/app/automation/",
     "backend/app/domain/",
     "backend/app/scenarios/",
     "backend/app/simulation/",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap and closed the Phase 1, Phase 2, and Phase 3 gates. The current `main` branch is in a post-Phase-3 handoff and maintenance state rather than an active implementation queue.
+The repository has completed Day 0 bootstrap, closed the Phase 1-3 gates, and opened the successor queue as `Phase 4 - Review Workflow and Ops Hardening`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -17,13 +17,14 @@ The repository has completed Day 0 bootstrap and closed the Phase 1, Phase 2, an
   - GitHub issue and PR templates
   - lane policy and bootstrap spec
   - CI upgraded to a long-running quality gate
-  - local lane-classification and phase-audit commands
+  - local lane-classification, phase-audit, and GitHub queue-audit commands
   - protected `main` with required status checks and auto-merge for safe-lane PRs
-  - a browser workbench shell that now renders report, claims, eval summary, rubric, corpus, graph, and scenarios
-- GitHub closeout is aligned with the local baseline:
+  - a browser workbench that now supports claim -> evidence drill-down and baseline/intervention trace review
+- GitHub queue state is aligned with the local baseline:
   - Phase 3 exit issue `#4` is closed
   - milestone `Phase 3 - Eval/UI/Demo` is closed
-  - future work should open a fresh GitHub issue and milestone instead of reusing the Phase 3 queue
+  - milestone `Phase 4 - Review Workflow and Ops Hardening` is open
+  - Phase 4 queue is initialized through issues `#26-#29`
 
 Local phase audits currently show:
 
@@ -61,6 +62,7 @@ python -m backend.app.cli report artifacts/demo/run/reporter_detained --baseline
 python -m backend.app.cli inspect-world --kind entity --id entity_east_gate --graph artifacts/demo/graph/graph.json --personas artifacts/demo/personas/personas.json
 python -m backend.app.cli classify-lane --files README.md backend/app/cli.py
 python -m backend.app.cli audit-phase phase1
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 ```
 
 ## Repo Map
@@ -76,7 +78,7 @@ python -m backend.app.cli audit-phase phase1
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): active Phase 3 workbench shell
+- [frontend](/D:/mirror/frontend): active Phase 4 review workflow workbench
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -117,10 +119,11 @@ Repository-side automation assets:
 - `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`
 - `python -m backend.app.cli classify-lane ...`
 - `python -m backend.app.cli audit-phase ...`
+- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 3 closeout are complete. Any future execution queue should be opened in GitHub before builder automation resumes.
+- Day 0 bootstrap and Phase 3 closeout are complete. Phase 4 is the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Protected-core changes still must not auto-merge just because checks are green.
 

--- a/backend/app/automation/__init__.py
+++ b/backend/app/automation/__init__.py
@@ -1,7 +1,17 @@
-from backend.app.automation.service import PhaseAudit, classify_git_refs, classify_paths, load_lane_policy, run_phase_audit
+from backend.app.automation.service import (
+    GitHubQueueAudit,
+    PhaseAudit,
+    audit_github_queue,
+    classify_git_refs,
+    classify_paths,
+    load_lane_policy,
+    run_phase_audit,
+)
 
 __all__ = [
+    "GitHubQueueAudit",
     "PhaseAudit",
+    "audit_github_queue",
     "classify_git_refs",
     "classify_paths",
     "load_lane_policy",

--- a/backend/app/automation/service.py
+++ b/backend/app/automation/service.py
@@ -59,10 +59,49 @@ class PhaseAudit:
         }
 
 
+@dataclass(frozen=True)
+class GitHubQueueAudit:
+    repo: str
+    status: str
+    active_milestone: str | None = None
+    checks: list[AuditCheck] = field(default_factory=list)
+    failures: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict:
+        return {
+            "repo": self.repo,
+            "status": self.status,
+            "active_milestone": self.active_milestone,
+            "checks": [check.as_dict() for check in self.checks],
+            "failures": self.failures,
+            "notes": self.notes,
+        }
+
+
 def _repo_root_from_path(path: Path | None = None) -> Path:
     if path is not None:
         return path
     return Path(__file__).resolve().parents[3]
+
+
+def _gh_json(args: list[str], *, repo_root: Path | None = None) -> object:
+    root = _repo_root_from_path(repo_root)
+    try:
+        result = subprocess.run(
+            ["gh", *args],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.strip() if exc.stderr else "unknown gh failure"
+        raise RuntimeError(
+            "GitHub queue audit requires an authenticated `gh` context with repo access. "
+            f"Command failed: gh {' '.join(args)}. stderr: {stderr}"
+        ) from exc
+    return json.loads(result.stdout) if result.stdout.strip() else None
 
 
 def load_lane_policy(policy_path: Path | None = None) -> dict:
@@ -113,6 +152,113 @@ def classify_git_refs(base: str, head: str, repo_root: Path | None = None, polic
     )
     paths = [line.strip().replace("\\", "/") for line in result.stdout.splitlines() if line.strip()]
     return classify_paths(paths, policy_path=policy_path)
+
+
+def _has_label(issue: dict, label_name: str) -> bool:
+    return any(label["name"] == label_name for label in issue.get("labels", []))
+
+
+def audit_github_queue(repo: str, *, repo_root: Path | None = None) -> GitHubQueueAudit:
+    root = _repo_root_from_path(repo_root)
+    open_milestones = _gh_json(["api", f"repos/{repo}/milestones?state=open"], repo_root=root)
+    milestone_count = len(open_milestones)
+
+    if milestone_count == 0:
+        checks = [
+            _make_check("single_open_milestone", True, "No open milestone exists; the builder queue should remain paused."),
+            _make_check("protected_exit_gate", True, "No active milestone means no exit gate is expected yet."),
+            _make_check("ready_work_items", True, "No active milestone means no ready work items are expected yet."),
+        ]
+        return GitHubQueueAudit(
+            repo=repo,
+            status="paused",
+            checks=checks,
+            notes=["Queue is paused until a fresh milestone and exit-gate issue are opened."],
+        )
+
+    milestone_titles = [milestone["title"] for milestone in open_milestones]
+    single_open_milestone = milestone_count == 1
+    checks = [
+        _make_check(
+            "single_open_milestone",
+            single_open_milestone,
+            "Open milestones: " + ", ".join(milestone_titles),
+        )
+    ]
+    if not single_open_milestone:
+        failures = [f"{check.name}: {check.details}" for check in checks if not check.passed]
+        return GitHubQueueAudit(
+            repo=repo,
+            status="fail",
+            checks=checks,
+            failures=failures,
+            notes=["Queue is ambiguous while more than one milestone is open."],
+        )
+
+    active_milestone = open_milestones[0]
+    milestone_issues = _gh_json(
+        ["api", f"repos/{repo}/issues?state=open&milestone={active_milestone['number']}&per_page=100"],
+        repo_root=root,
+    )
+    open_issues = [issue for issue in milestone_issues if "pull_request" not in issue]
+    exit_gates = [issue for issue in open_issues if issue["title"].lower().endswith("exit gate")]
+    ready_items = [issue for issue in open_issues if _has_label(issue, "status:ready")]
+
+    protected_exit_gate = (
+        len(exit_gates) == 1
+        and _has_label(exit_gates[0], "lane:protected-core")
+        and _has_label(exit_gates[0], "status:blocked")
+    )
+    ready_work_items = len(ready_items) > 0
+
+    checks.extend(
+        [
+            _make_check(
+                "protected_exit_gate",
+                protected_exit_gate,
+                "Open exit gate issues: "
+                + (
+                    ", ".join(issue["title"] for issue in exit_gates)
+                    if exit_gates
+                    else "none"
+                ),
+            ),
+            _make_check(
+                "ready_work_items",
+                ready_work_items,
+                "Open ready issues: "
+                + (", ".join(issue["title"] for issue in ready_items) if ready_items else "none"),
+            ),
+        ]
+    )
+
+    failures = [f"{check.name}: {check.details}" for check in checks if not check.passed and check.name != "ready_work_items"]
+    if failures:
+        return GitHubQueueAudit(
+            repo=repo,
+            status="fail",
+            active_milestone=active_milestone["title"],
+            checks=checks,
+            failures=failures,
+            notes=["Queue structure is invalid and should be repaired before builder automation resumes."],
+        )
+
+    if not ready_work_items:
+        return GitHubQueueAudit(
+            repo=repo,
+            status="paused",
+            active_milestone=active_milestone["title"],
+            checks=checks,
+            notes=["Queue remains paused because the active milestone has no ready work items."],
+        )
+
+    return GitHubQueueAudit(
+        repo=repo,
+        status="ready",
+        active_milestone=active_milestone["title"],
+        checks=checks,
+        notes=["Exactly one open milestone exists with a protected blocked exit gate and ready work items."],
+    )
 
 
 def _make_check(name: str, passed: bool, details: str) -> AuditCheck:
@@ -294,7 +440,7 @@ def run_phase_audit(
         notes = ["TODO[verify]: Deterministic replay across independent reruns is enforced by eval-demo, not by this artifact-only audit."]
     elif phase == "phase3":
         checks = _phase3_checks(settings, artifacts_root)
-        notes = ["TODO[verify]: Open a fresh GitHub milestone and exit-gate issue before resuming builder automation beyond the closed Phase 3 queue."]
+        notes = ["TODO[verify]: Use `audit-github-queue` to confirm the successor queue is ready before resuming builder automation beyond the closed Phase 3 queue."]
     else:
         raise ValueError(f"Unsupported phase: {phase}")
 

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -4,7 +4,7 @@ import argparse
 import json
 from pathlib import Path
 
-from backend.app.automation.service import classify_git_refs, classify_paths, run_phase_audit
+from backend.app.automation.service import audit_github_queue, classify_git_refs, classify_paths, run_phase_audit
 from backend.app.config import get_settings
 from backend.app.evals.service import run_phase0_demo
 from backend.app.graph.service import build_graph
@@ -62,6 +62,9 @@ def build_parser() -> argparse.ArgumentParser:
     audit = subparsers.add_parser("audit-phase", help="Run the local phase exit audit")
     audit.add_argument("phase", choices=["phase1", "phase2", "phase3"])
     audit.add_argument("--artifacts-root")
+
+    queue = subparsers.add_parser("audit-github-queue", help="Audit whether the GitHub successor queue is paused, ready, or structurally invalid")
+    queue.add_argument("--repo", required=True)
 
     subparsers.add_parser("eval-demo", help="Run the full Phase 0 demo pipeline")
     subparsers.add_parser("smoke", help="Run the end-to-end smoke pipeline")
@@ -126,6 +129,11 @@ def main(argv: list[str] | None = None) -> int:
         )
         print(json.dumps(audit.as_dict(), indent=2, ensure_ascii=False))
         return 0 if audit.status == "pass" else 1
+
+    if args.command == "audit-github-queue":
+        audit = audit_github_queue(args.repo, repo_root=settings.repo_root)
+        print(json.dumps(audit.as_dict(), indent=2, ensure_ascii=False))
+        return 0 if audit.status in {"ready", "paused"} else 1
 
     if args.command in {"eval-demo", "smoke"}:
         result = run_phase0_demo(settings=settings)

--- a/backend/tests/test_automation.py
+++ b/backend/tests/test_automation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from backend.app.automation.service import classify_paths, run_phase_audit
+from backend.app.automation.service import audit_github_queue, classify_paths, run_phase_audit
 from backend.app.config import get_settings
 from backend.app.evals.service import run_phase0_demo
 
@@ -20,6 +20,24 @@ def test_classify_paths_marks_safe_lane_changes() -> None:
     assert decision.protected_hits == []
 
 
+def test_classify_paths_marks_bootstrap_and_automation_changes_protected() -> None:
+    decision = classify_paths(
+        [
+            ".github/automation/bootstrap-spec.json",
+            ".github/ISSUE_TEMPLATE/work-item.yml",
+            "backend/app/automation/service.py",
+            "scripts/bootstrap_github.py",
+        ]
+    )
+    assert decision.lane == "lane:protected-core"
+    assert sorted(decision.protected_hits) == [
+        ".github/ISSUE_TEMPLATE/work-item.yml",
+        ".github/automation/bootstrap-spec.json",
+        "backend/app/automation/service.py",
+        "scripts/bootstrap_github.py",
+    ]
+
+
 def test_phase1_and_phase2_audit_pass_with_demo_artifacts(tmp_path: Path) -> None:
     settings = get_settings()
     run_phase0_demo(settings=settings, artifacts_root=tmp_path / "demo")
@@ -34,3 +52,56 @@ def test_phase3_audit_passes_with_current_workbench_contract(tmp_path: Path) -> 
     run_phase0_demo(settings=settings, artifacts_root=tmp_path / "demo")
     phase3 = run_phase_audit("phase3", settings=settings, artifacts_root=tmp_path / "demo")
     assert phase3.status == "pass"
+
+
+def test_audit_github_queue_pauses_without_open_milestone(monkeypatch) -> None:
+    def fake_gh_json(args: list[str], *, repo_root=None):
+        assert "milestones?state=open" in args[1]
+        return []
+
+    monkeypatch.setattr("backend.app.automation.service._gh_json", fake_gh_json)
+    audit = audit_github_queue("YSCJRH/mirror-sim")
+    assert audit.status == "paused"
+    assert audit.active_milestone is None
+
+
+def test_audit_github_queue_ready_with_single_milestone_and_ready_issue(monkeypatch) -> None:
+    def fake_gh_json(args: list[str], *, repo_root=None):
+        if "milestones?state=open" in args[1]:
+            return [{"number": 4, "title": "Phase 4 - Review Workflow and Ops Hardening"}]
+        if "issues?state=open&milestone=4" in args[1]:
+            return [
+                {
+                    "title": "Phase 4 exit gate",
+                    "labels": [
+                        {"name": "lane:protected-core"},
+                        {"name": "status:blocked"},
+                    ],
+                },
+                {
+                    "title": "Phase 4: add claim -> evidence drill-down in the workbench",
+                    "labels": [
+                        {"name": "status:ready"},
+                        {"name": "lane:auto-safe"},
+                    ],
+                },
+            ]
+        raise AssertionError(f"unexpected gh args: {args}")
+
+    monkeypatch.setattr("backend.app.automation.service._gh_json", fake_gh_json)
+    audit = audit_github_queue("YSCJRH/mirror-sim")
+    assert audit.status == "ready"
+    assert audit.active_milestone == "Phase 4 - Review Workflow and Ops Hardening"
+
+
+def test_audit_github_queue_fails_with_multiple_open_milestones(monkeypatch) -> None:
+    def fake_gh_json(args: list[str], *, repo_root=None):
+        assert "milestones?state=open" in args[1]
+        return [
+            {"number": 4, "title": "Phase 4 - Review Workflow and Ops Hardening"},
+            {"number": 5, "title": "Phase 5 - Placeholder"},
+        ]
+
+    monkeypatch.setattr("backend.app.automation.service._gh_json", fake_gh_json)
+    audit = audit_github_queue("YSCJRH/mirror-sim")
+    assert audit.status == "fail"

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from backend.app.cli import main
+from backend.app.automation.service import GitHubQueueAudit, AuditCheck
 from backend.app.config import get_settings
 from backend.app.safety.service import ensure_safe_scenario
 
@@ -81,6 +82,24 @@ def test_cli_audit_phase_outputs_json(tmp_path: Path, capsys) -> None:
     assert result == 0
     assert payload["phase"] == "phase1"
     assert payload["status"] == "pass"
+
+
+def test_cli_audit_github_queue_outputs_json(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        "backend.app.cli.audit_github_queue",
+        lambda repo, repo_root=None: GitHubQueueAudit(
+            repo=repo,
+            status="ready",
+            active_milestone="Phase 4 - Review Workflow and Ops Hardening",
+            checks=[AuditCheck(name="single_open_milestone", passed=True, details="ok")],
+            failures=[],
+            notes=["ok"],
+        ),
+    )
+    assert main(["audit-github-queue", "--repo", "YSCJRH/mirror-sim"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "ready"
+    assert payload["active_milestone"] == "Phase 4 - Review Workflow and Ops Hardening"
 
 
 def test_safety_blocks_redline_payload() -> None:

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -14,7 +14,10 @@ Day 0 bootstrap is complete.
 - Phase 1 and Phase 2 gates are closed.
 - Phase 3 is closed locally and in GitHub.
 - Phase 3 exit issue `#4` is closed and milestone `Phase 3 - Eval/UI/Demo` is closed.
-- No active implementation queue is currently open; builder automation should remain paused until a fresh issue and milestone are opened.
+- Phase 4 is the active successor queue.
+- milestone `Phase 4 - Review Workflow and Ops Hardening` is open.
+- The Phase 4 queue is initialized through issues `#26-#29`.
+- Builder state should now be derived from `audit-github-queue`, not from doc-only convention.
 
 ## Day 0 Bootstrap
 
@@ -36,6 +39,8 @@ Before builder automation is allowed to write code or auto-merge:
   - classify a change set into `lane:auto-safe` or `lane:protected-core`
 - `python -m backend.app.cli audit-phase phase1`
   - run the Phase 1 local exit audit
+- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
+  - report whether the successor GitHub queue is `paused`, `ready`, or structurally invalid
 
 ## Execution Roles
 
@@ -54,7 +59,7 @@ Before builder automation is allowed to write code or auto-merge:
 - `mirror-phase-auditor`
   - run local phase audits
   - compare against milestone state
-  - keep automation paused once the active phase is complete and no new milestone has been opened
+  - keep automation paused when no valid successor queue is open
 
 ## Guardrails
 
@@ -66,4 +71,4 @@ Before builder automation is allowed to write code or auto-merge:
 ## TODO[verify]
 
 - TODO[verify]: Codex cron automations should target worktrees, not the current dirty `main` checkout.
-- TODO[verify]: if a new milestone opens after Phase 3, create a fresh exit-gate issue instead of reusing the closed Phase 3 closeout thread.
+- TODO[verify]: after the initial Phase 4 implementation issues land, decide whether `Phase 4 exit gate` should remain blocked for a final closeout PR or close directly from reviewed artifact evidence.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the handoff baseline for the current `main` branch after the Phase 3 closeout.
+This note is the current successor-queue baseline after the Phase 4 kickoff.
 
 ## Snapshot
 
@@ -15,28 +15,35 @@ This note is the handoff baseline for the current `main` branch after the Phase 
   - `gh api repos/YSCJRH/mirror-sim`
     - `default_branch`: `main`
     - `license`: `MIT`
-    - `open_issues_count`: `0`
   - `gh api repos/YSCJRH/mirror-sim/issues/4`
     - Phase 3 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/3`
     - milestone `Phase 3 - Eval/UI/Demo` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/4`
+    - milestone `Phase 4 - Review Workflow and Ops Hardening` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=4"`
+    - Phase 4 queue is initialized through issues `#26-#29`
+  - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
+    - successor queue reports `ready` while open ready work items remain under the active milestone, and `paused` once only the blocked exit gate remains
 
 ## Trusted Source Of Truth
 
 - GitHub issue and milestone state remain the operational source of truth for current and future work.
 - Local phase audits remain the contract-aligned source of truth for whether the current repo state is runnable and reviewable.
+- `audit-github-queue` is the executable local rule for whether builder automation should remain `paused` or can resume against the successor queue.
 - `backlog/sprint-01.md` is historical seed material only and should not be used as the live queue.
 - Remote `origin/codex/*` branches should be treated as historical and superseded by `main` unless a future issue explicitly revives one.
 
 ## Current Main Capabilities
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
-- The frontend workbench shell renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
-- The current repository state is post-Phase-3 closeout, not an active Phase 3 implementation queue.
+- The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
+- The workbench now also supports claim -> evidence drill-down and baseline/intervention trace review without introducing backend API expansion.
+- The current repository state is in an active Phase 4 successor queue, not a post-Phase-3 idle handoff.
 
 ## Next Entry Point
 
-- No Phase 4 or successor milestone is open yet.
-- New implementation work should start by opening a fresh GitHub issue and milestone, then updating `docs/plans/phase-execution-queue.md` to match that new queue.
+- Phase 4 is the active milestone and the first execution slice is tracked by issues `#26-#29`.
+- New implementation work should attach to the existing Phase 4 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - TODO[verify]: delete or archive the superseded remote `codex/*` branches during the next repository cleanup window.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,12 +1,13 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 3 closeout.
+This note records the current post-Day-0 execution status for Mirror after the Phase 4 queue kickoff.
 
 ## Current Gate State
 
 - Phase 1 exit gate: closed
 - Phase 2 exit gate: closed
 - Phase 3 exit gate: closed
+- Phase 4 exit gate: open
 
 Local phase audits currently report:
 
@@ -32,19 +33,25 @@ Local phase audits currently report:
 - milestone `Phase 3 - Eval/UI/Demo`
   - closed
 - GitHub remote state
-  - no open issues
-  - no open pull requests
+  - no open issues or pull requests remained after Phase 3 closeout
 
 ## Current Queue
 
-- No active implementation queue is open on `main`.
-- GitHub remains the operational source of truth for any future queue.
+- milestone `Phase 4 - Review Workflow and Ops Hardening` is open.
+- `#26` `Phase 4 exit gate`
+  - open
+  - blocked until the first implementation slice is reviewed and merged
+- The first Phase 4 execution slice is tracked through:
+  - `#27` `Phase 4: harden successor-milestone bootstrap and builder pause/resume rules`
+  - `#28` `Phase 4: add claim -> evidence drill-down in the workbench`
+  - `#29` `Phase 4: add baseline/intervention trace timeline in the workbench`
+- GitHub remains the operational source of truth for the queue.
 - `backlog/sprint-01.md` remains a historical seed backlog only.
-- Future implementation should start from a fresh GitHub issue and milestone instead of reopening the closed Phase 3 queue.
+- Successor queue health should be checked with `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`.
 
 ## Automation Guidance
 
-- Builder should prefer the earliest unfinished open milestone once a new queue exists.
+- Builder should prefer the earliest unfinished open milestone once a valid queue exists.
 - Closed exit-gate issues and milestones should remain archived history, not be reused as active work trackers.
 - Safe-lane PRs may auto-merge once checks are green and no blocking labels are present.
 - Protected-core changes still require explicit review and must not auto-merge.

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -125,6 +125,30 @@ code {
   font-size: 0.92rem;
 }
 
+.linkPill {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid rgba(15, 107, 99, 0.18);
+  color: var(--accent-strong);
+  font-size: 0.92rem;
+  text-decoration: none;
+}
+
+.linkPill:hover,
+.jumpLink:hover {
+  border-color: rgba(15, 107, 99, 0.4);
+  color: var(--accent);
+}
+
+.jumpLink {
+  color: var(--accent-strong);
+  font-weight: 700;
+  text-decoration: none;
+}
+
 .panelHeader {
   display: grid;
   gap: 8px;
@@ -216,6 +240,12 @@ code {
   gap: 12px;
 }
 
+.drilldownGrid,
+.timelineRows {
+  display: grid;
+  gap: 16px;
+}
+
 .docList,
 .objectList {
   margin: 0;
@@ -265,6 +295,83 @@ code {
 .claimNote {
   font-size: 0.92rem;
   color: var(--muted);
+}
+
+.detailStack,
+.detailList {
+  display: grid;
+  gap: 14px;
+}
+
+.detailBlock {
+  display: grid;
+  gap: 12px;
+}
+
+.detailBlock h3 {
+  margin-bottom: 0;
+}
+
+.drilldownCard,
+.traceItem,
+.evidenceBlock {
+  display: grid;
+  gap: 12px;
+  padding: 18px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid var(--border);
+}
+
+.evidenceBlock p,
+.traceItem p {
+  margin: 0;
+}
+
+.timelineRow {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border-radius: 22px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(247, 240, 232, 0.96));
+  border: 1px solid var(--border);
+}
+
+.timelineRowDivergent {
+  border-color: rgba(15, 107, 99, 0.24);
+  box-shadow: 0 18px 38px rgba(15, 107, 99, 0.1);
+}
+
+.timelineCards {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.timelineCard {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid var(--border);
+  min-width: 0;
+}
+
+.timelineCardEmpty {
+  place-items: center;
+}
+
+.timelineState {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.subtle,
+.objectListEmpty {
+  color: var(--muted);
+  font-size: 0.92rem;
 }
 
 .pill {
@@ -339,6 +446,10 @@ code {
   }
 
   .reportGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .timelineCards {
     grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 
 export const metadata: Metadata = {
   title: "Mirror Workbench",
-  description: "Phase 3 browser workbench shell for the Fog Harbor demo."
+  description: "Phase 4 review workflow workbench for the Fog Harbor demo."
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,28 +4,28 @@ import path from "node:path";
 const sections = [
   {
     title: "Corpus",
-    copy: "Source documents, chunks, and demo-world evidence remain the base truth layer.",
+    copy: "Source documents and chunks remain the base truth layer behind every later review step.",
     path: "artifacts/demo/ingest"
   },
   {
     title: "World Model",
-    copy: "Graph entities, relations, events, and personas define the constrained simulation world.",
+    copy: "Graph entities, relations, events, and personas keep evidence-bearing context queryable.",
     path: "artifacts/demo/graph and artifacts/demo/personas"
   },
   {
     title: "Scenario",
-    copy: "Baseline and intervention scenarios stay explicit, normalized, and reviewable.",
+    copy: "Baseline and intervention scenarios stay explicit, normalized, and branch-comparable.",
     path: "artifacts/demo/scenario"
   },
   {
     title: "Run",
-    copy: "Deterministic traces, snapshots, and branch summaries keep replayability visible.",
+    copy: "Deterministic traces and snapshots now surface as a reviewer-readable branch timeline.",
     path: "artifacts/demo/run"
   },
   {
-    title: "Report",
-    copy: "Claims, evidence labels, and eval summaries remain the final review surface.",
-    path: "artifacts/demo/report and artifacts/demo/eval"
+    title: "Review Workflow",
+    copy: "Claims, evidence excerpts, graph context, and branch turns can be traversed without leaving the workbench.",
+    path: "artifacts/demo/report, run, and eval"
   }
 ];
 
@@ -34,6 +34,7 @@ type Claim = {
   text: string;
   label: string;
   evidence_ids: string[];
+  related_turn_ids: string[];
   confidence_note: string;
 };
 
@@ -50,6 +51,15 @@ type DocumentRow = {
   title: string;
   kind: string;
   metadata?: Record<string, string>;
+};
+
+type ChunkRow = {
+  chunk_id: string;
+  document_id: string;
+  text: string;
+  char_start: number;
+  char_end: number;
+  source_id: string;
 };
 
 type GraphEntity = {
@@ -96,6 +106,41 @@ type ScenarioPayload = {
   }>;
 };
 
+type TurnAction = {
+  turn_id: string;
+  run_id: string;
+  turn_index: number;
+  actor_id: string;
+  action_type: string;
+  target_id: string | null;
+  rationale: string;
+  evidence_ids: string[];
+  state_patch: Record<string, unknown>;
+};
+
+type SnapshotPayload = {
+  turn_index: number;
+  state: Record<string, unknown>;
+};
+
+type ScenarioKey = "baseline" | "reporter_detained";
+
+type RunPayload = {
+  key: ScenarioKey;
+  title: string;
+  scenario: ScenarioPayload;
+  actions: TurnAction[];
+  snapshots: SnapshotPayload[];
+};
+
+type TurnEntry = {
+  scenarioKey: ScenarioKey;
+  scenarioTitle: string;
+  scenarioDescription: string;
+  turn: TurnAction;
+  snapshot: SnapshotPayload | null;
+};
+
 async function readText(relativePath: string) {
   const repoRoot = path.resolve(process.cwd(), "..");
   return readFile(path.join(repoRoot, relativePath), "utf-8");
@@ -105,58 +150,221 @@ async function readJson<T>(relativePath: string) {
   return JSON.parse(await readText(relativePath)) as T;
 }
 
-async function loadWorkbenchData() {
-  const [report, claimsRaw, evalRaw, rubric, documentsRaw, graph, baselineScenario, interventionScenario] =
-    await Promise.all([
-    readText("artifacts/demo/report/report.md"),
-    readText("artifacts/demo/report/claims.json"),
-    readText("artifacts/demo/eval/summary.json"),
-    readText("docs/rubrics/human-review.md"),
-    readText("artifacts/demo/ingest/documents.jsonl"),
-    readJson<GraphPayload>("artifacts/demo/graph/graph.json"),
-    readJson<ScenarioPayload>("artifacts/demo/scenario/baseline.json"),
-    readJson<ScenarioPayload>("artifacts/demo/scenario/reporter_detained.json")
-    ]);
+async function readJsonl<T>(relativePath: string) {
+  return (await readText(relativePath))
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as T);
+}
+
+async function loadSnapshots(runDir: string, turnBudget: number) {
+  return Promise.all(
+    Array.from({ length: turnBudget }, (_, index) =>
+      readJson<SnapshotPayload>(
+        `artifacts/demo/run/${runDir}/snapshots/turn-${String(index + 1).padStart(2, "0")}.json`
+      )
+    )
+  );
+}
+
+async function loadRunPayload(
+  key: ScenarioKey,
+  runDir: string,
+  title: string,
+  scenario: ScenarioPayload
+): Promise<RunPayload> {
+  const [actions, snapshots] = await Promise.all([
+    readJsonl<TurnAction>(`artifacts/demo/run/${runDir}/run_trace.jsonl`),
+    loadSnapshots(runDir, scenario.turn_budget)
+  ]);
 
   return {
-    report,
-    claims: JSON.parse(claimsRaw) as Claim[],
-    evalSummary: JSON.parse(evalRaw) as EvalSummary,
-    rubric,
-    documents: documentsRaw
-      .split("\n")
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as DocumentRow),
-    graph,
-    baselineScenario,
-    interventionScenario
+    key,
+    title,
+    scenario,
+    actions,
+    snapshots
   };
 }
 
+async function loadWorkbenchData() {
+  const [
+    report,
+    claims,
+    evalSummary,
+    rubric,
+    documents,
+    chunks,
+    graph,
+    baselineScenario,
+    interventionScenario
+  ] = await Promise.all([
+    readText("artifacts/demo/report/report.md"),
+    readJson<Claim[]>("artifacts/demo/report/claims.json"),
+    readJson<EvalSummary>("artifacts/demo/eval/summary.json"),
+    readText("docs/rubrics/human-review.md"),
+    readJsonl<DocumentRow>("artifacts/demo/ingest/documents.jsonl"),
+    readJsonl<ChunkRow>("artifacts/demo/ingest/chunks.jsonl"),
+    readJson<GraphPayload>("artifacts/demo/graph/graph.json"),
+    readJson<ScenarioPayload>("artifacts/demo/scenario/baseline.json"),
+    readJson<ScenarioPayload>("artifacts/demo/scenario/reporter_detained.json")
+  ]);
+
+  const [baselineRun, interventionRun] = await Promise.all([
+    loadRunPayload("baseline", "baseline", "Baseline", baselineScenario),
+    loadRunPayload("reporter_detained", "reporter_detained", "Intervention", interventionScenario)
+  ]);
+
+  return {
+    report,
+    claims,
+    evalSummary,
+    rubric,
+    documents,
+    chunks,
+    graph,
+    baselineRun,
+    interventionRun
+  };
+}
+
+function formatValue(value: unknown) {
+  if (typeof value === "string") {
+    return value;
+  }
+  return JSON.stringify(value) ?? "undefined";
+}
+
+function buildTurnEntries(run: RunPayload): TurnEntry[] {
+  return run.actions.map((turn, index) => ({
+    scenarioKey: run.key,
+    scenarioTitle: run.scenario.title,
+    scenarioDescription: run.scenario.description,
+    turn,
+    snapshot: run.snapshots[index] ?? null
+  }));
+}
+
+function stateHighlights(state: Record<string, unknown> | undefined) {
+  if (!state) {
+    return [];
+  }
+
+  const keys = [
+    "festival_status",
+    "budget_exposed",
+    "ledger_public",
+    "budget_exposed_turn",
+    "ledger_public_turn",
+    "evacuation_requested",
+    "evacuation_triggered",
+    "evacuation_turn",
+    "public_pressure",
+    "command_post",
+    "mayor_alerted"
+  ];
+
+  return keys.flatMap((key) => {
+    const value = state[key];
+    if (value === null || value === undefined || value === false) {
+      return [];
+    }
+    return [`${key}=${formatValue(value)}`];
+  });
+}
+
 export default async function Page() {
-  const { report, claims, evalSummary, rubric, documents, graph, baselineScenario, interventionScenario } =
-    await loadWorkbenchData();
+  const {
+    report,
+    claims,
+    evalSummary,
+    rubric,
+    documents,
+    chunks,
+    graph,
+    baselineRun,
+    interventionRun
+  } = await loadWorkbenchData();
+
+  const documentsById = new Map(documents.map((document) => [document.document_id, document]));
+  const chunksById = new Map(chunks.map((chunk) => [chunk.chunk_id, chunk]));
+  const baselineTurns = buildTurnEntries(baselineRun);
+  const interventionTurns = buildTurnEntries(interventionRun);
+  const allTurns = [...baselineTurns, ...interventionTurns];
+  const turnsById = new Map(allTurns.map((entry) => [entry.turn.turn_id, entry]));
+  const claimIdsByTurnId = new Map<string, string[]>();
+
+  for (const claim of claims) {
+    for (const turnId of claim.related_turn_ids.filter((value): value is string => Boolean(value))) {
+      const ids = claimIdsByTurnId.get(turnId) ?? [];
+      ids.push(claim.claim_id);
+      claimIdsByTurnId.set(turnId, ids);
+    }
+  }
+
+  const claimDrilldowns = claims.map((claim) => {
+    const evidenceIdSet = new Set(claim.evidence_ids);
+    const evidenceChunks = claim.evidence_ids
+      .map((chunkId) => chunksById.get(chunkId))
+      .filter((chunk): chunk is ChunkRow => Boolean(chunk))
+      .map((chunk) => ({
+        chunk,
+        document: documentsById.get(chunk.document_id) ?? null
+      }));
+
+    const graphContext = {
+      entities: graph.entities.filter((entity) => entity.evidence_ids.some((evidenceId) => evidenceIdSet.has(evidenceId))),
+      relations: graph.relations.filter((relation) => relation.evidence_ids.some((evidenceId) => evidenceIdSet.has(evidenceId))),
+      events: graph.events.filter((event) => event.evidence_ids.some((evidenceId) => evidenceIdSet.has(evidenceId)))
+    };
+
+    const relatedTurns = claim.related_turn_ids
+      .filter((value): value is string => Boolean(value))
+      .map((turnId) => turnsById.get(turnId))
+      .filter((entry): entry is TurnEntry => Boolean(entry));
+
+    const scenarioContext = Array.from(new Set(relatedTurns.map((entry) => entry.scenarioKey))).map((scenarioKey) =>
+      scenarioKey === "baseline" ? baselineRun : interventionRun
+    );
+
+    return {
+      claim,
+      evidenceChunks,
+      graphContext,
+      relatedTurns,
+      scenarioContext
+    };
+  });
+
+  const timelineRows = Array.from(
+    { length: Math.max(baselineTurns.length, interventionTurns.length) },
+    (_, index) => ({
+      turnIndex: index + 1,
+      baseline: baselineTurns[index] ?? null,
+      intervention: interventionTurns[index] ?? null
+    })
+  );
 
   return (
     <main className="shell">
       <section className="hero">
-        <p className="eyebrow">Mirror Engine / Phase 3 Workbench</p>
-        <h1>Review the Fog Harbor sandbox from one place.</h1>
+        <p className="eyebrow">Mirror Engine / Phase 4 Review Workflow</p>
+        <h1>Review the Fog Harbor sandbox with evidence, trace, and branch context in one place.</h1>
         <p className="lede">
-          This shell is the browser entrypoint for the constrained demo world. It keeps the
-          workbench centered on evidence, artifacts, and phase-based review instead of free-form
-          chat first.
+          The workbench now stays artifact-first while adding the missing reviewer path:
+          from claim, to evidence, to branch timeline, without leaving the bounded demo world.
         </p>
         <div className="heroMeta">
           <span>Current demo: Fog Harbor East Gate</span>
-          <span>Current status: shell established, artifact panels follow next</span>
+          <span>Current phase: review workflow and ops hardening</span>
+          <span>No backend API expansion required</span>
         </div>
       </section>
 
       <section className="panel">
         <div className="panelHeader">
           <p className="eyebrow">Workbench Spine</p>
-          <h2>Each view maps directly to the durable artifact tree.</h2>
+          <h2>Each review step still maps directly to the durable artifact tree.</h2>
         </div>
         <div className="grid">
           {sections.map((section) => (
@@ -171,13 +379,13 @@ export default async function Page() {
 
       <section className="panel panelAccent">
         <div className="panelHeader">
-          <p className="eyebrow">Next Queue</p>
-          <h2>This entrypoint is intentionally narrow.</h2>
+          <p className="eyebrow">Phase 4 Slice</p>
+          <h2>The first successor slice stays contract-light and review-heavy.</h2>
         </div>
         <ul className="checklist">
-          <li>Render report, claims, eval summary, and rubric panels.</li>
-          <li>Expose corpus, graph, and scenario artifacts without changing their contracts.</li>
-          <li>Keep evidence and traceability visible in every later Phase 3 view.</li>
+          <li>Claim cards now link into their supporting evidence, graph context, and branch turns.</li>
+          <li>Baseline and intervention runs now surface as a reviewer-readable turn-by-turn timeline.</li>
+          <li>Everything still reads the existing artifact tree directly, with no backend API expansion.</li>
         </ul>
       </section>
 
@@ -209,14 +417,158 @@ export default async function Page() {
                   <p>{claim.text}</p>
                   <div className="claimEvidence">
                     {claim.evidence_ids.map((evidenceId) => (
-                      <code key={evidenceId}>{evidenceId}</code>
+                      <a key={evidenceId} className="linkPill" href={`#chunk-${evidenceId}`}>
+                        {evidenceId}
+                      </a>
                     ))}
                   </div>
+                  <div className="claimEvidence">
+                    {claim.related_turn_ids.filter(Boolean).map((turnId) => (
+                      <a key={turnId} className="linkPill" href={`#turn-${turnId}`}>
+                        {turnId}
+                      </a>
+                    ))}
+                  </div>
+                  <a className="jumpLink" href={`#drill-${claim.claim_id}`}>
+                    Open review drill-down
+                  </a>
                   <p className="claimNote">{claim.confidence_note}</p>
                 </article>
               ))}
             </div>
           </article>
+        </div>
+      </section>
+
+      <section className="panel">
+        <div className="panelHeader">
+          <p className="eyebrow">Claim Drill-Down</p>
+          <h2>Move from each claim into supporting evidence, graph context, and trace context.</h2>
+        </div>
+        <div className="drilldownGrid">
+          {claimDrilldowns.map(({ claim, evidenceChunks, graphContext, relatedTurns, scenarioContext }) => (
+            <article key={claim.claim_id} id={`drill-${claim.claim_id}`} className="drilldownCard">
+              <div className="claimHeader">
+                <strong>{claim.claim_id}</strong>
+                <span className="pill">{claim.label}</span>
+              </div>
+              <p>{claim.text}</p>
+
+              <div className="detailStack">
+                <section className="detailBlock">
+                  <h3>Evidence excerpts</h3>
+                  <div className="detailList">
+                    {evidenceChunks.map(({ chunk, document }) => (
+                      <article key={chunk.chunk_id} id={`chunk-${chunk.chunk_id}`} className="evidenceBlock">
+                        <div className="claimHeader">
+                          <strong>{document?.title ?? chunk.document_id}</strong>
+                          <span className="pill">{document?.kind ?? "chunk"}</span>
+                        </div>
+                        <div className="claimEvidence">
+                          <code>{chunk.chunk_id}</code>
+                          <code>{chunk.document_id}</code>
+                        </div>
+                        <p>{chunk.text}</p>
+                      </article>
+                    ))}
+                  </div>
+                </section>
+
+                <section className="detailBlock">
+                  <h3>Scenario context</h3>
+                  <div className="detailList">
+                    {scenarioContext.map((run) => (
+                      <article key={run.scenario.scenario_id} className="docCard">
+                        <div className="claimHeader">
+                          <strong>{run.scenario.title}</strong>
+                          <span className="pill">{run.title}</span>
+                        </div>
+                        <p>{run.scenario.description}</p>
+                        <div className="claimEvidence">
+                          <code>{run.scenario.scenario_id}</code>
+                          <code>turn_budget={run.scenario.turn_budget}</code>
+                          <code>injections={run.scenario.injections.length}</code>
+                        </div>
+                      </article>
+                    ))}
+                  </div>
+                </section>
+
+                <section className="detailBlock">
+                  <h3>Graph context</h3>
+                  <div className="objectColumns">
+                    <div>
+                      <h3>Entities</h3>
+                      <ul className="objectList">
+                        {graphContext.entities.length > 0 ? (
+                          graphContext.entities.map((entity) => (
+                            <li key={entity.entity_id}>
+                              <strong>{entity.name}</strong>
+                              <code>{entity.entity_id}</code>
+                            </li>
+                          ))
+                        ) : (
+                          <li className="objectListEmpty">No entity evidence overlap.</li>
+                        )}
+                      </ul>
+                    </div>
+                    <div>
+                      <h3>Relations</h3>
+                      <ul className="objectList">
+                        {graphContext.relations.length > 0 ? (
+                          graphContext.relations.map((relation) => (
+                            <li key={relation.relation_id}>
+                              <strong>{relation.relation_type}</strong>
+                              <code>{relation.relation_id}</code>
+                            </li>
+                          ))
+                        ) : (
+                          <li className="objectListEmpty">No relation evidence overlap.</li>
+                        )}
+                      </ul>
+                    </div>
+                    <div>
+                      <h3>Events</h3>
+                      <ul className="objectList">
+                        {graphContext.events.length > 0 ? (
+                          graphContext.events.map((event) => (
+                            <li key={event.event_id}>
+                              <strong>{event.name}</strong>
+                              <code>{event.event_id}</code>
+                            </li>
+                          ))
+                        ) : (
+                          <li className="objectListEmpty">No event evidence overlap.</li>
+                        )}
+                      </ul>
+                    </div>
+                  </div>
+                </section>
+
+                <section className="detailBlock">
+                  <h3>Related turns</h3>
+                  <div className="detailList">
+                    {relatedTurns.map((entry) => (
+                      <article key={entry.turn.turn_id} className="traceItem">
+                        <div className="claimHeader">
+                          <strong>{entry.turn.turn_id}</strong>
+                          <span className="pill">{entry.scenarioTitle}</span>
+                        </div>
+                        <div className="claimEvidence">
+                          <a className="linkPill" href={`#turn-${entry.turn.turn_id}`}>
+                            jump to timeline
+                          </a>
+                          <code>{entry.turn.action_type}</code>
+                          {entry.turn.target_id ? <code>{entry.turn.target_id}</code> : null}
+                        </div>
+                        <p>{entry.turn.rationale}</p>
+                      </article>
+                    ))}
+                  </div>
+                </section>
+              </div>
+            </article>
+          ))}
         </div>
       </section>
 
@@ -254,9 +606,8 @@ export default async function Page() {
               <code>{documents.length} documents</code>
             </div>
             <p>
-              The browser shell now exposes the source-document layer directly, so later reviewers
-              can trace claims and graph objects back to the bounded corpus instead of treating the
-              simulation as a black box.
+              The source-document layer remains fully visible, so reviewers can verify evidence
+              chains without treating the simulation or report layer as a black box.
             </p>
           </article>
         </div>
@@ -324,8 +675,8 @@ export default async function Page() {
               <code>entities / relations / events</code>
             </div>
             <p>
-              This view keeps the graph inspectable without introducing a new API or a heavy graph
-              visualization dependency. It is intentionally review-first and contract-light.
+              This view still avoids a heavy graph dependency, but the new claim drill-down now
+              cross-links evidence-bearing graph records when a claim shares their `evidence_ids`.
             </p>
           </article>
         </div>
@@ -343,15 +694,15 @@ export default async function Page() {
               <code>artifacts/demo/scenario/baseline.json</code>
             </div>
             <div className="claimHeader">
-              <strong>{baselineScenario.title}</strong>
-              <span className="pill">{baselineScenario.scenario_id}</span>
+              <strong>{baselineRun.scenario.title}</strong>
+              <span className="pill">{baselineRun.scenario.scenario_id}</span>
             </div>
             <div className="claimEvidence">
-              <code>turn_budget={baselineScenario.turn_budget}</code>
-              <code>branch_count={baselineScenario.branch_count}</code>
+              <code>turn_budget={baselineRun.scenario.turn_budget}</code>
+              <code>branch_count={baselineRun.scenario.branch_count}</code>
             </div>
             <pre className="artifactPre artifactPreCompact">
-              {JSON.stringify(baselineScenario, null, 2)}
+              {JSON.stringify(baselineRun.scenario, null, 2)}
             </pre>
           </article>
 
@@ -361,18 +712,101 @@ export default async function Page() {
               <code>artifacts/demo/scenario/reporter_detained.json</code>
             </div>
             <div className="claimHeader">
-              <strong>{interventionScenario.title}</strong>
-              <span className="pill">{interventionScenario.scenario_id}</span>
+              <strong>{interventionRun.scenario.title}</strong>
+              <span className="pill">{interventionRun.scenario.scenario_id}</span>
             </div>
             <div className="claimEvidence">
-              <code>turn_budget={interventionScenario.turn_budget}</code>
-              <code>branch_count={interventionScenario.branch_count}</code>
-              <code>injections={interventionScenario.injections.length}</code>
+              <code>turn_budget={interventionRun.scenario.turn_budget}</code>
+              <code>branch_count={interventionRun.scenario.branch_count}</code>
+              <code>injections={interventionRun.scenario.injections.length}</code>
             </div>
             <pre className="artifactPre artifactPreCompact">
-              {JSON.stringify(interventionScenario, null, 2)}
+              {JSON.stringify(interventionRun.scenario, null, 2)}
             </pre>
           </article>
+        </div>
+      </section>
+
+      <section className="panel">
+        <div className="panelHeader">
+          <p className="eyebrow">Run Timeline</p>
+          <h2>Compare baseline and intervention turns with trace, state patch, and snapshot state.</h2>
+        </div>
+        <div className="timelineRows">
+          {timelineRows.map(({ turnIndex, baseline, intervention }) => {
+            const divergent =
+              baseline?.turn.action_type !== intervention?.turn.action_type ||
+              baseline?.turn.target_id !== intervention?.turn.target_id;
+
+            return (
+              <article key={turnIndex} className={`timelineRow${divergent ? " timelineRowDivergent" : ""}`}>
+                <div className="claimHeader">
+                  <strong>Turn {turnIndex}</strong>
+                  <span className="pill">{divergent ? "branch divergence" : "same step"}</span>
+                </div>
+                <div className="timelineCards">
+                  {[baseline, intervention].map((entry, index) => (
+                    <section
+                      key={index === 0 ? "baseline" : "intervention"}
+                      id={entry ? `turn-${entry.turn.turn_id}` : undefined}
+                      className={`timelineCard${entry ? "" : " timelineCardEmpty"}`}
+                    >
+                      {entry ? (
+                        <>
+                          <div className="artifactMeta">
+                            <span>{entry.scenarioKey === "baseline" ? "baseline" : "intervention"}</span>
+                            <code>{entry.turn.turn_id}</code>
+                          </div>
+                          <div className="claimHeader">
+                            <strong>{entry.turn.action_type}</strong>
+                            <span className="pill">{entry.turn.actor_id}</span>
+                          </div>
+                          <p>{entry.turn.rationale}</p>
+                          <div className="claimEvidence">
+                            {entry.turn.target_id ? <code>{entry.turn.target_id}</code> : null}
+                            {claimIdsByTurnId.get(entry.turn.turn_id)?.map((claimId) => (
+                              <a key={claimId} className="linkPill" href={`#drill-${claimId}`}>
+                                {claimId}
+                              </a>
+                            ))}
+                          </div>
+                          <div className="claimEvidence">
+                            {entry.turn.evidence_ids.map((evidenceId) => (
+                              <a key={evidenceId} className="linkPill" href={`#chunk-${evidenceId}`}>
+                                {evidenceId}
+                              </a>
+                            ))}
+                          </div>
+                          <div className="timelineState">
+                            {Object.keys(entry.turn.state_patch).length > 0 ? (
+                              Object.entries(entry.turn.state_patch).map(([key, value]) => (
+                                <code key={key}>
+                                  {key}={formatValue(value)}
+                                </code>
+                              ))
+                            ) : (
+                              <span className="subtle">no state patch</span>
+                            )}
+                          </div>
+                          <div className="timelineState">
+                            {stateHighlights(entry.snapshot?.state).length > 0 ? (
+                              stateHighlights(entry.snapshot?.state).map((highlight) => (
+                                <code key={highlight}>{highlight}</code>
+                              ))
+                            ) : (
+                              <span className="subtle">no highlighted snapshot state</span>
+                            )}
+                          </div>
+                        </>
+                      ) : (
+                        <span className="subtle">No turn recorded for this branch.</span>
+                      )}
+                    </section>
+                  ))}
+                </div>
+              </article>
+            );
+          })}
         </div>
       </section>
 

--- a/scripts/bootstrap_github.py
+++ b/scripts/bootstrap_github.py
@@ -43,7 +43,7 @@ def bootstrap_github(repo: str, spec_path: Path, *, apply: bool) -> None:
     cwd = spec_path.resolve().parents[2]
     spec = json.loads(spec_path.read_text(encoding="utf-8"))
     existing_labels = _gh_json(["api", f"repos/{repo}/labels", "--paginate"], cwd=cwd)
-    existing_milestones = _gh_json(["api", f"repos/{repo}/milestones"], cwd=cwd)
+    existing_milestones = _gh_json(["api", f"repos/{repo}/milestones?state=all", "--paginate"], cwd=cwd)
     existing_issues = _gh_json(["api", f"repos/{repo}/issues?state=all", "--paginate"], cwd=cwd)
     milestone_numbers: dict[str, int] = {}
 
@@ -71,7 +71,7 @@ def bootstrap_github(repo: str, spec_path: Path, *, apply: bool) -> None:
             milestone_numbers[milestone["title"]] = created["number"]
 
     if apply:
-        refreshed_milestones = _gh_json(["api", f"repos/{repo}/milestones"], cwd=cwd)
+        refreshed_milestones = _gh_json(["api", f"repos/{repo}/milestones?state=all", "--paginate"], cwd=cwd)
         for milestone in refreshed_milestones:
             milestone_numbers[milestone["title"]] = milestone["number"]
 


### PR DESCRIPTION
## Summary
- harden successor-milestone bootstrap and builder pause/resume rules for the new Phase 4 queue
- extend the workbench with claim -> evidence drill-down and a baseline/intervention trace timeline
- align README and planning docs to the active Phase 4 successor queue

Closes #27
Closes #28
Closes #29

## Testing
- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`
- `python -m backend.app.cli classify-lane --files .github/ISSUE_TEMPLATE/work-item.yml .github/ISSUE_TEMPLATE/phase-exit.yml .github/automation/bootstrap-spec.json .github/automation/lane-policy.json backend/app/automation/service.py scripts/bootstrap_github.py frontend/src/app/page.tsx frontend/src/app/globals.css`
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
- `./make.ps1 test`
- `./make.ps1 smoke`
- `./make.ps1 eval-demo`
- `python -m backend.app.cli audit-phase phase1`
- `python -m backend.app.cli audit-phase phase2`
- `python -m backend.app.cli audit-phase phase3`
- `npm.cmd run build --prefix frontend`

## Notes
- this PR intentionally leaves `Phase 4 exit gate` open so final closeout can happen from reviewed, merged state
- the initial `npm run build` failure was environment-level `spawn EPERM`; the elevated rerun passed cleanly
- the initial `smoke` / `eval-demo` conflict seen earlier in this workspace was due to parallel artifact writes, so the final verification was run sequentially