### PR TITLE
[codex] Sync repo truth to Phase 9 queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -31,6 +31,10 @@
     {
       "title": "Phase 8 - Closeout Delivery and Pickup Routing",
       "description": "Turn the new operator handoff surfaces into exit-gate-ready closeout packets and lane-aware pickup guidance without changing core simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 9 - Review Delivery Polish and Completeness",
+      "description": "Consolidate the growing workbench delivery surfaces by mapping each export to its GitHub or operator destination and surfacing completion gaps without changing core simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -73,6 +77,11 @@
       "name": "phase:8",
       "color": "236f85",
       "description": "Phase 8 closeout delivery and pickup routing work."
+    },
+    {
+      "name": "phase:9",
+      "color": "315f8c",
+      "description": "Phase 9 review delivery polish and completeness work."
     },
     {
       "name": "area:backend",
@@ -414,6 +423,51 @@
         "lane:auto-safe"
       ],
       "body": "## goal\nAdd a lane-aware pickup panel to the workbench so the next operator can see different handoff and review steps for `lane:auto-safe` versus `lane:protected-core` without leaving the workbench.\n\n## input\n- current decision-brief and issue-comment packet state\n- `docs/plans/long-running-loop-runbook.md`\n- current claim and timeline context already rendered in the workbench\n\n## output\n- a toggleable lane-specific pickup checklist and routing panel in the workbench\n- copyable guidance that stays aligned with the current runbook without mutating GitHub state\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- changing lane-classifier rules\n- changing runbook governance contracts\n- storing per-user preferences or workflow state\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that switching lanes updates the checklist and handoff guidance copy\n\n## touches contract\nNo. This issue must remain frontend-only and repo-read-only.\n\n## phase\nPhase 8"
+    },
+    {
+      "title": "Phase 9 exit gate",
+      "milestone": "Phase 9 - Review Delivery Polish and Completeness",
+      "labels": [
+        "phase:9",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nConfirm that the Phase 9 review delivery polish and completeness criteria are satisfied before the automation system advances again.\n\n## input\n- Phase 9 milestone state\n- merged PR state for queue sync and delivery-polish work\n- local validation commands and reviewed artifacts\n\n## output\n- explicit Phase 9 closeout decision\n- documented stop condition for the Phase 9 queue\n- gap issues if any execution issue remains incomplete\n\n## out-of-scope\n- opening the next successor milestone before Phase 9 completion\n- simulation, report, claim, evidence, scenario, or artifact contract expansion\n\n## minimal test\n- `./make.ps1 smoke`\n- `./make.ps1 test`\n- `./make.ps1 eval-demo`\n- `python -m backend.app.cli audit-phase phase3`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. Exit gating controls whether the automation queue may advance.\n\n## phase\nPhase 9"
+    },
+    {
+      "title": "Phase 9: sync bootstrap spec and docs to the active delivery-polish queue",
+      "milestone": "Phase 9 - Review Delivery Polish and Completeness",
+      "labels": [
+        "phase:9",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nSync the repository source of truth from the closed Phase 8 baseline to the active Phase 9 queue so docs, bootstrap metadata, and README reflect the new delivery-polish track.\n\n## input\n- `.github/automation/bootstrap-spec.json`\n- `README.md`\n- `docs/plans/automation-roadmap.md`\n- `docs/plans/current-state-baseline.md`\n- `docs/plans/phase-execution-queue.md`\n- current live GitHub milestone and issue state\n\n## output\n- `phase:9` and Phase 9 queue objects recorded in the bootstrap spec\n- README and planning docs updated to show Phase 9 as the active successor queue\n- no stale Phase 8 active-queue language remains in the active-state docs\n\n## out-of-scope\n- local automation card changes\n- simulation, report, or artifact contract changes\n- delivery-surface UI changes\n\n## minimal test\n- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`\n- `python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`\n- `./make.ps1 test`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. This work changes the active operational GitHub queue truth surface.\n\n## phase\nPhase 9"
+    },
+    {
+      "title": "Phase 9: add export destination guide and packet chooser in the workbench",
+      "milestone": "Phase 9 - Review Delivery Polish and Completeness",
+      "labels": [
+        "phase:9",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd an export destination guide and packet chooser to the workbench so an operator can quickly decide which current packet belongs in a PR comment, an exit gate, or the next pickup handoff without scanning every export surface.\n\n## input\n- current review packet, issue-comment packet, closeout packet, and pickup-routing packet surfaces\n- current decision-brief and reviewer-note state\n- current workbench layout\n\n## output\n- a destination guide that maps each packet to its intended GitHub or operator touchpoint\n- a packet chooser or jump surface that reduces export-surface hunting in the workbench\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas, report schemas, or trace schemas\n- hiding or removing the existing export surfaces\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that each export surface is clearly mapped to a destination\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 9"
+    },
+    {
+      "title": "Phase 9: add delivery completeness summary and missing-input warnings in the workbench",
+      "milestone": "Phase 9 - Review Delivery Polish and Completeness",
+      "labels": [
+        "phase:9",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a delivery completeness summary to the workbench so an operator can see which missing scores, notes, or blockers still weaken the current packet set before copying review, closeout, or pickup exports.\n\n## input\n- current reviewer scorecard state\n- current decision brief, closeout packet, and pickup-routing packet state\n- current blocker and note handling in the workbench\n\n## output\n- a delivery-readiness summary panel that highlights missing rubric scores, empty reviewer notes, and unresolved blockers\n- visible warnings that make incomplete exports harder to miss before handoff\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- persistent draft storage\n- changing packet or rubric contracts\n- changing lane-classifier or queue-governance behavior\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that incomplete scorecard or note state surfaces clear warnings in the UI\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 9"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-7 gates, and resumed the successor queue as `Phase 8 - Closeout Delivery and Pickup Routing`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-8 gates, and resumed the successor queue as `Phase 9 - Review Delivery Polish and Completeness`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -28,8 +28,9 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-7 gates, and re
   - milestone `Phase 5 - Review Sign-off and Evidence Packaging` is closed
   - milestone `Phase 6 - Automation Activation and Queue Hygiene` is closed
   - milestone `Phase 7 - Operator Handoff and Review Delivery` is closed
-  - milestone `Phase 8 - Closeout Delivery and Pickup Routing` is open
-  - Phase 8 queue is initialized through issues `#53-#56`
+  - milestone `Phase 8 - Closeout Delivery and Pickup Routing` is closed
+  - milestone `Phase 9 - Review Delivery Polish and Completeness` is open
+  - Phase 9 queue is initialized through issues `#60-#63`
 
 Local phase audits currently show:
 
@@ -84,7 +85,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): review workbench with Phase 7 handoff surfaces landed and the current Phase 8 closeout-delivery queue still consuming the same artifact surface
+- [frontend](/D:/mirror/frontend): review workbench with Phase 8 closeout and lane-routing surfaces landed and the current Phase 9 delivery-polish queue still consuming the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -129,10 +130,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 7 closeout are complete. Phase 8 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 8 closeout are complete. Phase 9 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may resume pickup guidance only against the Phase 8 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation may resume pickup guidance only against the Phase 9 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, and Phase 8 is now the active closeout-delivery track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, and Phase 9 is now the active delivery-polish track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -25,9 +25,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 7 is closed locally and in GitHub.
 - Phase 7 exit issue `#46` is closed and milestone `Phase 7 - Operator Handoff and Review Delivery` is closed.
 - The Phase 7 queue was completed through issues `#46-#49`.
-- Phase 8 is the active successor queue.
-- milestone `Phase 8 - Closeout Delivery and Pickup Routing` is open.
-- The Phase 8 queue is initialized through issues `#53-#56`.
+- Phase 8 is closed locally and in GitHub.
+- Phase 8 exit issue `#53` is closed and milestone `Phase 8 - Closeout Delivery and Pickup Routing` is closed.
+- The Phase 8 queue was completed through issues `#53-#56`.
+- Phase 9 is the active successor queue.
+- milestone `Phase 9 - Review Delivery Polish and Completeness` is open.
+- The Phase 9 queue is initialized through issues `#60-#63`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 8 active-queue baseline.
+This note is the current Phase 9 active-queue baseline.
 
 ## Snapshot
 
@@ -36,11 +36,15 @@ This note is the current Phase 8 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/issues/46`
     - Phase 7 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/8`
-    - milestone `Phase 8 - Closeout Delivery and Pickup Routing` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=8"`
-    - Phase 8 queue is initialized through issues `#53-#56`
+    - milestone `Phase 8 - Closeout Delivery and Pickup Routing` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/53`
+    - Phase 8 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/9`
+    - milestone `Phase 9 - Review Delivery Polish and Completeness` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=9"`
+    - Phase 9 queue is initialized through issues `#60-#63`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` because Phase 8 has one blocked protected-core exit gate and multiple ready work items
+    - successor queue currently reports `ready` because Phase 9 has one blocked protected-core exit gate and multiple ready work items
 
 ## Trusted Source Of Truth
 
@@ -57,13 +61,13 @@ This note is the current Phase 8 active-queue baseline.
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
-- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, and operator decision briefs without introducing backend API expansion.
-- The current repository state is in an active Phase 8 successor queue, not a closed Phase 7 baseline.
+- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, and lane-aware pickup routing without introducing backend API expansion.
+- The current repository state is in an active Phase 9 successor queue, not a closed Phase 8 baseline.
 
 ## Next Entry Point
 
-- Phase 8 is the active milestone and the current closeout-delivery slice is tracked by issues `#53-#56`.
-- New implementation work should attach to the existing Phase 8 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- Phase 9 is the active milestone and the current delivery-polish slice is tracked by issues `#60-#63`.
+- New implementation work should attach to the existing Phase 9 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
 - The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 8 queue resumption.
+This note records the current post-Day-0 execution status for Mirror after the Phase 9 queue resumption.
 
 ## Current Gate State
 
@@ -11,7 +11,8 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 5 exit gate: closed
 - Phase 6 exit gate: closed
 - Phase 7 exit gate: closed
-- Phase 8 exit gate: open
+- Phase 8 exit gate: closed
+- Phase 9 exit gate: open
 
 Local phase audits currently report:
 
@@ -54,16 +55,24 @@ Local phase audits currently report:
   - closed
 - milestone `Phase 7 - Operator Handoff and Review Delivery`
   - closed
+- Phase 8 exit issue `#53`
+  - closed
+- milestone `Phase 8 - Closeout Delivery and Pickup Routing`
+  - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 8 queue kickoff
+  - no open pull requests remain after the Phase 9 queue kickoff
 
 ## Current Queue
 
-- milestone `Phase 8 - Closeout Delivery and Pickup Routing` is open.
-- `#53` `Phase 8 exit gate`
+- milestone `Phase 9 - Review Delivery Polish and Completeness` is open.
+- `#60` `Phase 9 exit gate`
   - open
-  - blocked until the Phase 8 closeout delivery and pickup routing slice is complete
-- The current Phase 8 execution slice is tracked through:
+  - blocked until the Phase 9 review delivery polish and completeness slice is complete
+- The current Phase 9 execution slice is tracked through:
+  - `#61` `Phase 9: sync bootstrap spec and docs to the active delivery-polish queue`
+  - `#62` `Phase 9: add export destination guide and packet chooser in the workbench`
+  - `#63` `Phase 9: add delivery completeness summary and missing-input warnings in the workbench`
+- The completed Phase 8 slice was tracked through:
   - `#54` `Phase 8: sync bootstrap spec and docs to the active closeout-delivery queue`
   - `#55` `Phase 8: add exit-gate-ready closeout packet sections in the workbench`
   - `#56` `Phase 8: add lane-aware pickup checklist and handoff routing panel in the workbench`


### PR DESCRIPTION
## Summary
- add Phase 9 milestone, label, and issue definitions to the GitHub bootstrap spec
- update README and planning docs so Phase 9 is the only active execution queue
- record Phase 8 closeout and the newly bootstrapped Phase 9 queue in the current-state notes

## Testing
- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
- ./make.ps1 test
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim

Closes #61