### PR TITLE
[codex] Sync repo truth to Phase 8 queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -27,6 +27,10 @@
     {
       "title": "Phase 7 - Operator Handoff and Review Delivery",
       "description": "Turn the resumed queue into a reviewer-to-operator handoff loop by adding GitHub-ready delivery surfaces in the workbench without changing core simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 8 - Closeout Delivery and Pickup Routing",
+      "description": "Turn the new operator handoff surfaces into exit-gate-ready closeout packets and lane-aware pickup guidance without changing core simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -64,6 +68,11 @@
       "name": "phase:7",
       "color": "1f8f99",
       "description": "Phase 7 operator handoff and review delivery work."
+    },
+    {
+      "name": "phase:8",
+      "color": "236f85",
+      "description": "Phase 8 closeout delivery and pickup routing work."
     },
     {
       "name": "area:backend",
@@ -360,6 +369,51 @@
         "lane:auto-safe"
       ],
       "body": "## goal\nAdd a decision brief and next-action handoff panel to the workbench so the reviewer can package a recommended next step, blockers, and sign-off posture for the next operator pickup.\n\n## input\n- current reviewer scorecard and notes state\n- current packet export state\n- existing eval summary and claim/timeline context from the Phase 5 workbench\n\n## output\n- a handoff-focused decision brief panel in the workbench\n- structured next-action / blocker / recommendation sections derived from existing frontend state\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- live GitHub issue mutation\n- simulation, report, rubric, or queue contract changes\n- local automation schedule changes\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the brief can be copied as an operator handoff summary without editing raw JSON\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 7"
+    },
+    {
+      "title": "Phase 8 exit gate",
+      "milestone": "Phase 8 - Closeout Delivery and Pickup Routing",
+      "labels": [
+        "phase:8",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nConfirm that the Phase 8 closeout delivery and pickup routing criteria are satisfied before the automation system advances again.\n\n## input\n- Phase 8 milestone state\n- merged PR state for queue sync and closeout-delivery work\n- local validation commands and reviewed artifacts\n\n## output\n- explicit Phase 8 closeout decision\n- documented stop condition for the Phase 8 queue\n- gap issues if any execution issue remains incomplete\n\n## out-of-scope\n- opening the next successor milestone before Phase 8 completion\n- simulation, report, claim, evidence, scenario, or artifact contract expansion\n\n## minimal test\n- `./make.ps1 smoke`\n- `./make.ps1 test`\n- `./make.ps1 eval-demo`\n- `python -m backend.app.cli audit-phase phase3`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. Exit gating controls whether the automation queue may advance.\n\n## phase\nPhase 8"
+    },
+    {
+      "title": "Phase 8: sync bootstrap spec and docs to the active closeout-delivery queue",
+      "milestone": "Phase 8 - Closeout Delivery and Pickup Routing",
+      "labels": [
+        "phase:8",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nSync the repository source of truth from the closed Phase 7 baseline to the active Phase 8 queue so docs, bootstrap metadata, and README reflect the new closeout-delivery track.\n\n## input\n- `.github/automation/bootstrap-spec.json`\n- `README.md`\n- `docs/plans/automation-roadmap.md`\n- `docs/plans/current-state-baseline.md`\n- `docs/plans/phase-execution-queue.md`\n- current live GitHub milestone and issue state\n\n## output\n- `phase:8` and Phase 8 queue objects recorded in the bootstrap spec\n- README and planning docs updated to show Phase 8 as the active successor queue\n- no stale Phase 7 active-queue language remains in the active-state docs\n\n## out-of-scope\n- local automation card changes\n- simulation, report, or artifact contract changes\n- closeout packet UI work\n\n## minimal test\n- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`\n- `python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`\n- `./make.ps1 test`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. This work changes the active operational GitHub queue truth surface.\n\n## phase\nPhase 8"
+    },
+    {
+      "title": "Phase 8: add exit-gate-ready closeout packet sections in the workbench",
+      "milestone": "Phase 8 - Closeout Delivery and Pickup Routing",
+      "labels": [
+        "phase:8",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a closeout-focused packet to the workbench so an operator can copy a phase or issue closeout summary into an exit gate or milestone note without rebuilding the current review state by hand.\n\n## input\n- current reviewer scorecard, issue-comment packet, and decision-brief state\n- existing eval summary and claim/timeline context from the current workbench\n- current validation command set already trusted in the repo\n\n## output\n- copyable closeout packet sections in the workbench\n- closeout copy that includes sign-off posture, validation checklist, carry-forward evidence anchors, and reviewer notes\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- posting directly to GitHub\n- changing eval, report, or trace schemas\n- introducing persistent closeout artifacts under `artifacts/`\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the copied packet reads cleanly as an exit-gate or milestone closeout comment\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 8"
+    },
+    {
+      "title": "Phase 8: add lane-aware pickup checklist and handoff routing panel in the workbench",
+      "milestone": "Phase 8 - Closeout Delivery and Pickup Routing",
+      "labels": [
+        "phase:8",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a lane-aware pickup panel to the workbench so the next operator can see different handoff and review steps for `lane:auto-safe` versus `lane:protected-core` without leaving the workbench.\n\n## input\n- current decision-brief and issue-comment packet state\n- `docs/plans/long-running-loop-runbook.md`\n- current claim and timeline context already rendered in the workbench\n\n## output\n- a toggleable lane-specific pickup checklist and routing panel in the workbench\n- copyable guidance that stays aligned with the current runbook without mutating GitHub state\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- changing lane-classifier rules\n- changing runbook governance contracts\n- storing per-user preferences or workflow state\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that switching lanes updates the checklist and handoff guidance copy\n\n## touches contract\nNo. This issue must remain frontend-only and repo-read-only.\n\n## phase\nPhase 8"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-6 gates, and resumed the successor queue as `Phase 7 - Operator Handoff and Review Delivery`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-7 gates, and resumed the successor queue as `Phase 8 - Closeout Delivery and Pickup Routing`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -19,7 +19,7 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-6 gates, and re
   - CI upgraded to a long-running quality gate
   - local lane-classification, phase-audit, and GitHub queue-audit commands
   - protected `main` with required status checks and auto-merge for safe-lane PRs
-  - a browser workbench that now supports claim -> evidence drill-down and baseline/intervention trace review
+  - a browser workbench that now supports claim -> evidence drill-down, trace review, reviewer scorecards, issue-comment packets, and operator handoff briefs
   - a documented worktree-based pickup and handoff path for long-running queue execution
 - GitHub queue state is aligned with the local baseline:
   - Phase 3 exit issue `#4` is closed
@@ -27,8 +27,9 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-6 gates, and re
   - milestone `Phase 4 - Review Workflow and Ops Hardening` is closed
   - milestone `Phase 5 - Review Sign-off and Evidence Packaging` is closed
   - milestone `Phase 6 - Automation Activation and Queue Hygiene` is closed
-  - milestone `Phase 7 - Operator Handoff and Review Delivery` is open
-  - Phase 7 queue is initialized through issues `#46-#49`
+  - milestone `Phase 7 - Operator Handoff and Review Delivery` is closed
+  - milestone `Phase 8 - Closeout Delivery and Pickup Routing` is open
+  - Phase 8 queue is initialized through issues `#53-#56`
 
 Local phase audits currently show:
 
@@ -83,7 +84,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): Phase 6-complete review sign-off workbench with the current Phase 7 handoff queue still consuming the same artifact surface
+- [frontend](/D:/mirror/frontend): review workbench with Phase 7 handoff surfaces landed and the current Phase 8 closeout-delivery queue still consuming the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -128,10 +129,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 6 closeout are complete. Phase 7 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 7 closeout are complete. Phase 8 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may resume pickup guidance only against the Phase 7 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation may resume pickup guidance only against the Phase 8 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, and Phase 7 is now the active handoff-delivery track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, and Phase 8 is now the active closeout-delivery track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -22,9 +22,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 6 is closed locally and in GitHub.
 - Phase 6 exit issue `#40` is closed and milestone `Phase 6 - Automation Activation and Queue Hygiene` is closed.
 - The Phase 6 queue was completed through issues `#40-#43`.
-- Phase 7 is the active successor queue.
-- milestone `Phase 7 - Operator Handoff and Review Delivery` is open.
-- The Phase 7 queue is initialized through issues `#46-#49`.
+- Phase 7 is closed locally and in GitHub.
+- Phase 7 exit issue `#46` is closed and milestone `Phase 7 - Operator Handoff and Review Delivery` is closed.
+- The Phase 7 queue was completed through issues `#46-#49`.
+- Phase 8 is the active successor queue.
+- milestone `Phase 8 - Closeout Delivery and Pickup Routing` is open.
+- The Phase 8 queue is initialized through issues `#53-#56`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 7 active-queue baseline.
+This note is the current Phase 8 active-queue baseline.
 
 ## Snapshot
 
@@ -32,11 +32,15 @@ This note is the current Phase 7 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/issues/40`
     - Phase 6 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/7`
-    - milestone `Phase 7 - Operator Handoff and Review Delivery` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=7"`
-    - Phase 7 queue is initialized through issues `#46-#49`
+    - milestone `Phase 7 - Operator Handoff and Review Delivery` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/46`
+    - Phase 7 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/8`
+    - milestone `Phase 8 - Closeout Delivery and Pickup Routing` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=8"`
+    - Phase 8 queue is initialized through issues `#53-#56`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` because Phase 7 has one blocked protected-core exit gate and multiple ready work items
+    - successor queue currently reports `ready` because Phase 8 has one blocked protected-core exit gate and multiple ready work items
 
 ## Trusted Source Of Truth
 
@@ -53,13 +57,13 @@ This note is the current Phase 7 active-queue baseline.
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
-- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, and shareable review packet export without introducing backend API expansion.
-- The current repository state is in an active Phase 7 successor queue, not a paused post-Phase-6 baseline.
+- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, and operator decision briefs without introducing backend API expansion.
+- The current repository state is in an active Phase 8 successor queue, not a closed Phase 7 baseline.
 
 ## Next Entry Point
 
-- Phase 7 is the active milestone and the current operator-handoff slice is tracked by issues `#46-#49`.
-- New implementation work should attach to the existing Phase 7 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- Phase 8 is the active milestone and the current closeout-delivery slice is tracked by issues `#53-#56`.
+- New implementation work should attach to the existing Phase 8 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
 - The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 7 queue resumption.
+This note records the current post-Day-0 execution status for Mirror after the Phase 8 queue resumption.
 
 ## Current Gate State
 
@@ -10,7 +10,8 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 4 exit gate: closed
 - Phase 5 exit gate: closed
 - Phase 6 exit gate: closed
-- Phase 7 exit gate: open
+- Phase 7 exit gate: closed
+- Phase 8 exit gate: open
 
 Local phase audits currently report:
 
@@ -49,16 +50,24 @@ Local phase audits currently report:
   - closed
 - milestone `Phase 6 - Automation Activation and Queue Hygiene`
   - closed
+- Phase 7 exit issue `#46`
+  - closed
+- milestone `Phase 7 - Operator Handoff and Review Delivery`
+  - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 7 queue kickoff
+  - no open pull requests remain after the Phase 8 queue kickoff
 
 ## Current Queue
 
-- milestone `Phase 7 - Operator Handoff and Review Delivery` is open.
-- `#46` `Phase 7 exit gate`
+- milestone `Phase 8 - Closeout Delivery and Pickup Routing` is open.
+- `#53` `Phase 8 exit gate`
   - open
-  - blocked until the Phase 7 operator handoff and review delivery slice is complete
-- The current Phase 7 execution slice is tracked through:
+  - blocked until the Phase 8 closeout delivery and pickup routing slice is complete
+- The current Phase 8 execution slice is tracked through:
+  - `#54` `Phase 8: sync bootstrap spec and docs to the active closeout-delivery queue`
+  - `#55` `Phase 8: add exit-gate-ready closeout packet sections in the workbench`
+  - `#56` `Phase 8: add lane-aware pickup checklist and handoff routing panel in the workbench`
+- The completed Phase 7 slice was tracked through:
   - `#47` `Phase 7: sync bootstrap spec and docs to the active handoff queue`
   - `#48` `Phase 7: add issue-comment-ready review packet sections in the workbench`
   - `#49` `Phase 7: add decision brief and next-action handoff panel in the workbench`
@@ -87,8 +96,8 @@ Local phase audits currently report:
 
 ## Historical Branch Status
 
-- The visible `origin/codex/*` branches correspond to closed or merged work.
-- Treat those branches as historical and superseded by `main`, not as an active queue.
+- No remote `origin/codex/*` branches remain after the Phase 6 branch-hygiene closeout.
+- Treat any future recreated `codex/*` remote branch as temporary execution state, not as a standing backlog.
 - Delete a historical branch when it is tied only to closed or merged work and no open issue, PR, or runbook step references it.
 - Keep a historical branch only when an open issue or unresolved forensic comparison explicitly depends on it.
 - Revive a historical branch only through a new issue that names the branch and explains why `main` is insufficient.


### PR DESCRIPTION
## Summary
- add Phase 8 milestone, label, and issue definitions to the GitHub bootstrap spec
- update README and planning docs so Phase 8 is the only active execution queue
- record Phase 7 closeout and the newly bootstrapped Phase 8 queue in the current-state notes

## Testing
- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
- ./make.ps1 test
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim

Closes #54