### PR TITLE
[codex] Sync Phase 5 repo truth and add loop runbook

### DIFF
--- a/.github/ISSUE_TEMPLATE/phase-exit.yml
+++ b/.github/ISSUE_TEMPLATE/phase-exit.yml
@@ -2,16 +2,12 @@ name: Mirror Phase Exit Gate
 description: Track the explicit exit criteria that must pass before automation can advance to the next phase.
 title: "[phase-exit] "
 body:
-  - type: dropdown
+  - type: input
     id: phase
     attributes:
-      label: Phase
-      description: Which phase exit gate is this?
-      options:
-        - Phase 1 - World/Persona Modeling
-        - Phase 2 - Scenario/Simulation Loop
-        - Phase 3 - Eval/UI/Demo
-        - Phase 4 - Review Workflow and Ops Hardening
+      label: Phase / Milestone
+      description: Enter the active GitHub milestone title for this exit gate.
+      placeholder: Phase 5 - Review Sign-off and Evidence Packaging
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -2,16 +2,12 @@ name: Mirror Work Item
 description: Create a Codex-friendly implementation task with explicit inputs, outputs, and tests.
 title: "[work-item] "
 body:
-  - type: dropdown
+  - type: input
     id: phase
     attributes:
-      label: Phase
-      description: Which blueprint phase does this work belong to?
-      options:
-        - Phase 1 - World/Persona Modeling
-        - Phase 2 - Scenario/Simulation Loop
-        - Phase 3 - Eval/UI/Demo
-        - Phase 4 - Review Workflow and Ops Hardening
+      label: Phase / Milestone
+      description: Enter the active GitHub milestone title for this work item.
+      placeholder: Phase 5 - Review Sign-off and Evidence Packaging
     validations:
       required: true
   - type: dropdown

--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -15,6 +15,10 @@
     {
       "title": "Phase 4 - Review Workflow and Ops Hardening",
       "description": "Restart the GitHub execution queue, harden successor-phase automation, and upgrade the workbench into a review workflow without expanding core simulation/report contracts."
+    },
+    {
+      "title": "Phase 5 - Review Sign-off and Evidence Packaging",
+      "description": "Turn the Phase 4 review workflow into a usable sign-off flow, package review output for handoff, and remove repeated successor-queue bootstrap friction without expanding simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -37,6 +41,11 @@
       "name": "phase:4",
       "color": "8a63d2",
       "description": "Phase 4 review workflow and ops hardening work."
+    },
+    {
+      "name": "phase:5",
+      "color": "5319e7",
+      "description": "Phase 5 review sign-off and evidence packaging work."
     },
     {
       "name": "area:backend",
@@ -184,6 +193,63 @@
         "lane:auto-safe"
       ],
       "body": "## goal\nAdd a baseline/intervention trace timeline in the workbench so reviewers can compare branch evolution turn by turn using existing run artifacts.\n\n## input\n- `artifacts/demo/run/baseline/run_trace.jsonl`\n- `artifacts/demo/run/reporter_detained/run_trace.jsonl`\n- `artifacts/demo/run/*/snapshots/*.json`\n- `artifacts/demo/report/claims.json`\n- current workbench frontend\n\n## output\n- reviewer-readable branch timeline and turn comparison view\n- timeline links that connect related claim turns to baseline/intervention run context\n- no new derived artifact files and no simulation output changes in the first slice\n\n## out-of-scope\n- changing simulation semantics\n- adding new backend endpoints or new persistent artifact formats\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n\n## touches contract\nNo. This issue must remain a UI-only consumer of existing run artifacts.\n\n## phase\nPhase 4"
+    },
+    {
+      "title": "Phase 5 exit gate",
+      "milestone": "Phase 5 - Review Sign-off and Evidence Packaging",
+      "labels": [
+        "phase:5",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nConfirm that the Phase 5 review sign-off and evidence packaging criteria are satisfied before the automation system advances again.\n\n## input\n- Phase 5 milestone state\n- merged PR state for review sign-off workflow and evidence packaging work\n- local validation commands and reviewed artifacts\n\n## output\n- explicit Phase 5 closeout decision\n- documented stop condition for the Phase 5 queue\n- gap issues if any execution issue remains incomplete\n\n## out-of-scope\n- opening the next successor milestone before Phase 5 completion\n- simulation, report, claim, evidence, scenario, or artifact contract expansion\n\n## minimal test\n- `./make.ps1 smoke`\n- `./make.ps1 test`\n- `./make.ps1 eval-demo`\n- `python -m backend.app.cli audit-phase phase3`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. Exit gating controls whether the automation queue may advance.\n\n## phase\nPhase 5"
+    },
+    {
+      "title": "Phase 5: decouple successor bootstrap from hardcoded phase templates and sync queue docs",
+      "milestone": "Phase 5 - Review Sign-off and Evidence Packaging",
+      "labels": [
+        "phase:5",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nRemove repeated successor-phase bootstrap friction by decoupling phase handling from hardcoded issue form/template enumerations and syncing the queue docs to the new active Phase 5 state.\n\n## input\n- `.github/ISSUE_TEMPLATE/work-item.yml`\n- `.github/ISSUE_TEMPLATE/phase-exit.yml`\n- `.github/automation/bootstrap-spec.json`\n- queue state docs under `docs/plans/`\n- current `audit-github-queue` behavior\n\n## output\n- issue/template handling no longer requires a manual hardcoded phase dropdown patch for each successor phase\n- bootstrap metadata and queue docs aligned with Phase 5 as the only active execution milestone\n- protected-core governance note for how future phases should be introduced\n\n## out-of-scope\n- simulation, report, claim, evidence, scenario, or artifact contract changes\n- new frontend review features\n\n## minimal test\n- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`\n- `python -m backend.app.cli classify-lane --files .github/ISSUE_TEMPLATE/work-item.yml .github/ISSUE_TEMPLATE/phase-exit.yml .github/automation/bootstrap-spec.json docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`\n- `./make.ps1 test`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. This work changes queue governance and external GitHub intake behavior.\n\n## phase\nPhase 5"
+    },
+    {
+      "title": "Phase 5: add reviewer scorecard and sign-off worksheet in the workbench",
+      "milestone": "Phase 5 - Review Sign-off and Evidence Packaging",
+      "labels": [
+        "phase:5",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nTurn the static human review rubric into an actionable reviewer scorecard and sign-off worksheet inside the workbench.\n\n## input\n- `docs/rubrics/human-review.md`\n- `artifacts/demo/report/claims.json`\n- `artifacts/demo/eval/summary.json`\n- `artifacts/demo/run/*/run_trace.jsonl`\n- current `frontend/src/app/page.tsx`\n\n## output\n- reviewer-facing 1-5 score controls for Usefulness, Credibility, Explainability, and Actionability\n- sign-off worksheet summary and reviewer notes region generated directly in the workbench\n- frontend-only derived state that still consumes existing artifacts unchanged\n\n## out-of-scope\n- backend APIs, persistent reviewer storage, or new artifact files\n- changes to report schema, claim labels, or evidence semantics\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that worksheet text updates when rubric scores change\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 5"
+    },
+    {
+      "title": "Phase 5: add shareable review packet export from claims, timeline, and rubric",
+      "milestone": "Phase 5 - Review Sign-off and Evidence Packaging",
+      "labels": [
+        "phase:5",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a shareable review packet export so a reviewer can package claims, divergent turns, eval summary, and rubric context into a reusable handoff artifact without leaving the workbench.\n\n## input\n- `artifacts/demo/report/claims.json`\n- `artifacts/demo/run/baseline/run_trace.jsonl`\n- `artifacts/demo/run/reporter_detained/run_trace.jsonl`\n- `artifacts/demo/eval/summary.json`\n- `docs/rubrics/human-review.md`\n- current workbench frontend\n\n## output\n- a copyable Markdown review packet derived entirely in the frontend\n- exported content that includes claim IDs, turn IDs, rubric dimensions, and current summary context\n- no backend export endpoint and no new persistent artifact format in this slice\n\n## out-of-scope\n- posting directly to GitHub\n- changing report or trace schemas\n- generating new saved files under `artifacts/`\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that exported Markdown includes claim IDs and turn IDs\n\n## touches contract\nNo. This issue must remain a frontend-only consumer of the current artifact tree.\n\n## phase\nPhase 5"
+    },
+    {
+      "title": "Phase 5: codify worktree-based orchestrator pickup and handoff runbook",
+      "milestone": "Phase 5 - Review Sign-off and Evidence Packaging",
+      "labels": [
+        "phase:5",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nCodify the worktree-based orchestrator pickup and handoff runbook so long-running execution no longer depends on oral convention.\n\n## input\n- `docs/plans/automation-roadmap.md`\n- `docs/plans/current-state-baseline.md`\n- `docs/plans/phase-execution-queue.md`\n- active GitHub Phase 5 queue state\n- `audit-github-queue` and phase audit commands\n\n## output\n- `docs/plans/long-running-loop-runbook.md`\n- a documented pickup order for authenticated queue audit, worktree naming, one-writer issue ownership, lane-specific review paths, and post-merge re-audit\n- explicit branch hygiene rules for historical `origin/codex/*` branches\n\n## out-of-scope\n- local automation cards, heartbeat schedules, or cron setup\n- new worktree wrapper scripts\n- simulation, report, or artifact contract changes\n\n## minimal test\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n- `python -m backend.app.cli classify-lane --files docs/plans/long-running-loop-runbook.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`\n- manual review that the runbook can drive pickup -> worktree -> PR -> checkpoint without unstated steps\n\n## touches contract\nYes. This work defines the operational execution surface for long-running queue consumption.\n\n## phase\nPhase 5"
     }
   ]
 }

--- a/.github/workflows/phase0.yml
+++ b/.github/workflows/phase0.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Audit Phase 2
         run: python -m backend.app.cli audit-phase phase2
 
+      - name: Audit Phase 3
+        run: python -m backend.app.cli audit-phase phase3
+
       - name: Upload demo artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -78,3 +81,7 @@ jobs:
       - name: Audit Phase 2
         shell: pwsh
         run: python -m backend.app.cli audit-phase phase2
+
+      - name: Audit Phase 3
+        shell: pwsh
+        run: python -m backend.app.cli audit-phase phase3

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-3 gates, and opened the successor queue as `Phase 4 - Review Workflow and Ops Hardening`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-4 gates, and opened the successor queue as `Phase 5 - Review Sign-off and Evidence Packaging`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -20,11 +20,13 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-3 gates, and op
   - local lane-classification, phase-audit, and GitHub queue-audit commands
   - protected `main` with required status checks and auto-merge for safe-lane PRs
   - a browser workbench that now supports claim -> evidence drill-down and baseline/intervention trace review
+  - a documented worktree-based pickup and handoff path for long-running queue execution
 - GitHub queue state is aligned with the local baseline:
   - Phase 3 exit issue `#4` is closed
   - milestone `Phase 3 - Eval/UI/Demo` is closed
-  - milestone `Phase 4 - Review Workflow and Ops Hardening` is open
-  - Phase 4 queue is initialized through issues `#26-#29`
+  - milestone `Phase 4 - Review Workflow and Ops Hardening` is closed
+  - milestone `Phase 5 - Review Sign-off and Evidence Packaging` is open
+  - Phase 5 queue is initialized through issues `#31-#35`
 
 Local phase audits currently show:
 
@@ -73,12 +75,13 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [docs/plans/automation-roadmap.md](/D:/mirror/docs/plans/automation-roadmap.md): long-running automation bootstrap and operating plan
 - [docs/plans/phase-execution-queue.md](/D:/mirror/docs/plans/phase-execution-queue.md): current phase queue and execution order
 - [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md): current handoff baseline and trusted source-of-truth checks
+- [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md): worktree-based queue pickup, review, and handoff runbook
 - [docs/architecture/contracts.md](/D:/mirror/docs/architecture/contracts.md): durable contracts and assumptions
 - [data/demo/config/world_model.yaml](/D:/mirror/data/demo/config/world_model.yaml): demo world model and persona blueprint
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): active Phase 4 review workflow workbench
+- [frontend](/D:/mirror/frontend): active Phase 5 review sign-off workbench
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -123,8 +126,9 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 3 closeout are complete. Phase 4 is the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 4 closeout are complete. Phase 5 is the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
+- Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/backend/tests/test_automation.py
+++ b/backend/tests/test_automation.py
@@ -66,20 +66,25 @@ def test_audit_github_queue_pauses_without_open_milestone(monkeypatch) -> None:
 
 
 def test_audit_github_queue_ready_with_single_milestone_and_ready_issue(monkeypatch) -> None:
+    milestone_number = 5
+    milestone_title = "Current Active Queue"
+    exit_gate_title = "Current exit gate"
+    ready_title = "Current ready work item"
+
     def fake_gh_json(args: list[str], *, repo_root=None):
         if "milestones?state=open" in args[1]:
-            return [{"number": 4, "title": "Phase 4 - Review Workflow and Ops Hardening"}]
-        if "issues?state=open&milestone=4" in args[1]:
+            return [{"number": milestone_number, "title": milestone_title}]
+        if f"issues?state=open&milestone={milestone_number}" in args[1]:
             return [
                 {
-                    "title": "Phase 4 exit gate",
+                    "title": exit_gate_title,
                     "labels": [
                         {"name": "lane:protected-core"},
                         {"name": "status:blocked"},
                     ],
                 },
                 {
-                    "title": "Phase 4: add claim -> evidence drill-down in the workbench",
+                    "title": ready_title,
                     "labels": [
                         {"name": "status:ready"},
                         {"name": "lane:auto-safe"},
@@ -91,15 +96,15 @@ def test_audit_github_queue_ready_with_single_milestone_and_ready_issue(monkeypa
     monkeypatch.setattr("backend.app.automation.service._gh_json", fake_gh_json)
     audit = audit_github_queue("YSCJRH/mirror-sim")
     assert audit.status == "ready"
-    assert audit.active_milestone == "Phase 4 - Review Workflow and Ops Hardening"
+    assert audit.active_milestone == milestone_title
 
 
 def test_audit_github_queue_fails_with_multiple_open_milestones(monkeypatch) -> None:
     def fake_gh_json(args: list[str], *, repo_root=None):
         assert "milestones?state=open" in args[1]
         return [
-            {"number": 4, "title": "Phase 4 - Review Workflow and Ops Hardening"},
-            {"number": 5, "title": "Phase 5 - Placeholder"},
+            {"number": 4, "title": "Active Queue A"},
+            {"number": 5, "title": "Active Queue B"},
         ]
 
     monkeypatch.setattr("backend.app.automation.service._gh_json", fake_gh_json)

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -85,12 +85,13 @@ def test_cli_audit_phase_outputs_json(tmp_path: Path, capsys) -> None:
 
 
 def test_cli_audit_github_queue_outputs_json(monkeypatch, capsys) -> None:
+    milestone_title = "Current Active Queue"
     monkeypatch.setattr(
         "backend.app.cli.audit_github_queue",
         lambda repo, repo_root=None: GitHubQueueAudit(
             repo=repo,
             status="ready",
-            active_milestone="Phase 4 - Review Workflow and Ops Hardening",
+            active_milestone=milestone_title,
             checks=[AuditCheck(name="single_open_milestone", passed=True, details="ok")],
             failures=[],
             notes=["ok"],
@@ -99,7 +100,7 @@ def test_cli_audit_github_queue_outputs_json(monkeypatch, capsys) -> None:
     assert main(["audit-github-queue", "--repo", "YSCJRH/mirror-sim"]) == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "ready"
-    assert payload["active_milestone"] == "Phase 4 - Review Workflow and Ops Hardening"
+    assert payload["active_milestone"] == milestone_title
 
 
 def test_safety_blocks_redline_payload() -> None:

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete.
+Day 0 bootstrap is complete and the repo-first Phase 5 closure is now the active track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -14,10 +14,13 @@ Day 0 bootstrap is complete.
 - Phase 1 and Phase 2 gates are closed.
 - Phase 3 is closed locally and in GitHub.
 - Phase 3 exit issue `#4` is closed and milestone `Phase 3 - Eval/UI/Demo` is closed.
-- Phase 4 is the active successor queue.
-- milestone `Phase 4 - Review Workflow and Ops Hardening` is open.
-- The Phase 4 queue is initialized through issues `#26-#29`.
+- Phase 4 is closed locally and in GitHub.
+- Phase 4 exit issue `#26` is closed and milestone `Phase 4 - Review Workflow and Ops Hardening` is closed.
+- Phase 5 is the active successor queue.
+- milestone `Phase 5 - Review Sign-off and Evidence Packaging` is open.
+- The Phase 5 queue is initialized through issues `#31-#35`.
 - Builder state should now be derived from `audit-github-queue`, not from doc-only convention.
+- The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 
 ## Day 0 Bootstrap
 
@@ -67,8 +70,5 @@ Before builder automation is allowed to write code or auto-merge:
 - Path hits under that policy force `lane:protected-core`.
 - Protected-core PRs may be automated, but they must not auto-merge.
 - Any open `status:needs-adr` or `risk:safety` label blocks auto-merge.
-
-## TODO[verify]
-
-- TODO[verify]: Codex cron automations should target worktrees, not the current dirty `main` checkout.
-- TODO[verify]: after the initial Phase 4 implementation issues land, decide whether `Phase 4 exit gate` should remain blocked for a final closeout PR or close directly from reviewed artifact evidence.
+- Long-running execution must run from isolated worktrees rather than the current `main` checkout.
+- Queue pickup order, one-writer ownership, and branch hygiene should follow `docs/plans/long-running-loop-runbook.md`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current successor-queue baseline after the Phase 4 kickoff.
+This note is the current successor-queue baseline after the Phase 5 repo-first kickoff.
 
 ## Snapshot
 
@@ -20,11 +20,15 @@ This note is the current successor-queue baseline after the Phase 4 kickoff.
   - `gh api repos/YSCJRH/mirror-sim/milestones/3`
     - milestone `Phase 3 - Eval/UI/Demo` is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/4`
-    - milestone `Phase 4 - Review Workflow and Ops Hardening` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=4"`
-    - Phase 4 queue is initialized through issues `#26-#29`
+    - milestone `Phase 4 - Review Workflow and Ops Hardening` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/26`
+    - Phase 4 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/5`
+    - milestone `Phase 5 - Review Sign-off and Evidence Packaging` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=5"`
+    - Phase 5 queue is initialized through issues `#31-#35`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue reports `ready` while open ready work items remain under the active milestone, and `paused` once only the blocked exit gate remains
+    - successor queue currently reports `ready` for the active Phase 5 milestone because one blocked protected exit gate and multiple ready work items are present
 
 ## Trusted Source Of Truth
 
@@ -32,18 +36,21 @@ This note is the current successor-queue baseline after the Phase 4 kickoff.
 - Local phase audits remain the contract-aligned source of truth for whether the current repo state is runnable and reviewable.
 - `audit-github-queue` is the executable local rule for whether builder automation should remain `paused` or can resume against the successor queue.
 - `backlog/sprint-01.md` is historical seed material only and should not be used as the live queue.
-- Remote `origin/codex/*` branches should be treated as historical and superseded by `main` unless a future issue explicitly revives one.
+- Remote `origin/codex/*` branches are historical and superseded by `main`.
+- Delete a historical remote branch once it is tied only to merged or closed work and no open issue, PR, or runbook step still references it.
+- Keep a historical remote branch only when an open issue or unresolved forensic comparison explicitly names it.
+- Revive a historical remote branch only by opening a new issue that states why `main` is insufficient.
 
 ## Current Main Capabilities
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
 - The workbench now also supports claim -> evidence drill-down and baseline/intervention trace review without introducing backend API expansion.
-- The current repository state is in an active Phase 4 successor queue, not a post-Phase-3 idle handoff.
+- The current repository state is in an active Phase 5 successor queue, not a post-Phase-4 idle handoff.
 
 ## Next Entry Point
 
-- Phase 4 is the active milestone and the first execution slice is tracked by issues `#26-#29`.
-- New implementation work should attach to the existing Phase 4 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- Phase 5 is the active milestone and the current repo-first slice is tracked by issues `#31-#35`.
+- New implementation work should attach to the existing Phase 5 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
-- TODO[verify]: delete or archive the superseded remote `codex/*` branches during the next repository cleanup window.
+- `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.

--- a/docs/plans/long-running-loop-runbook.md
+++ b/docs/plans/long-running-loop-runbook.md
@@ -1,0 +1,65 @@
+# Long-Running Loop Runbook
+
+This runbook defines the manual, worktree-based pickup and handoff flow for consuming the live GitHub queue without relying on oral convention.
+
+## Preconditions
+
+- Run the loop from an authenticated `gh` context with access to `YSCJRH/mirror-sim`.
+- Use `main` only as the clean coordination checkout.
+- Treat GitHub milestone and issue state as the operational source of truth.
+- Treat local phase audits and `audit-github-queue` as the executable go/no-go checks.
+
+## Pickup Order
+
+1. Run `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`.
+2. Confirm the queue reports `ready` and identifies exactly one active milestone.
+3. Read the open issues under that active milestone.
+4. Pick the earliest open `status:ready` issue in that milestone.
+5. Confirm whether the issue is `lane:auto-safe` or `lane:protected-core` before writing code.
+
+If `audit-github-queue` reports `paused`, stop and do not invent new work outside the active milestone.
+
+## Worktree Rules
+
+- Create one dedicated worktree per issue.
+- Name the worktree `wt/<phase>-<topic>`.
+- Allow only one writer worktree to own a given issue at a time.
+- Keep docs-only or evaluation-only parallel work in separate worktrees or threads; do not use multiple writers against the same protected-core surface.
+- After a merge, return to the clean coordination checkout before picking the next issue.
+
+## PR And Merge Paths
+
+`lane:auto-safe`
+- Open a PR once checks are ready.
+- Allow auto-merge only when required checks are green and no blocking labels are present.
+- Re-run local smoke, test, and eval checks if the change touched the workbench or demo artifact readers.
+
+`lane:protected-core`
+- Open a PR with explicit protected-core framing.
+- Do not auto-merge.
+- Require an explicit review pass on queue governance, templates, contracts, or operating docs before merge.
+- Re-run local phase audits in addition to smoke, test, and eval checks when the change touches queue governance, CI, or runbook logic.
+
+## Post-Merge Checkpoint
+
+Immediately after each merge:
+
+1. Run `./make.ps1 smoke`
+2. Run `./make.ps1 test`
+3. Run `./make.ps1 eval-demo`
+4. Run `python -m backend.app.cli audit-phase phase1`
+5. Run `python -m backend.app.cli audit-phase phase2`
+6. Run `python -m backend.app.cli audit-phase phase3`
+7. Run authenticated `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
+8. Confirm the merged issue is closed or otherwise updated in GitHub.
+
+If the queue becomes `fail`, stop pickup and repair the milestone, exit gate, or label structure before continuing.
+
+## Branch Hygiene
+
+- Treat current `origin/codex/*` branches as historical and superseded by `main`.
+- Delete a historical branch once it is tied only to merged or closed work and no open issue, PR, or runbook step still references it.
+- Keep a historical branch only when an open issue or unresolved forensic comparison explicitly depends on it.
+- Revive a historical branch only through a new issue that names the branch and explains why `main` is insufficient.
+
+This runbook does not create local automation cards, background schedulers, daemon processes, or worktree wrapper scripts. It documents the stable manual loop that future local automation must follow.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,13 +1,14 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 4 queue kickoff.
+This note records the current post-Day-0 execution status for Mirror after the Phase 5 repo-first queue kickoff.
 
 ## Current Gate State
 
 - Phase 1 exit gate: closed
 - Phase 2 exit gate: closed
 - Phase 3 exit gate: closed
-- Phase 4 exit gate: open
+- Phase 4 exit gate: closed
+- Phase 5 exit gate: open
 
 Local phase audits currently report:
 
@@ -28,26 +29,34 @@ Local phase audits currently report:
   - merged via PR `#22`
 - docs sync
   - merged via PR `#23`
+- Phase 4 repo/workbench hardening
+  - merged via PR `#30`
 - Phase 3 exit issue `#4`
   - closed
 - milestone `Phase 3 - Eval/UI/Demo`
   - closed
+- Phase 4 exit issue `#26`
+  - closed
+- milestone `Phase 4 - Review Workflow and Ops Hardening`
+  - closed
 - GitHub remote state
-  - no open issues or pull requests remained after Phase 3 closeout
+  - no open pull requests remain after the Phase 5 queue bootstrap
 
 ## Current Queue
 
-- milestone `Phase 4 - Review Workflow and Ops Hardening` is open.
-- `#26` `Phase 4 exit gate`
+- milestone `Phase 5 - Review Sign-off and Evidence Packaging` is open.
+- `#31` `Phase 5 exit gate`
   - open
-  - blocked until the first implementation slice is reviewed and merged
-- The first Phase 4 execution slice is tracked through:
-  - `#27` `Phase 4: harden successor-milestone bootstrap and builder pause/resume rules`
-  - `#28` `Phase 4: add claim -> evidence drill-down in the workbench`
-  - `#29` `Phase 4: add baseline/intervention trace timeline in the workbench`
+  - blocked until the Phase 5 sign-off and evidence-packaging slice is complete
+- The current Phase 5 execution slice is tracked through:
+  - `#32` `Phase 5: decouple successor bootstrap from hardcoded phase templates and sync queue docs`
+  - `#33` `Phase 5: add reviewer scorecard and sign-off worksheet in the workbench`
+  - `#34` `Phase 5: add shareable review packet export from claims, timeline, and rubric`
+  - `#35` `Phase 5: codify worktree-based orchestrator pickup and handoff runbook`
 - GitHub remains the operational source of truth for the queue.
 - `backlog/sprint-01.md` remains a historical seed backlog only.
 - Successor queue health should be checked with `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`.
+- Worktree pickup and handoff should follow `docs/plans/long-running-loop-runbook.md`.
 
 ## Automation Guidance
 
@@ -55,9 +64,12 @@ Local phase audits currently report:
 - Closed exit-gate issues and milestones should remain archived history, not be reused as active work trackers.
 - Safe-lane PRs may auto-merge once checks are green and no blocking labels are present.
 - Protected-core changes still require explicit review and must not auto-merge.
+- Long-running execution should assign exactly one writer worktree per issue.
 
 ## Historical Branch Status
 
 - The visible `origin/codex/*` branches correspond to closed or merged work.
 - Treat those branches as historical and superseded by `main`, not as an active queue.
-- TODO[verify]: delete or archive the superseded remote branches during the next repository cleanup window.
+- Delete a historical branch when it is tied only to closed or merged work and no open issue, PR, or runbook step references it.
+- Keep a historical branch only when an open issue or unresolved forensic comparison explicitly depends on it.
+- Revive a historical branch only through a new issue that names the branch and explains why `main` is insufficient.


### PR DESCRIPTION
## Summary
- sync the repo source-of-truth from the closed Phase 4 queue to the active Phase 5 queue
- replace hardcoded phase dropdowns with free-text milestone inputs and add the long-running worktree runbook
- extend CI to audit phase3 and make queue audit fixtures phase-agnostic

Closes #32
Closes #35

## Testing
- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`
- `python -m backend.app.cli classify-lane --files .github/ISSUE_TEMPLATE/work-item.yml .github/ISSUE_TEMPLATE/phase-exit.yml .github/automation/bootstrap-spec.json .github/workflows/phase0.yml docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md docs/plans/long-running-loop-runbook.md`
- `./make.ps1 smoke`
- `./make.ps1 test`
- `./make.ps1 eval-demo`
- `python -m backend.app.cli audit-phase phase1`
- `python -m backend.app.cli audit-phase phase2`
- `python -m backend.app.cli audit-phase phase3`
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`

## Notes
- this PR intentionally leaves Phase 5 product work (`#33` and `#34`) plus the blocked exit gate (`#31`) open
- `audit-github-queue` was re-run from an authenticated context because the command depends on live GitHub queue state