### PR TITLE
[codex] Add reviewer scorecard to the Phase 5 workbench

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -342,6 +342,142 @@ code {
   box-shadow: 0 18px 38px rgba(15, 107, 99, 0.1);
 }
 
+.reviewColumns {
+  display: grid;
+  grid-template-columns: 1.45fr 1fr;
+  gap: 18px;
+}
+
+.reviewScoreGrid {
+  display: grid;
+  gap: 14px;
+}
+
+.scoreCard,
+.worksheetCard {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid var(--border);
+}
+
+.scoreAnchors {
+  display: grid;
+  gap: 8px;
+}
+
+.scoreAnchors p,
+.worksheetNotes p,
+.worksheetFollowup p {
+  margin: 0;
+}
+
+.scoreButtons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.scoreButton {
+  min-width: 44px;
+  min-height: 44px;
+  border-radius: 14px;
+  border: 1px solid rgba(15, 107, 99, 0.2);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--accent-strong);
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.scoreButton:hover {
+  border-color: rgba(15, 107, 99, 0.45);
+}
+
+.scoreButtonActive {
+  background: var(--accent);
+  color: #f7fbfa;
+  border-color: var(--accent-strong);
+}
+
+.scoreHint {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.94rem;
+}
+
+.reviewSidebar {
+  display: grid;
+  gap: 18px;
+  align-content: start;
+}
+
+.statusPill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 0.84rem;
+  font-weight: 700;
+  text-transform: lowercase;
+}
+
+.statusPillincomplete {
+  background: rgba(112, 87, 255, 0.12);
+  color: #4f39b8;
+}
+
+.statusPillready {
+  background: rgba(15, 107, 99, 0.14);
+  color: var(--accent-strong);
+}
+
+.statusPillfollowup {
+  background: rgba(191, 120, 72, 0.14);
+  color: #8c4f21;
+}
+
+.statusPillhold {
+  background: rgba(161, 49, 49, 0.14);
+  color: #7c2727;
+}
+
+.worksheetNotes,
+.worksheetFollowup {
+  display: grid;
+  gap: 8px;
+}
+
+.reviewerNotesCard {
+  align-content: start;
+}
+
+.noteLabel {
+  font-weight: 700;
+  color: var(--accent-strong);
+}
+
+.notesField {
+  width: 100%;
+  min-height: 180px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(15, 107, 99, 0.18);
+  background: rgba(255, 255, 255, 0.94);
+  color: var(--ink);
+  font: inherit;
+  line-height: 1.55;
+  resize: vertical;
+}
+
+.notesField:focus {
+  outline: 2px solid rgba(15, 107, 99, 0.2);
+  border-color: rgba(15, 107, 99, 0.45);
+}
+
 .timelineCards {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -446,6 +582,10 @@ code {
   }
 
   .reportGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .reviewColumns {
     grid-template-columns: 1fr;
   }
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 
 export const metadata: Metadata = {
   title: "Mirror Workbench",
-  description: "Phase 4 review workflow workbench for the Fog Harbor demo."
+  description: "Phase 5 review sign-off workbench for the Fog Harbor demo."
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { ReviewScorecard } from "./review-scorecard";
 
 const sections = [
   {
@@ -124,6 +125,13 @@ type SnapshotPayload = {
 };
 
 type ScenarioKey = "baseline" | "reporter_detained";
+
+type RubricRow = {
+  dimension: string;
+  one: string;
+  three: string;
+  five: string;
+};
 
 type RunPayload = {
   key: ScenarioKey;
@@ -273,6 +281,47 @@ function stateHighlights(state: Record<string, unknown> | undefined) {
   });
 }
 
+function parseRubricRows(rubric: string): RubricRow[] {
+  const rows = rubric
+    .split("\n")
+    .filter((line) => line.startsWith("|"))
+    .slice(2)
+    .map((line) => line.split("|").map((cell) => cell.trim()).filter(Boolean))
+    .filter((cells) => cells.length >= 4)
+    .map(([dimension, one, three, five]) => ({ dimension, one, three, five }));
+
+  if (rows.length > 0) {
+    return rows;
+  }
+
+  return [
+    {
+      dimension: "Usefulness",
+      one: "Adds no new understanding",
+      three: "Some useful contrast",
+      five: "Clearly clarifies branch differences"
+    },
+    {
+      dimension: "Credibility",
+      one: "Reads like guesswork",
+      three: "Partly grounded",
+      five: "Evidence boundaries are clear"
+    },
+    {
+      dimension: "Explainability",
+      one: "Hard to trace",
+      three: "Mostly understandable",
+      five: "Easy to replay from trace"
+    },
+    {
+      dimension: "Actionability",
+      one: "No next step is obvious",
+      three: "Some follow-up hints",
+      five: "Clear next engineering/product step"
+    }
+  ];
+}
+
 export default async function Page() {
   const {
     report,
@@ -286,6 +335,7 @@ export default async function Page() {
     interventionRun
   } = await loadWorkbenchData();
 
+  const rubricRows = parseRubricRows(rubric);
   const documentsById = new Map(documents.map((document) => [document.document_id, document]));
   const chunksById = new Map(chunks.map((chunk) => [chunk.chunk_id, chunk]));
   const baselineTurns = buildTurnEntries(baselineRun);
@@ -348,15 +398,15 @@ export default async function Page() {
   return (
     <main className="shell">
       <section className="hero">
-        <p className="eyebrow">Mirror Engine / Phase 4 Review Workflow</p>
+        <p className="eyebrow">Mirror Engine / Phase 5 Review Sign-Off</p>
         <h1>Review the Fog Harbor sandbox with evidence, trace, and branch context in one place.</h1>
         <p className="lede">
-          The workbench now stays artifact-first while adding the missing reviewer path:
-          from claim, to evidence, to branch timeline, without leaving the bounded demo world.
+          The workbench now stays artifact-first while extending the reviewer path:
+          from claim, to evidence, to branch timeline, to a live sign-off worksheet inside the bounded demo world.
         </p>
         <div className="heroMeta">
           <span>Current demo: Fog Harbor East Gate</span>
-          <span>Current phase: review workflow and ops hardening</span>
+          <span>Current phase: review sign-off and evidence packaging</span>
           <span>No backend API expansion required</span>
         </div>
       </section>
@@ -379,13 +429,13 @@ export default async function Page() {
 
       <section className="panel panelAccent">
         <div className="panelHeader">
-          <p className="eyebrow">Phase 4 Slice</p>
-          <h2>The first successor slice stays contract-light and review-heavy.</h2>
+          <p className="eyebrow">Phase 5 Slice</p>
+          <h2>The current successor slice turns review context into sign-off context.</h2>
         </div>
         <ul className="checklist">
           <li>Claim cards now link into their supporting evidence, graph context, and branch turns.</li>
           <li>Baseline and intervention runs now surface as a reviewer-readable turn-by-turn timeline.</li>
-          <li>Everything still reads the existing artifact tree directly, with no backend API expansion.</li>
+          <li>Reviewer scorecards and sign-off worksheets now live on top of the same artifacts, still without backend API expansion.</li>
         </ul>
       </section>
 
@@ -851,6 +901,17 @@ export default async function Page() {
           </article>
         </div>
       </section>
+
+      <ReviewScorecard
+        rubricRows={rubricRows}
+        claimCount={claims.length}
+        divergentTurnCount={timelineRows.filter(({ baseline, intervention }) => (
+          baseline?.turn.action_type !== intervention?.turn.action_type ||
+          baseline?.turn.target_id !== intervention?.turn.target_id
+        )).length}
+        evalName={evalSummary.eval_name}
+        evalStatus={evalSummary.status}
+      />
     </main>
   );
 }

--- a/frontend/src/app/review-scorecard.tsx
+++ b/frontend/src/app/review-scorecard.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useState } from "react";
+
+type RubricRow = {
+  dimension: string;
+  one: string;
+  three: string;
+  five: string;
+};
+
+type ReviewScorecardProps = {
+  rubricRows: RubricRow[];
+  claimCount: number;
+  divergentTurnCount: number;
+  evalName: string;
+  evalStatus: string;
+};
+
+const scoreOptions = [1, 2, 3, 4, 5] as const;
+
+function formatDecisionLabel(score: number | null) {
+  return score === null ? "unscored" : `${score}/5`;
+}
+
+function currentAnchor(row: RubricRow, score: number | null) {
+  if (score === null) {
+    return "Select a score to anchor this worksheet row.";
+  }
+  if (score <= 2) {
+    return row.one;
+  }
+  if (score === 3) {
+    return row.three;
+  }
+  return row.five;
+}
+
+function decisionFromScores(
+  scores: Record<string, number | null>,
+  totalRows: number
+): {
+  label: string;
+  tone: "incomplete" | "ready" | "followup" | "hold";
+  summary: string;
+  average: string;
+} {
+  const selectedScores = Object.values(scores).filter((value): value is number => value !== null);
+  if (selectedScores.length < totalRows) {
+    return {
+      label: "worksheet incomplete",
+      tone: "incomplete",
+      summary: "Finish scoring every rubric dimension before making a sign-off recommendation.",
+      average: "pending"
+    };
+  }
+
+  const average = selectedScores.reduce((sum, value) => sum + value, 0) / selectedScores.length;
+  const minimum = Math.min(...selectedScores);
+
+  if (average >= 4 && minimum >= 3) {
+    return {
+      label: "ready to sign off",
+      tone: "ready",
+      summary: "Evidence boundaries and branch replay look strong enough to move toward sign-off.",
+      average: average.toFixed(1)
+    };
+  }
+
+  if (average >= 3 && minimum >= 2) {
+    return {
+      label: "needs targeted follow-up",
+      tone: "followup",
+      summary: "The review is broadly usable, but at least one rubric dimension still needs focused cleanup before sign-off.",
+      average: average.toFixed(1)
+    };
+  }
+
+  return {
+    label: "hold and revise",
+    tone: "hold",
+    summary: "The current branch still reads as too risky or too hard to replay for sign-off. Rework the weakest dimensions first.",
+    average: average.toFixed(1)
+  };
+}
+
+export function ReviewScorecard({
+  rubricRows,
+  claimCount,
+  divergentTurnCount,
+  evalName,
+  evalStatus
+}: ReviewScorecardProps) {
+  const [scores, setScores] = useState<Record<string, number | null>>(() =>
+    Object.fromEntries(rubricRows.map((row) => [row.dimension, null]))
+  );
+  const [notes, setNotes] = useState("");
+
+  const filledCount = Object.values(scores).filter((value) => value !== null).length;
+  const decision = decisionFromScores(scores, rubricRows.length);
+  const weakDimensions = rubricRows.filter((row) => {
+    const score = scores[row.dimension];
+    return score !== null && score < 3;
+  });
+
+  return (
+    <section className="panel panelAccent">
+      <div className="panelHeader">
+        <p className="eyebrow">Reviewer Sign-Off</p>
+        <h2>Turn the rubric into a live scorecard and a provisional sign-off worksheet.</h2>
+        <p>
+          This worksheet stays frontend-only: it reads the current demo artifacts, accepts reviewer input,
+          and generates a sign-off view without creating new saved files.
+        </p>
+      </div>
+
+      <div className="reviewColumns">
+        <div className="reviewScoreGrid">
+          {rubricRows.map((row) => {
+            const selectedScore = scores[row.dimension];
+            return (
+              <article key={row.dimension} className="scoreCard">
+                <div className="claimHeader">
+                  <strong>{row.dimension}</strong>
+                  <span className="pill">{formatDecisionLabel(selectedScore)}</span>
+                </div>
+                <div className="scoreAnchors">
+                  <p>
+                    <strong>1</strong>: {row.one}
+                  </p>
+                  <p>
+                    <strong>3</strong>: {row.three}
+                  </p>
+                  <p>
+                    <strong>5</strong>: {row.five}
+                  </p>
+                </div>
+                <div className="scoreButtons">
+                  {scoreOptions.map((score) => (
+                    <button
+                      key={score}
+                      type="button"
+                      className={`scoreButton${selectedScore === score ? " scoreButtonActive" : ""}`}
+                      onClick={() =>
+                        setScores((current) => ({
+                          ...current,
+                          [row.dimension]: score
+                        }))
+                      }
+                    >
+                      {score}
+                    </button>
+                  ))}
+                </div>
+                <p className="scoreHint">{currentAnchor(row, selectedScore)}</p>
+              </article>
+            );
+          })}
+        </div>
+
+        <div className="reviewSidebar">
+          <article className="worksheetCard">
+            <div className="artifactMeta">
+              <span>worksheet</span>
+              <code>{filledCount}/{rubricRows.length} dimensions scored</code>
+            </div>
+            <div className="claimHeader">
+              <strong>Provisional decision</strong>
+              <span className={`statusPill statusPill${decision.tone}`}>
+                {decision.label}
+              </span>
+            </div>
+            <p>{decision.summary}</p>
+
+            <div className="metricGrid">
+              <div className="metricCard">
+                <span>eval</span>
+                <strong>{evalStatus}</strong>
+              </div>
+              <div className="metricCard">
+                <span>claims</span>
+                <strong>{claimCount}</strong>
+              </div>
+              <div className="metricCard">
+                <span>divergent turns</span>
+                <strong>{divergentTurnCount}</strong>
+              </div>
+              <div className="metricCard">
+                <span>average</span>
+                <strong>{decision.average}</strong>
+              </div>
+            </div>
+
+            <ul className="checklist compact">
+              <li>Eval source: `{evalName}`</li>
+              {rubricRows.map((row) => (
+                <li key={row.dimension}>
+                  {row.dimension}: {formatDecisionLabel(scores[row.dimension])}
+                </li>
+              ))}
+            </ul>
+
+            <div className="worksheetNotes">
+              <h3>Reviewer notes snapshot</h3>
+              <p>{notes.trim() ? notes : "No reviewer notes captured yet."}</p>
+            </div>
+
+            {weakDimensions.length > 0 ? (
+              <div className="worksheetFollowup">
+                <h3>Follow-up focus</h3>
+                <p>
+                  Revisit: {weakDimensions.map((row) => row.dimension).join(", ")}.
+                </p>
+              </div>
+            ) : null}
+          </article>
+
+          <article className="artifactCard reviewerNotesCard">
+            <div className="artifactMeta">
+              <span>notes</span>
+              <code>reviewer workspace</code>
+            </div>
+            <label className="noteLabel" htmlFor="reviewer-notes">
+              Reviewer notes
+            </label>
+            <textarea
+              id="reviewer-notes"
+              className="notesField"
+              value={notes}
+              onChange={(event) => setNotes(event.target.value)}
+              placeholder="Capture the strongest evidence boundary, the weakest rubric dimension, and whether the branch is ready to sign off."
+            />
+          </article>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add an interactive reviewer scorecard on top of the current Phase 5 workbench artifacts
- generate a live provisional sign-off worksheet and reviewer notes region without any backend API expansion
- update the frontend phase copy from review workflow to review sign-off

Closes #33

## Testing
- `python -m backend.app.cli classify-lane --files frontend/src/app/page.tsx frontend/src/app/review-scorecard.tsx frontend/src/app/globals.css frontend/src/app/layout.tsx`
- `npm.cmd run build --prefix frontend`
- `./make.ps1 smoke`
- `./make.ps1 eval-demo`
- `./make.ps1 test`

## Notes
- the workbench still reads only the existing artifact tree and `docs/rubrics/human-review.md`
- the initial sandboxed `next build` hit the known Windows `spawn EPERM` environment issue; the authenticated rerun outside the sandbox passed cleanly
- the manual worksheet is intentionally not a shareable export yet; that remains in `#34`