### PR TITLE
[codex] Add issue-comment-ready packet sections

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -459,6 +459,16 @@ code {
   align-content: start;
 }
 
+.packetStack {
+  display: grid;
+  gap: 18px;
+}
+
+.packetSection {
+  display: grid;
+  gap: 12px;
+}
+
 .noteLabel {
   font-weight: 700;
   color: var(--accent-strong);
@@ -493,6 +503,10 @@ code {
   font: inherit;
   line-height: 1.55;
   resize: vertical;
+}
+
+.packetFieldCompact {
+  min-height: 220px;
 }
 
 .actionButton {

--- a/frontend/src/app/review-scorecard.tsx
+++ b/frontend/src/app/review-scorecard.tsx
@@ -110,6 +110,7 @@ export function ReviewScorecard({
   );
   const [notes, setNotes] = useState("");
   const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
+  const [issueCommentCopyState, setIssueCommentCopyState] = useState<"idle" | "copied" | "failed">("idle");
 
   const filledCount = Object.values(scores).filter((value) => value !== null).length;
   const decision = decisionFromScores(scores, rubricRows.length);
@@ -151,6 +152,29 @@ export function ReviewScorecard({
       `  - 3: ${row.three}`,
       `  - 5: ${row.five}`
     ]),
+    "",
+    "## Reviewer Notes",
+    notes.trim() ? notes : "- No reviewer notes captured yet."
+  ].join("\n");
+  const issueCommentMarkdown = [
+    "## Review Handoff",
+    `- Provisional sign-off: ${decision.label}`,
+    `- Eval: ${evalName} (${evalStatus})`,
+    `- Scorecard coverage: ${filledCount}/${rubricRows.length} dimensions scored`,
+    "",
+    "## Claims To Carry Forward",
+    ...claimPackets.flatMap((claim) => [
+      `- \`${claim.claimId}\`: ${claim.text}`,
+      `  - related turns: ${claim.relatedTurnIds.length > 0 ? claim.relatedTurnIds.join(", ") : "none"}`
+    ]),
+    "",
+    "## Divergent Turns To Replay",
+    ...(divergentTurns.length > 0
+      ? divergentTurns.map(
+          (turn) =>
+            `- Turn ${turn.turnIndex}: baseline \`${turn.baselineTurnId ?? "none"}\` vs intervention \`${turn.interventionTurnId ?? "none"}\``
+        )
+      : ["- No divergent turns highlighted in the current comparison."]),
     "",
     "## Reviewer Notes",
     notes.trim() ? notes : "- No reviewer notes captured yet."
@@ -290,35 +314,70 @@ export function ReviewScorecard({
               <span>packet</span>
               <code>frontend-derived markdown</code>
             </div>
-            <div className="claimHeader">
-              <strong>Shareable review packet</strong>
-              <button
-                type="button"
-                className="actionButton"
-                onClick={async () => {
-                  try {
-                    await navigator.clipboard.writeText(packetMarkdown);
-                    setCopyState("copied");
-                  } catch {
-                    setCopyState("failed");
-                  }
-                }}
-              >
-                Copy markdown packet
-              </button>
+            <div className="packetStack">
+              <div className="packetSection">
+                <div className="claimHeader">
+                  <strong>Shareable review packet</strong>
+                  <button
+                    type="button"
+                    className="actionButton"
+                    onClick={async () => {
+                      try {
+                        await navigator.clipboard.writeText(packetMarkdown);
+                        setCopyState("copied");
+                      } catch {
+                        setCopyState("failed");
+                      }
+                    }}
+                  >
+                    Copy markdown packet
+                  </button>
+                </div>
+                <p className="scoreHint">
+                  This packet packages claim IDs, divergent turn IDs, rubric context, and the current worksheet summary
+                  without creating any new artifact files.
+                </p>
+                <textarea className="packetField" readOnly value={packetMarkdown} />
+                <p className="scoreHint">
+                  {copyState === "copied"
+                    ? "Packet copied to clipboard."
+                    : copyState === "failed"
+                      ? "Clipboard copy failed. You can still copy from the packet field."
+                      : "Use this field as the handoff-ready packet for reviewers or follow-on product work."}
+                </p>
+              </div>
+
+              <div className="packetSection">
+                <div className="claimHeader">
+                  <strong>Issue comment packet</strong>
+                  <button
+                    type="button"
+                    className="actionButton"
+                    onClick={async () => {
+                      try {
+                        await navigator.clipboard.writeText(issueCommentMarkdown);
+                        setIssueCommentCopyState("copied");
+                      } catch {
+                        setIssueCommentCopyState("failed");
+                      }
+                    }}
+                  >
+                    Copy issue comment
+                  </button>
+                </div>
+                <p className="scoreHint">
+                  This version trims the handoff into GitHub-ready sections so an operator can paste it into an issue or PR comment without reformatting.
+                </p>
+                <textarea className="packetField packetFieldCompact" readOnly value={issueCommentMarkdown} />
+                <p className="scoreHint">
+                  {issueCommentCopyState === "copied"
+                    ? "Issue comment packet copied to clipboard."
+                    : issueCommentCopyState === "failed"
+                      ? "Clipboard copy failed. You can still copy from the packet field."
+                      : "Use this field when the next operator needs a GitHub-comment-ready review handoff."}
+                </p>
+              </div>
             </div>
-            <p className="scoreHint">
-              This packet packages claim IDs, divergent turn IDs, rubric context, and the current worksheet summary
-              without creating any new artifact files.
-            </p>
-            <textarea className="packetField" readOnly value={packetMarkdown} />
-            <p className="scoreHint">
-              {copyState === "copied"
-                ? "Packet copied to clipboard."
-                : copyState === "failed"
-                  ? "Clipboard copy failed. You can still copy from the packet field."
-                  : "Use this field as the handoff-ready packet for reviewers or follow-on product work."}
-            </p>
           </article>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add GitHub issue-comment-ready handoff sections alongside the existing generic review packet
- keep the handoff content derived from the current reviewer scorecard, divergent turns, and notes state without any backend API work
- preserve the existing packet export while making the operator handoff cleaner to paste into GitHub comments

Closes #48

## Testing
- `python -m backend.app.cli classify-lane --files frontend/src/app/review-scorecard.tsx frontend/src/app/globals.css frontend/src/app/page.tsx frontend/src/app/layout.tsx`
- `npm.cmd run build --prefix frontend`
- `./make.ps1 smoke`
- `./make.ps1 eval-demo`
- `./make.ps1 test`

## Notes
- the initial parallel `smoke` / `eval-demo` run hit the known shared-artifact snapshot conflict on Windows; the final verification was rerun sequentially and passed
- the new issue-comment packet is still frontend-derived and does not post to GitHub directly
- `#49` remains the next ready frontend handoff issue