### PR TITLE
[codex] Add shareable review packet export

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -455,6 +455,10 @@ code {
   align-content: start;
 }
 
+.packetCard {
+  align-content: start;
+}
+
 .noteLabel {
   font-weight: 700;
   color: var(--accent-strong);
@@ -476,6 +480,38 @@ code {
 .notesField:focus {
   outline: 2px solid rgba(15, 107, 99, 0.2);
   border-color: rgba(15, 107, 99, 0.45);
+}
+
+.packetField {
+  width: 100%;
+  min-height: 260px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(15, 107, 99, 0.18);
+  background: #1f1d1a;
+  color: #f5efe4;
+  font: inherit;
+  line-height: 1.55;
+  resize: vertical;
+}
+
+.actionButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(15, 107, 99, 0.24);
+  background: rgba(255, 255, 255, 0.88);
+  color: var(--accent-strong);
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.actionButton:hover {
+  border-color: rgba(15, 107, 99, 0.45);
+  color: var(--accent);
 }
 
 .timelineCards {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -911,6 +911,23 @@ export default async function Page() {
         )).length}
         evalName={evalSummary.eval_name}
         evalStatus={evalSummary.status}
+        claimPackets={claims.map((claim) => ({
+          claimId: claim.claim_id,
+          text: claim.text,
+          relatedTurnIds: claim.related_turn_ids.filter(Boolean)
+        }))}
+        divergentTurns={timelineRows
+          .filter(({ baseline, intervention }) => (
+            baseline?.turn.action_type !== intervention?.turn.action_type ||
+            baseline?.turn.target_id !== intervention?.turn.target_id
+          ))
+          .map(({ turnIndex, baseline, intervention }) => ({
+            turnIndex,
+            baselineTurnId: baseline?.turn.turn_id ?? null,
+            baselineAction: baseline?.turn.action_type ?? null,
+            interventionTurnId: intervention?.turn.turn_id ?? null,
+            interventionAction: intervention?.turn.action_type ?? null
+          }))}
       />
     </main>
   );

--- a/frontend/src/app/review-scorecard.tsx
+++ b/frontend/src/app/review-scorecard.tsx
@@ -15,6 +15,18 @@ type ReviewScorecardProps = {
   divergentTurnCount: number;
   evalName: string;
   evalStatus: string;
+  claimPackets: Array<{
+    claimId: string;
+    text: string;
+    relatedTurnIds: string[];
+  }>;
+  divergentTurns: Array<{
+    turnIndex: number;
+    baselineTurnId: string | null;
+    baselineAction: string | null;
+    interventionTurnId: string | null;
+    interventionAction: string | null;
+  }>;
 };
 
 const scoreOptions = [1, 2, 3, 4, 5] as const;
@@ -89,12 +101,15 @@ export function ReviewScorecard({
   claimCount,
   divergentTurnCount,
   evalName,
-  evalStatus
+  evalStatus,
+  claimPackets,
+  divergentTurns
 }: ReviewScorecardProps) {
   const [scores, setScores] = useState<Record<string, number | null>>(() =>
     Object.fromEntries(rubricRows.map((row) => [row.dimension, null]))
   );
   const [notes, setNotes] = useState("");
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
 
   const filledCount = Object.values(scores).filter((value) => value !== null).length;
   const decision = decisionFromScores(scores, rubricRows.length);
@@ -102,6 +117,44 @@ export function ReviewScorecard({
     const score = scores[row.dimension];
     return score !== null && score < 3;
   });
+  const packetMarkdown = [
+    "# Mirror Review Packet",
+    "",
+    "## Current Summary",
+    `- Eval: ${evalName} (${evalStatus})`,
+    `- Claims reviewed: ${claimCount}`,
+    `- Divergent turns: ${divergentTurnCount}`,
+    `- Provisional sign-off: ${decision.label}`,
+    `- Scorecard coverage: ${filledCount}/${rubricRows.length} dimensions scored`,
+    "",
+    "## Rubric Scorecard",
+    ...rubricRows.map((row) => `- ${row.dimension}: ${formatDecisionLabel(scores[row.dimension])}`),
+    "",
+    "## Claim Packet",
+    ...claimPackets.flatMap((claim) => [
+      `- ${claim.claimId}: ${claim.text}`,
+      `  - related turns: ${claim.relatedTurnIds.length > 0 ? claim.relatedTurnIds.join(", ") : "none"}`
+    ]),
+    "",
+    "## Divergent Turn Packet",
+    ...(divergentTurns.length > 0
+      ? divergentTurns.map(
+          (turn) =>
+            `- Turn ${turn.turnIndex}: baseline ${turn.baselineTurnId ?? "none"} (${turn.baselineAction ?? "none"}) vs intervention ${turn.interventionTurnId ?? "none"} (${turn.interventionAction ?? "none"})`
+        )
+      : ["- No divergent turns highlighted in the current packet."]),
+    "",
+    "## Rubric Context",
+    ...rubricRows.flatMap((row) => [
+      `- ${row.dimension}`,
+      `  - 1: ${row.one}`,
+      `  - 3: ${row.three}`,
+      `  - 5: ${row.five}`
+    ]),
+    "",
+    "## Reviewer Notes",
+    notes.trim() ? notes : "- No reviewer notes captured yet."
+  ].join("\n");
 
   return (
     <section className="panel panelAccent">
@@ -230,6 +283,42 @@ export function ReviewScorecard({
               onChange={(event) => setNotes(event.target.value)}
               placeholder="Capture the strongest evidence boundary, the weakest rubric dimension, and whether the branch is ready to sign off."
             />
+          </article>
+
+          <article className="artifactCard packetCard">
+            <div className="artifactMeta">
+              <span>packet</span>
+              <code>frontend-derived markdown</code>
+            </div>
+            <div className="claimHeader">
+              <strong>Shareable review packet</strong>
+              <button
+                type="button"
+                className="actionButton"
+                onClick={async () => {
+                  try {
+                    await navigator.clipboard.writeText(packetMarkdown);
+                    setCopyState("copied");
+                  } catch {
+                    setCopyState("failed");
+                  }
+                }}
+              >
+                Copy markdown packet
+              </button>
+            </div>
+            <p className="scoreHint">
+              This packet packages claim IDs, divergent turn IDs, rubric context, and the current worksheet summary
+              without creating any new artifact files.
+            </p>
+            <textarea className="packetField" readOnly value={packetMarkdown} />
+            <p className="scoreHint">
+              {copyState === "copied"
+                ? "Packet copied to clipboard."
+                : copyState === "failed"
+                  ? "Clipboard copy failed. You can still copy from the packet field."
+                  : "Use this field as the handoff-ready packet for reviewers or follow-on product work."}
+            </p>
           </article>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a frontend-derived markdown review packet that packages claims, divergent turn IDs, rubric context, and the current worksheet summary
- keep the packet tied to the existing reviewer scorecard state so notes and scores flow into the export without any backend API work
- preserve the current artifact-only workbench contract while making review handoff copyable

Closes #34

## Testing
- `python -m backend.app.cli classify-lane --files frontend/src/app/page.tsx frontend/src/app/review-scorecard.tsx frontend/src/app/globals.css frontend/src/app/layout.tsx`
- `npm.cmd run build --prefix frontend`
- `./make.ps1 smoke`
- `./make.ps1 eval-demo`
- `./make.ps1 test`

## Notes
- the packet is intentionally frontend-derived and does not write files under `artifacts/`
- the exported markdown includes claim IDs, divergent turn IDs, rubric dimensions, and the current worksheet summary
- the sandboxed `next build` again hit the known Windows `spawn EPERM` environment issue; the authenticated rerun outside the sandbox passed cleanly