### PR TITLE
[codex] Sync Phase 6 queue truth

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -19,6 +19,10 @@
     {
       "title": "Phase 5 - Review Sign-off and Evidence Packaging",
       "description": "Turn the Phase 4 review workflow into a usable sign-off flow, package review output for handoff, and remove repeated successor-queue bootstrap friction without expanding simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 6 - Automation Activation and Queue Hygiene",
+      "description": "Resume the long-running loop by activating local Codex queue automation on top of the worktree runbook, syncing repo truth to the new queue, and cleaning historical branch noise without changing simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -46,6 +50,11 @@
       "name": "phase:5",
       "color": "5319e7",
       "description": "Phase 5 review sign-off and evidence packaging work."
+    },
+    {
+      "name": "phase:6",
+      "color": "0b7b6c",
+      "description": "Phase 6 automation activation and queue hygiene work."
     },
     {
       "name": "area:backend",
@@ -250,6 +259,53 @@
         "lane:protected-core"
       ],
       "body": "## goal\nCodify the worktree-based orchestrator pickup and handoff runbook so long-running execution no longer depends on oral convention.\n\n## input\n- `docs/plans/automation-roadmap.md`\n- `docs/plans/current-state-baseline.md`\n- `docs/plans/phase-execution-queue.md`\n- active GitHub Phase 5 queue state\n- `audit-github-queue` and phase audit commands\n\n## output\n- `docs/plans/long-running-loop-runbook.md`\n- a documented pickup order for authenticated queue audit, worktree naming, one-writer issue ownership, lane-specific review paths, and post-merge re-audit\n- explicit branch hygiene rules for historical `origin/codex/*` branches\n\n## out-of-scope\n- local automation cards, heartbeat schedules, or cron setup\n- new worktree wrapper scripts\n- simulation, report, or artifact contract changes\n\n## minimal test\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n- `python -m backend.app.cli classify-lane --files docs/plans/long-running-loop-runbook.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`\n- manual review that the runbook can drive pickup -> worktree -> PR -> checkpoint without unstated steps\n\n## touches contract\nYes. This work defines the operational execution surface for long-running queue consumption.\n\n## phase\nPhase 5"
+    },
+    {
+      "title": "Phase 6 exit gate",
+      "milestone": "Phase 6 - Automation Activation and Queue Hygiene",
+      "labels": [
+        "phase:6",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nConfirm that the Phase 6 automation activation and queue hygiene criteria are satisfied before the automation system advances again.\n\n## input\n- Phase 6 milestone state\n- merged PR state for queue sync, automation activation, and branch hygiene work\n- local validation commands and reviewed artifacts\n\n## output\n- explicit Phase 6 closeout decision\n- documented stop condition for the Phase 6 queue\n- gap issues if any execution issue remains incomplete\n\n## out-of-scope\n- opening the next successor milestone before Phase 6 completion\n- simulation, report, claim, evidence, scenario, or artifact contract expansion\n\n## minimal test\n- `./make.ps1 smoke`\n- `./make.ps1 test`\n- `./make.ps1 eval-demo`\n- `python -m backend.app.cli audit-phase phase3`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. Exit gating controls whether the automation queue may advance.\n\n## phase\nPhase 6"
+    },
+    {
+      "title": "Phase 6: sync bootstrap spec and docs to the active automation queue",
+      "milestone": "Phase 6 - Automation Activation and Queue Hygiene",
+      "labels": [
+        "phase:6",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nSync the repository source of truth from the paused post-Phase-5 baseline to the active Phase 6 queue so docs, bootstrap metadata, and README reflect the newly resumed long-running loop.\n\n## input\n- `.github/automation/bootstrap-spec.json`\n- `README.md`\n- `docs/plans/automation-roadmap.md`\n- `docs/plans/current-state-baseline.md`\n- `docs/plans/phase-execution-queue.md`\n- current live GitHub milestone and issue state\n\n## output\n- `phase:6` and Phase 6 queue objects recorded in the bootstrap spec\n- README and planning docs updated to show Phase 6 as the active successor queue\n- no stale Phase 5 paused-baseline language remains in the active-state docs\n\n## out-of-scope\n- local automation card creation\n- remote branch deletion\n- simulation, report, or artifact contract changes\n\n## minimal test\n- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`\n- `python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`\n- `./make.ps1 test`\n- authenticated `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. This work changes the active operational GitHub queue truth surface.\n\n## phase\nPhase 6"
+    },
+    {
+      "title": "Phase 6: define and activate local Codex queue heartbeat against the worktree runbook",
+      "milestone": "Phase 6 - Automation Activation and Queue Hygiene",
+      "labels": [
+        "phase:6",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nDefine and activate the first local Codex queue heartbeat against the worktree runbook so the long-running loop can resume from a real recurring operator surface instead of a doc-only manual path.\n\n## input\n- `docs/plans/long-running-loop-runbook.md`\n- `docs/plans/automation-roadmap.md`\n- current authenticated `audit-github-queue` behavior\n- current Codex desktop automation capabilities\n\n## output\n- one documented local automation configuration for queue heartbeat / pickup review\n- operator instructions for pause, resume, and failure handling\n- no repo scheduler code and no daemon process inside the repository\n\n## out-of-scope\n- simulation/report/artifact contract changes\n- branch deletion\n- backend service endpoints for automation state\n\n## minimal test\n- manual verification that the automation definition points at the correct workspace and queue audit command\n- authenticated `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. This work changes the live execution posture of the long-running loop.\n\n## phase\nPhase 6"
+    },
+    {
+      "title": "Phase 6: classify and clean superseded remote codex branches",
+      "milestone": "Phase 6 - Automation Activation and Queue Hygiene",
+      "labels": [
+        "phase:6",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nApply the documented branch hygiene rules to the visible historical `origin/codex/*` branches so the resumed queue is not obscured by stale remote branch noise.\n\n## input\n- `docs/plans/long-running-loop-runbook.md`\n- `docs/plans/current-state-baseline.md`\n- current remote branch inventory\n- current open issues and PR state\n\n## output\n- a classified inventory of historical remote branches\n- deletion of clearly superseded remote branches that are no longer referenced by open work\n- an explicit keep/revive note for any branches that must remain\n\n## out-of-scope\n- reopening historical work without a new issue\n- deleting branches that are still tied to open work or unresolved forensic comparison\n- simulation/report/artifact contract changes\n\n## minimal test\n- `git branch -r`\n- `gh api repos/YSCJRH/mirror-sim/branches?per_page=100`\n- manual verification that no kept branch is still undocumented\n\n## touches contract\nYes. This work changes the operational GitHub hygiene surface for the long-running loop.\n\n## phase\nPhase 6"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap and closed the Phase 1-5 gates. The long-running loop is currently paused until a fresh successor queue is opened in GitHub.
+The repository has completed Day 0 bootstrap, closed the Phase 1-5 gates, and resumed the successor queue as `Phase 6 - Automation Activation and Queue Hygiene`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -26,8 +26,8 @@ The repository has completed Day 0 bootstrap and closed the Phase 1-5 gates. The
   - milestone `Phase 3 - Eval/UI/Demo` is closed
   - milestone `Phase 4 - Review Workflow and Ops Hardening` is closed
   - milestone `Phase 5 - Review Sign-off and Evidence Packaging` is closed
-  - Phase 5 queue was completed through issues `#31-#35`
-  - `audit-github-queue` should now report `paused` until the next successor milestone and exit gate are opened
+  - milestone `Phase 6 - Automation Activation and Queue Hygiene` is open
+  - Phase 6 queue is initialized through issues `#40-#43`
 
 Local phase audits currently show:
 
@@ -82,7 +82,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): Phase 5-complete review sign-off workbench
+- [frontend](/D:/mirror/frontend): Phase 5-complete review sign-off workbench with the current Phase 6 automation queue still consuming the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -127,10 +127,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 5 closeout are complete. No execution milestone should be reopened or resumed implicitly.
+- Day 0 bootstrap and Phase 5 closeout are complete. Phase 6 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- Builder automation should remain paused until a fresh successor milestone and blocked protected-core exit gate are opened.
+- Builder automation may resume only against the Phase 6 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete and Phase 5 closeout is complete.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, and Phase 6 is now the active queue-resumption track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -19,6 +19,9 @@ Day 0 bootstrap is complete and Phase 5 closeout is complete.
 - Phase 5 is closed locally and in GitHub.
 - Phase 5 exit issue `#31` is closed and milestone `Phase 5 - Review Sign-off and Evidence Packaging` is closed.
 - The Phase 5 queue was completed through issues `#31-#35`.
+- Phase 6 is the active successor queue.
+- milestone `Phase 6 - Automation Activation and Queue Hygiene` is open.
+- The Phase 6 queue is initialized through issues `#40-#43`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 
@@ -72,4 +75,4 @@ Before builder automation is allowed to write code or auto-merge:
 - Any open `status:needs-adr` or `risk:safety` label blocks auto-merge.
 - Long-running execution must run from isolated worktrees rather than the current `main` checkout.
 - Queue pickup order, one-writer ownership, and branch hygiene should follow `docs/plans/long-running-loop-runbook.md`.
-- When no open milestone exists, the correct queue state is `paused`, and the next action is to open a fresh successor milestone plus a blocked protected-core exit gate before resuming builder automation.
+- When the active milestone exists and the queue reports `ready`, the builder may resume against that milestone only.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current post-Phase-5 paused baseline.
+This note is the current Phase 6 active-queue baseline.
 
 ## Snapshot
 
@@ -27,8 +27,12 @@ This note is the current post-Phase-5 paused baseline.
     - milestone `Phase 5 - Review Sign-off and Evidence Packaging` is `closed`
   - `gh api repos/YSCJRH/mirror-sim/issues/31`
     - Phase 5 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/6`
+    - milestone `Phase 6 - Automation Activation and Queue Hygiene` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=6"`
+    - Phase 6 queue is initialized through issues `#40-#43`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue should now report `paused` because no open milestone is available for pickup yet
+    - successor queue currently reports `ready` because Phase 6 has one blocked protected-core exit gate and multiple ready work items
 
 ## Trusted Source Of Truth
 
@@ -46,11 +50,11 @@ This note is the current post-Phase-5 paused baseline.
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
 - The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, and shareable review packet export without introducing backend API expansion.
-- The current repository state is a paused post-Phase-5 baseline, not an active successor queue.
+- The current repository state is in an active Phase 6 successor queue, not a paused post-Phase-5 idle baseline.
 
 ## Next Entry Point
 
-- No execution milestone is currently open for pickup.
-- The next implementation work must begin by opening a fresh successor milestone and its blocked protected-core exit gate before any new ready issues are introduced.
+- Phase 6 is the active milestone and the current queue-resumption slice is tracked by issues `#40-#43`.
+- New implementation work should attach to the existing Phase 6 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 5 closeout.
+This note records the current post-Day-0 execution status for Mirror after the Phase 6 queue resumption.
 
 ## Current Gate State
 
@@ -9,6 +9,7 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 3 exit gate: closed
 - Phase 4 exit gate: closed
 - Phase 5 exit gate: closed
+- Phase 6 exit gate: open
 
 Local phase audits currently report:
 
@@ -44,11 +45,18 @@ Local phase audits currently report:
 - milestone `Phase 5 - Review Sign-off and Evidence Packaging`
   - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 5 closeout
+  - no open pull requests remain after the Phase 6 queue kickoff
 
 ## Current Queue
 
-- No execution milestone is currently open.
+- milestone `Phase 6 - Automation Activation and Queue Hygiene` is open.
+- `#40` `Phase 6 exit gate`
+  - open
+  - blocked until the Phase 6 automation activation and queue hygiene slice is complete
+- The current Phase 6 execution slice is tracked through:
+  - `#41` `Phase 6: sync bootstrap spec and docs to the active automation queue`
+  - `#42` `Phase 6: define and activate local Codex queue heartbeat against the worktree runbook`
+  - `#43` `Phase 6: classify and clean superseded remote codex branches`
 - The completed Phase 5 slice was tracked through:
   - `#32` `Phase 5: decouple successor bootstrap from hardcoded phase templates and sync queue docs`
   - `#33` `Phase 5: add reviewer scorecard and sign-off worksheet in the workbench`
@@ -66,7 +74,7 @@ Local phase audits currently report:
 - Safe-lane PRs may auto-merge once checks are green and no blocking labels are present.
 - Protected-core changes still require explicit review and must not auto-merge.
 - Long-running execution should assign exactly one writer worktree per issue.
-- When `audit-github-queue` reports `paused` because no open milestone exists, open the next successor queue before resuming builder pickup.
+- When `audit-github-queue` reports `ready`, consume only the currently active milestone and do not parallel-open another execution queue.
 
 ## Historical Branch Status
 


### PR DESCRIPTION
## Summary
- sync the repository source of truth from the paused post-Phase-5 baseline to the active Phase 6 queue
- add Phase 6 milestone, label, and issue definitions to the bootstrap spec
- update README and planning docs so main matches the live successor queue again

Closes #41

## Testing
- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`
- `python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`
- `./make.ps1 test`
- `./make.ps1 smoke`
- `./make.ps1 eval-demo`
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`

## Notes
- Phase 6 objects were opened manually first so the queue could resume from `paused` to `ready`
- the initial parallel `smoke` / `eval-demo` run hit the known shared-artifact snapshot conflict on Windows; the final verification was rerun sequentially and passed
- this PR intentionally leaves `#42`, `#43`, and the blocked exit gate `#40` open as the remaining Phase 6 work