### PR TITLE
[codex] Sync Phase 7 queue truth

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -23,6 +23,10 @@
     {
       "title": "Phase 6 - Automation Activation and Queue Hygiene",
       "description": "Resume the long-running loop by activating local Codex queue automation on top of the worktree runbook, syncing repo truth to the new queue, and cleaning historical branch noise without changing simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 7 - Operator Handoff and Review Delivery",
+      "description": "Turn the resumed queue into a reviewer-to-operator handoff loop by adding GitHub-ready delivery surfaces in the workbench without changing core simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -55,6 +59,11 @@
       "name": "phase:6",
       "color": "0b7b6c",
       "description": "Phase 6 automation activation and queue hygiene work."
+    },
+    {
+      "name": "phase:7",
+      "color": "1f8f99",
+      "description": "Phase 7 operator handoff and review delivery work."
     },
     {
       "name": "area:backend",
@@ -306,6 +315,51 @@
         "lane:protected-core"
       ],
       "body": "## goal\nApply the documented branch hygiene rules to the visible historical `origin/codex/*` branches so the resumed queue is not obscured by stale remote branch noise.\n\n## input\n- `docs/plans/long-running-loop-runbook.md`\n- `docs/plans/current-state-baseline.md`\n- current remote branch inventory\n- current open issues and PR state\n\n## output\n- a classified inventory of historical remote branches\n- deletion of clearly superseded remote branches that are no longer referenced by open work\n- an explicit keep/revive note for any branches that must remain\n\n## out-of-scope\n- reopening historical work without a new issue\n- deleting branches that are still tied to open work or unresolved forensic comparison\n- simulation/report/artifact contract changes\n\n## minimal test\n- `git branch -r`\n- `gh api repos/YSCJRH/mirror-sim/branches?per_page=100`\n- manual verification that no kept branch is still undocumented\n\n## touches contract\nYes. This work changes the operational GitHub hygiene surface for the long-running loop.\n\n## phase\nPhase 6"
+    },
+    {
+      "title": "Phase 7 exit gate",
+      "milestone": "Phase 7 - Operator Handoff and Review Delivery",
+      "labels": [
+        "phase:7",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nConfirm that the Phase 7 operator handoff and review delivery criteria are satisfied before the automation system advances again.\n\n## input\n- Phase 7 milestone state\n- merged PR state for queue sync and review-delivery work\n- local validation commands and reviewed artifacts\n\n## output\n- explicit Phase 7 closeout decision\n- documented stop condition for the Phase 7 queue\n- gap issues if any execution issue remains incomplete\n\n## out-of-scope\n- opening the next successor milestone before Phase 7 completion\n- simulation, report, claim, evidence, scenario, or artifact contract expansion\n\n## minimal test\n- `./make.ps1 smoke`\n- `./make.ps1 test`\n- `./make.ps1 eval-demo`\n- `python -m backend.app.cli audit-phase phase3`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. Exit gating controls whether the automation queue may advance.\n\n## phase\nPhase 7"
+    },
+    {
+      "title": "Phase 7: sync bootstrap spec and docs to the active handoff queue",
+      "milestone": "Phase 7 - Operator Handoff and Review Delivery",
+      "labels": [
+        "phase:7",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nSync the repository source of truth from the paused post-Phase-6 baseline to the active Phase 7 queue so docs, bootstrap metadata, and README reflect the newly resumed handoff loop.\n\n## input\n- `.github/automation/bootstrap-spec.json`\n- `README.md`\n- `docs/plans/automation-roadmap.md`\n- `docs/plans/current-state-baseline.md`\n- `docs/plans/phase-execution-queue.md`\n- current live GitHub milestone and issue state\n\n## output\n- `phase:7` and Phase 7 queue objects recorded in the bootstrap spec\n- README and planning docs updated to show Phase 7 as the active successor queue\n- no stale paused post-Phase-6 language remains in the active-state docs\n\n## out-of-scope\n- local automation card changes\n- simulation, report, or artifact contract changes\n- historical branch deletion\n\n## minimal test\n- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`\n- `python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`\n- `./make.ps1 test`\n- authenticated `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. This work changes the active operational GitHub queue truth surface.\n\n## phase\nPhase 7"
+    },
+    {
+      "title": "Phase 7: add issue-comment-ready review packet sections in the workbench",
+      "milestone": "Phase 7 - Operator Handoff and Review Delivery",
+      "labels": [
+        "phase:7",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nExtend the workbench review packet into an issue-comment-ready handoff surface so an operator can copy a GitHub-ready review brief without reformatting the current packet by hand.\n\n## input\n- current `frontend/src/app/review-scorecard.tsx`\n- current claim packet, divergent turn packet, and reviewer note state\n- existing demo artifacts under `artifacts/demo/**`\n\n## output\n- copyable issue-comment-ready markdown sections in the workbench\n- handoff copy that preserves claim IDs, divergent turn IDs, reviewer notes, and sign-off posture\n- no backend API calls and no persistent artifact writes\n\n## out-of-scope\n- posting directly to GitHub\n- changing report, trace, or rubric contracts\n- introducing repo-side automation logic\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the copied packet reads cleanly as a GitHub issue or PR comment\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 7"
+    },
+    {
+      "title": "Phase 7: add decision brief and next-action handoff panel in the workbench",
+      "milestone": "Phase 7 - Operator Handoff and Review Delivery",
+      "labels": [
+        "phase:7",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a decision brief and next-action handoff panel to the workbench so the reviewer can package a recommended next step, blockers, and sign-off posture for the next operator pickup.\n\n## input\n- current reviewer scorecard and notes state\n- current packet export state\n- existing eval summary and claim/timeline context from the Phase 5 workbench\n\n## output\n- a handoff-focused decision brief panel in the workbench\n- structured next-action / blocker / recommendation sections derived from existing frontend state\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- live GitHub issue mutation\n- simulation, report, rubric, or queue contract changes\n- local automation schedule changes\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the brief can be copied as an operator handoff summary without editing raw JSON\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 7"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap and closed the Phase 1-6 gates. The long-running loop is currently paused until a fresh successor queue is opened in GitHub.
+The repository has completed Day 0 bootstrap, closed the Phase 1-6 gates, and resumed the successor queue as `Phase 7 - Operator Handoff and Review Delivery`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -27,8 +27,8 @@ The repository has completed Day 0 bootstrap and closed the Phase 1-6 gates. The
   - milestone `Phase 4 - Review Workflow and Ops Hardening` is closed
   - milestone `Phase 5 - Review Sign-off and Evidence Packaging` is closed
   - milestone `Phase 6 - Automation Activation and Queue Hygiene` is closed
-  - Phase 6 queue was completed through issues `#40-#43`
-  - the local queue heartbeat remains active, but `audit-github-queue` should now report `paused` until the next successor milestone and exit gate are opened
+  - milestone `Phase 7 - Operator Handoff and Review Delivery` is open
+  - Phase 7 queue is initialized through issues `#46-#49`
 
 Local phase audits currently show:
 
@@ -83,7 +83,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): Phase 6-complete review sign-off workbench
+- [frontend](/D:/mirror/frontend): Phase 6-complete review sign-off workbench with the current Phase 7 handoff queue still consuming the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -128,10 +128,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 6 closeout are complete. No execution milestone should be reopened or resumed implicitly.
+- Day 0 bootstrap and Phase 6 closeout are complete. Phase 7 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may remain active, but builder pickup should stay paused until a fresh successor milestone and blocked protected-core exit gate are opened.
+- The local heartbeat automation may resume pickup guidance only against the Phase 7 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, and Phase 6 closeout is complete.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, and Phase 7 is now the active handoff-delivery track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -22,6 +22,9 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, and Phase 6 closeout 
 - Phase 6 is closed locally and in GitHub.
 - Phase 6 exit issue `#40` is closed and milestone `Phase 6 - Automation Activation and Queue Hygiene` is closed.
 - The Phase 6 queue was completed through issues `#40-#43`.
+- Phase 7 is the active successor queue.
+- milestone `Phase 7 - Operator Handoff and Review Delivery` is open.
+- The Phase 7 queue is initialized through issues `#46-#49`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.
@@ -76,4 +79,4 @@ Before builder automation is allowed to write code or auto-merge:
 - Any open `status:needs-adr` or `risk:safety` label blocks auto-merge.
 - Long-running execution must run from isolated worktrees rather than the current `main` checkout.
 - Queue pickup order, one-writer ownership, and branch hygiene should follow `docs/plans/long-running-loop-runbook.md`.
-- When no open milestone exists, the correct queue state is `paused`; the next action is to open a fresh successor milestone plus a blocked protected-core exit gate before resuming builder automation.
+- When the active milestone exists and the queue reports `ready`, the builder may resume against that milestone only.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current post-Phase-6 paused baseline.
+This note is the current Phase 7 active-queue baseline.
 
 ## Snapshot
 
@@ -31,8 +31,12 @@ This note is the current post-Phase-6 paused baseline.
     - milestone `Phase 6 - Automation Activation and Queue Hygiene` is `closed`
   - `gh api repos/YSCJRH/mirror-sim/issues/40`
     - Phase 6 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/7`
+    - milestone `Phase 7 - Operator Handoff and Review Delivery` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=7"`
+    - Phase 7 queue is initialized through issues `#46-#49`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue should now report `paused` because no open milestone is available for pickup yet
+    - successor queue currently reports `ready` because Phase 7 has one blocked protected-core exit gate and multiple ready work items
 
 ## Trusted Source Of Truth
 
@@ -50,12 +54,12 @@ This note is the current post-Phase-6 paused baseline.
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
 - The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, and shareable review packet export without introducing backend API expansion.
-- The current repository state is a paused post-Phase-6 baseline, not an active successor queue.
+- The current repository state is in an active Phase 7 successor queue, not a paused post-Phase-6 baseline.
 
 ## Next Entry Point
 
-- No execution milestone is currently open for pickup.
-- The next implementation work must begin by opening a fresh successor milestone and its blocked protected-core exit gate before any new ready issues are introduced.
+- Phase 7 is the active milestone and the current operator-handoff slice is tracked by issues `#46-#49`.
+- New implementation work should attach to the existing Phase 7 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
 - The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 6 closeout.
+This note records the current post-Day-0 execution status for Mirror after the Phase 7 queue resumption.
 
 ## Current Gate State
 
@@ -10,6 +10,7 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 4 exit gate: closed
 - Phase 5 exit gate: closed
 - Phase 6 exit gate: closed
+- Phase 7 exit gate: open
 
 Local phase audits currently report:
 
@@ -49,11 +50,18 @@ Local phase audits currently report:
 - milestone `Phase 6 - Automation Activation and Queue Hygiene`
   - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 6 closeout
+  - no open pull requests remain after the Phase 7 queue kickoff
 
 ## Current Queue
 
-- No execution milestone is currently open.
+- milestone `Phase 7 - Operator Handoff and Review Delivery` is open.
+- `#46` `Phase 7 exit gate`
+  - open
+  - blocked until the Phase 7 operator handoff and review delivery slice is complete
+- The current Phase 7 execution slice is tracked through:
+  - `#47` `Phase 7: sync bootstrap spec and docs to the active handoff queue`
+  - `#48` `Phase 7: add issue-comment-ready review packet sections in the workbench`
+  - `#49` `Phase 7: add decision brief and next-action handoff panel in the workbench`
 - The completed Phase 6 slice was tracked through:
   - `#41` `Phase 6: sync bootstrap spec and docs to the active automation queue`
   - `#42` `Phase 6: define and activate local Codex queue heartbeat against the worktree runbook`
@@ -75,7 +83,7 @@ Local phase audits currently report:
 - Safe-lane PRs may auto-merge once checks are green and no blocking labels are present.
 - Protected-core changes still require explicit review and must not auto-merge.
 - Long-running execution should assign exactly one writer worktree per issue.
-- When `audit-github-queue` reports `paused` because no open milestone exists, open the next successor queue before resuming builder pickup.
+- When `audit-github-queue` reports `ready`, consume only the currently active milestone and do not parallel-open another execution queue.
 
 ## Historical Branch Status
 


### PR DESCRIPTION
## Summary
- sync the repository source of truth from the paused post-Phase-6 baseline to the active Phase 7 queue
- add Phase 7 milestone, label, and issue definitions to the bootstrap spec
- update README and planning docs so main matches the live successor queue again

Closes #47

## Testing
- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`
- `python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`
- `./make.ps1 test`
- `./make.ps1 smoke`
- `./make.ps1 eval-demo`
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`

## Notes
- Phase 7 queue objects were opened manually first so the live queue could resume from `paused` to `ready`
- this PR intentionally leaves `#48`, `#49`, and the blocked exit gate `#46` open as the remaining Phase 7 work