### PR TITLE
[codex] Close out Phase 5 and document paused baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-4 gates, and opened the successor queue as `Phase 5 - Review Sign-off and Evidence Packaging`.
+The repository has completed Day 0 bootstrap and closed the Phase 1-5 gates. The long-running loop is currently paused until a fresh successor queue is opened in GitHub.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -25,8 +25,9 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-4 gates, and op
   - Phase 3 exit issue `#4` is closed
   - milestone `Phase 3 - Eval/UI/Demo` is closed
   - milestone `Phase 4 - Review Workflow and Ops Hardening` is closed
-  - milestone `Phase 5 - Review Sign-off and Evidence Packaging` is open
-  - Phase 5 queue is initialized through issues `#31-#35`
+  - milestone `Phase 5 - Review Sign-off and Evidence Packaging` is closed
+  - Phase 5 queue was completed through issues `#31-#35`
+  - `audit-github-queue` should now report `paused` until the next successor milestone and exit gate are opened
 
 Local phase audits currently show:
 
@@ -81,7 +82,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): active Phase 5 review sign-off workbench
+- [frontend](/D:/mirror/frontend): Phase 5-complete review sign-off workbench
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -126,9 +127,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 4 closeout are complete. Phase 5 is the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 5 closeout are complete. No execution milestone should be reopened or resumed implicitly.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
+- Builder automation should remain paused until a fresh successor milestone and blocked protected-core exit gate are opened.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete and the repo-first Phase 5 closure is now the active track.
+Day 0 bootstrap is complete and Phase 5 closeout is complete.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -16,10 +16,10 @@ Day 0 bootstrap is complete and the repo-first Phase 5 closure is now the active
 - Phase 3 exit issue `#4` is closed and milestone `Phase 3 - Eval/UI/Demo` is closed.
 - Phase 4 is closed locally and in GitHub.
 - Phase 4 exit issue `#26` is closed and milestone `Phase 4 - Review Workflow and Ops Hardening` is closed.
-- Phase 5 is the active successor queue.
-- milestone `Phase 5 - Review Sign-off and Evidence Packaging` is open.
-- The Phase 5 queue is initialized through issues `#31-#35`.
-- Builder state should now be derived from `audit-github-queue`, not from doc-only convention.
+- Phase 5 is closed locally and in GitHub.
+- Phase 5 exit issue `#31` is closed and milestone `Phase 5 - Review Sign-off and Evidence Packaging` is closed.
+- The Phase 5 queue was completed through issues `#31-#35`.
+- Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 
 ## Day 0 Bootstrap
@@ -72,3 +72,4 @@ Before builder automation is allowed to write code or auto-merge:
 - Any open `status:needs-adr` or `risk:safety` label blocks auto-merge.
 - Long-running execution must run from isolated worktrees rather than the current `main` checkout.
 - Queue pickup order, one-writer ownership, and branch hygiene should follow `docs/plans/long-running-loop-runbook.md`.
+- When no open milestone exists, the correct queue state is `paused`, and the next action is to open a fresh successor milestone plus a blocked protected-core exit gate before resuming builder automation.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current successor-queue baseline after the Phase 5 repo-first kickoff.
+This note is the current post-Phase-5 paused baseline.
 
 ## Snapshot
 
@@ -24,11 +24,11 @@ This note is the current successor-queue baseline after the Phase 5 repo-first k
   - `gh api repos/YSCJRH/mirror-sim/issues/26`
     - Phase 4 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/5`
-    - milestone `Phase 5 - Review Sign-off and Evidence Packaging` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=5"`
-    - Phase 5 queue is initialized through issues `#31-#35`
+    - milestone `Phase 5 - Review Sign-off and Evidence Packaging` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/31`
+    - Phase 5 exit issue is `closed`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` for the active Phase 5 milestone because one blocked protected exit gate and multiple ready work items are present
+    - successor queue should now report `paused` because no open milestone is available for pickup yet
 
 ## Trusted Source Of Truth
 
@@ -45,12 +45,12 @@ This note is the current successor-queue baseline after the Phase 5 repo-first k
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
-- The workbench now also supports claim -> evidence drill-down and baseline/intervention trace review without introducing backend API expansion.
-- The current repository state is in an active Phase 5 successor queue, not a post-Phase-4 idle handoff.
+- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, and shareable review packet export without introducing backend API expansion.
+- The current repository state is a paused post-Phase-5 baseline, not an active successor queue.
 
 ## Next Entry Point
 
-- Phase 5 is the active milestone and the current repo-first slice is tracked by issues `#31-#35`.
-- New implementation work should attach to the existing Phase 5 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- No execution milestone is currently open for pickup.
+- The next implementation work must begin by opening a fresh successor milestone and its blocked protected-core exit gate before any new ready issues are introduced.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 5 repo-first queue kickoff.
+This note records the current post-Day-0 execution status for Mirror after the Phase 5 closeout.
 
 ## Current Gate State
 
@@ -8,7 +8,7 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 2 exit gate: closed
 - Phase 3 exit gate: closed
 - Phase 4 exit gate: closed
-- Phase 5 exit gate: open
+- Phase 5 exit gate: closed
 
 Local phase audits currently report:
 
@@ -39,16 +39,17 @@ Local phase audits currently report:
   - closed
 - milestone `Phase 4 - Review Workflow and Ops Hardening`
   - closed
+- Phase 5 exit issue `#31`
+  - closed
+- milestone `Phase 5 - Review Sign-off and Evidence Packaging`
+  - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 5 queue bootstrap
+  - no open pull requests remain after the Phase 5 closeout
 
 ## Current Queue
 
-- milestone `Phase 5 - Review Sign-off and Evidence Packaging` is open.
-- `#31` `Phase 5 exit gate`
-  - open
-  - blocked until the Phase 5 sign-off and evidence-packaging slice is complete
-- The current Phase 5 execution slice is tracked through:
+- No execution milestone is currently open.
+- The completed Phase 5 slice was tracked through:
   - `#32` `Phase 5: decouple successor bootstrap from hardcoded phase templates and sync queue docs`
   - `#33` `Phase 5: add reviewer scorecard and sign-off worksheet in the workbench`
   - `#34` `Phase 5: add shareable review packet export from claims, timeline, and rubric`
@@ -65,6 +66,7 @@ Local phase audits currently report:
 - Safe-lane PRs may auto-merge once checks are green and no blocking labels are present.
 - Protected-core changes still require explicit review and must not auto-merge.
 - Long-running execution should assign exactly one writer worktree per issue.
+- When `audit-github-queue` reports `paused` because no open milestone exists, open the next successor queue before resuming builder pickup.
 
 ## Historical Branch Status
 


### PR DESCRIPTION
## Summary
- sync README and planning docs from an active Phase 5 queue to a completed Phase 5 closeout baseline
- document that `audit-github-queue` should now be `paused` until a fresh successor milestone and exit gate are opened
- preserve the worktree runbook as the standing operating surface for the next successor queue

## Testing
- `./make.ps1 smoke`
- `./make.ps1 test`
- `./make.ps1 eval-demo`
- `python -m backend.app.cli audit-phase phase1`
- `python -m backend.app.cli audit-phase phase2`
- `python -m backend.app.cli audit-phase phase3`

## Notes
- this PR prepares the final closeout state for `#31`; the issue and milestone will be closed immediately after merge from the reviewed, merged baseline
- after this merge, `audit-github-queue` should report `paused` until a fresh successor queue is opened