### PR TITLE
[codex] Document paused baseline after Phase 6 closeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-5 gates, and resumed the successor queue as `Phase 6 - Automation Activation and Queue Hygiene`.
+The repository has completed Day 0 bootstrap and closed the Phase 1-6 gates. The long-running loop is currently paused until a fresh successor queue is opened in GitHub.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -26,8 +26,9 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-5 gates, and re
   - milestone `Phase 3 - Eval/UI/Demo` is closed
   - milestone `Phase 4 - Review Workflow and Ops Hardening` is closed
   - milestone `Phase 5 - Review Sign-off and Evidence Packaging` is closed
-  - milestone `Phase 6 - Automation Activation and Queue Hygiene` is open
-  - Phase 6 queue is initialized through issues `#40-#43`
+  - milestone `Phase 6 - Automation Activation and Queue Hygiene` is closed
+  - Phase 6 queue was completed through issues `#40-#43`
+  - the local queue heartbeat remains active, but `audit-github-queue` should now report `paused` until the next successor milestone and exit gate are opened
 
 Local phase audits currently show:
 
@@ -82,7 +83,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): Phase 5-complete review sign-off workbench with the current Phase 6 automation queue still consuming the same artifact surface
+- [frontend](/D:/mirror/frontend): Phase 6-complete review sign-off workbench
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -127,10 +128,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 5 closeout are complete. Phase 6 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 6 closeout are complete. No execution milestone should be reopened or resumed implicitly.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- Builder automation may resume only against the Phase 6 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation may remain active, but builder pickup should stay paused until a fresh successor milestone and blocked protected-core exit gate are opened.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, and Phase 6 is now the active queue-resumption track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, and Phase 6 closeout is complete.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -19,11 +19,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, and Phase 6 is now th
 - Phase 5 is closed locally and in GitHub.
 - Phase 5 exit issue `#31` is closed and milestone `Phase 5 - Review Sign-off and Evidence Packaging` is closed.
 - The Phase 5 queue was completed through issues `#31-#35`.
-- Phase 6 is the active successor queue.
-- milestone `Phase 6 - Automation Activation and Queue Hygiene` is open.
-- The Phase 6 queue is initialized through issues `#40-#43`.
+- Phase 6 is closed locally and in GitHub.
+- Phase 6 exit issue `#40` is closed and milestone `Phase 6 - Automation Activation and Queue Hygiene` is closed.
+- The Phase 6 queue was completed through issues `#40-#43`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
+- The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.
 
 ## Day 0 Bootstrap
 
@@ -75,4 +76,4 @@ Before builder automation is allowed to write code or auto-merge:
 - Any open `status:needs-adr` or `risk:safety` label blocks auto-merge.
 - Long-running execution must run from isolated worktrees rather than the current `main` checkout.
 - Queue pickup order, one-writer ownership, and branch hygiene should follow `docs/plans/long-running-loop-runbook.md`.
-- When the active milestone exists and the queue reports `ready`, the builder may resume against that milestone only.
+- When no open milestone exists, the correct queue state is `paused`; the next action is to open a fresh successor milestone plus a blocked protected-core exit gate before resuming builder automation.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 6 active-queue baseline.
+This note is the current post-Phase-6 paused baseline.
 
 ## Snapshot
 
@@ -28,11 +28,11 @@ This note is the current Phase 6 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/issues/31`
     - Phase 5 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/6`
-    - milestone `Phase 6 - Automation Activation and Queue Hygiene` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=6"`
-    - Phase 6 queue is initialized through issues `#40-#43`
+    - milestone `Phase 6 - Automation Activation and Queue Hygiene` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/40`
+    - Phase 6 exit issue is `closed`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` because Phase 6 has one blocked protected-core exit gate and multiple ready work items
+    - successor queue should now report `paused` because no open milestone is available for pickup yet
 
 ## Trusted Source Of Truth
 
@@ -50,11 +50,12 @@ This note is the current Phase 6 active-queue baseline.
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
 - The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, and shareable review packet export without introducing backend API expansion.
-- The current repository state is in an active Phase 6 successor queue, not a paused post-Phase-5 idle baseline.
+- The current repository state is a paused post-Phase-6 baseline, not an active successor queue.
 
 ## Next Entry Point
 
-- Phase 6 is the active milestone and the current queue-resumption slice is tracked by issues `#40-#43`.
-- New implementation work should attach to the existing Phase 6 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- No execution milestone is currently open for pickup.
+- The next implementation work must begin by opening a fresh successor milestone and its blocked protected-core exit gate before any new ready issues are introduced.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
+- The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 6 queue resumption.
+This note records the current post-Day-0 execution status for Mirror after the Phase 6 closeout.
 
 ## Current Gate State
 
@@ -9,7 +9,7 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 3 exit gate: closed
 - Phase 4 exit gate: closed
 - Phase 5 exit gate: closed
-- Phase 6 exit gate: open
+- Phase 6 exit gate: closed
 
 Local phase audits currently report:
 
@@ -44,16 +44,17 @@ Local phase audits currently report:
   - closed
 - milestone `Phase 5 - Review Sign-off and Evidence Packaging`
   - closed
+- Phase 6 exit issue `#40`
+  - closed
+- milestone `Phase 6 - Automation Activation and Queue Hygiene`
+  - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 6 queue kickoff
+  - no open pull requests remain after the Phase 6 closeout
 
 ## Current Queue
 
-- milestone `Phase 6 - Automation Activation and Queue Hygiene` is open.
-- `#40` `Phase 6 exit gate`
-  - open
-  - blocked until the Phase 6 automation activation and queue hygiene slice is complete
-- The current Phase 6 execution slice is tracked through:
+- No execution milestone is currently open.
+- The completed Phase 6 slice was tracked through:
   - `#41` `Phase 6: sync bootstrap spec and docs to the active automation queue`
   - `#42` `Phase 6: define and activate local Codex queue heartbeat against the worktree runbook`
   - `#43` `Phase 6: classify and clean superseded remote codex branches`
@@ -74,7 +75,7 @@ Local phase audits currently report:
 - Safe-lane PRs may auto-merge once checks are green and no blocking labels are present.
 - Protected-core changes still require explicit review and must not auto-merge.
 - Long-running execution should assign exactly one writer worktree per issue.
-- When `audit-github-queue` reports `ready`, consume only the currently active milestone and do not parallel-open another execution queue.
+- When `audit-github-queue` reports `paused` because no open milestone exists, open the next successor queue before resuming builder pickup.
 
 ## Historical Branch Status
 


### PR DESCRIPTION
## Summary
- sync README and planning docs from an active Phase 6 queue back to the paused post-Phase-6 baseline
- document that the local heartbeat remains active while the live GitHub queue correctly returns `paused`
- preserve the Phase 6 bootstrap objects in history while making the public status text truthful again

## Testing
- `./make.ps1 smoke`
- `./make.ps1 test`
- authenticated `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`

## Notes
- Phase 6 closeout was completed directly in GitHub before this PR, so this PR only repairs the repo-facing status text
- after merge, the repo docs and live queue state should both agree that no successor milestone is currently open