### PR TITLE
[codex] Sync repo truth to Phase 10 queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -35,6 +35,10 @@
     {
       "title": "Phase 9 - Review Delivery Polish and Completeness",
       "description": "Consolidate the growing workbench delivery surfaces by mapping each export to its GitHub or operator destination and surfacing completion gaps without changing core simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 10 - Guided Delivery and Quick Export",
+      "description": "Turn the growing set of workbench delivery surfaces into a more guided, lower-friction operator flow with destination-aware recommendations and quick export actions, without changing core simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -82,6 +86,11 @@
       "name": "phase:9",
       "color": "315f8c",
       "description": "Phase 9 review delivery polish and completeness work."
+    },
+    {
+      "name": "phase:10",
+      "color": "4157a5",
+      "description": "Phase 10 guided delivery and quick export work."
     },
     {
       "name": "area:backend",
@@ -468,6 +477,51 @@
         "lane:auto-safe"
       ],
       "body": "## goal\nAdd a delivery completeness summary to the workbench so an operator can see which missing scores, notes, or blockers still weaken the current packet set before copying review, closeout, or pickup exports.\n\n## input\n- current reviewer scorecard state\n- current decision brief, closeout packet, and pickup-routing packet state\n- current blocker and note handling in the workbench\n\n## output\n- a delivery-readiness summary panel that highlights missing rubric scores, empty reviewer notes, and unresolved blockers\n- visible warnings that make incomplete exports harder to miss before handoff\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- persistent draft storage\n- changing packet or rubric contracts\n- changing lane-classifier or queue-governance behavior\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that incomplete scorecard or note state surfaces clear warnings in the UI\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 9"
+    },
+    {
+      "title": "Phase 10 exit gate",
+      "milestone": "Phase 10 - Guided Delivery and Quick Export",
+      "labels": [
+        "phase:10",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nConfirm that the Phase 10 guided delivery and quick export criteria are satisfied before the automation system advances again.\n\n## input\n- Phase 10 milestone state\n- merged PR state for queue sync and guided-delivery work\n- local validation commands and reviewed artifacts\n\n## output\n- explicit Phase 10 closeout decision\n- documented stop condition for the Phase 10 queue\n- gap issues if any execution issue remains incomplete\n\n## out-of-scope\n- opening the next successor milestone before Phase 10 completion\n- simulation, report, claim, evidence, scenario, or artifact contract expansion\n\n## minimal test\n- `./make.ps1 smoke`\n- `./make.ps1 test`\n- `./make.ps1 eval-demo`\n- `python -m backend.app.cli audit-phase phase3`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. Exit gating controls whether the automation queue may advance.\n\n## phase\nPhase 10"
+    },
+    {
+      "title": "Phase 10: sync bootstrap spec and docs to the active guided-delivery queue",
+      "milestone": "Phase 10 - Guided Delivery and Quick Export",
+      "labels": [
+        "phase:10",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nSync the repository source of truth from the closed Phase 9 baseline to the active Phase 10 queue so docs, bootstrap metadata, and README reflect the new guided-delivery track.\n\n## input\n- `.github/automation/bootstrap-spec.json`\n- `README.md`\n- `docs/plans/automation-roadmap.md`\n- `docs/plans/current-state-baseline.md`\n- `docs/plans/phase-execution-queue.md`\n- current live GitHub milestone and issue state\n\n## output\n- `phase:10` and Phase 10 queue objects recorded in the bootstrap spec\n- README and planning docs updated to show Phase 10 as the active successor queue\n- no stale Phase 9 active-queue language remains in the active-state docs\n\n## out-of-scope\n- local automation card changes\n- simulation, report, or artifact contract changes\n- guided-export UI changes\n\n## minimal test\n- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`\n- `python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`\n- `./make.ps1 test`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. This work changes the active operational GitHub queue truth surface.\n\n## phase\nPhase 10"
+    },
+    {
+      "title": "Phase 10: add destination-aware recommended export banner and quick-copy action in the workbench",
+      "milestone": "Phase 10 - Guided Delivery and Quick Export",
+      "labels": [
+        "phase:10",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a destination-aware recommendation banner to the workbench so the operator can see the currently best export for a PR comment, closeout, or pickup handoff and copy it without hopping between multiple packet cards.\n\n## input\n- current packet chooser, delivery-readiness panel, and export surfaces\n- current sign-off posture, blockers, and reviewer-note state\n- current workbench layout\n\n## output\n- a recommended export banner tied to the current state and selected destination\n- one-step quick-copy for the recommended export from the guide surface\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or queue-governance rules\n- removing the existing detailed export cards\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that changing the destination updates the recommendation and quick-copy target\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 10"
+    },
+    {
+      "title": "Phase 10: add packet coverage matrix and destination inclusion preview in the workbench",
+      "milestone": "Phase 10 - Guided Delivery and Quick Export",
+      "labels": [
+        "phase:10",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a packet coverage matrix to the workbench so an operator can see which current export includes claims, blockers, validation commands, lane guidance, and reviewer notes before copying it to a destination.\n\n## input\n- current review packet, issue-comment packet, closeout packet, decision brief, and pickup-routing packet surfaces\n- current export destination guide and delivery-readiness panel\n- current workbench layout\n\n## output\n- a matrix or inclusion preview that compares packet coverage by destination and content type\n- a clearer explanation of what each export omits as well as what it includes\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- packet schema changes\n- removing existing packet surfaces\n- storing user preferences or persistent delivery presets\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the matrix helps distinguish packet coverage and omissions at a glance\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 10"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-8 gates, and resumed the successor queue as `Phase 9 - Review Delivery Polish and Completeness`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-9 gates, and resumed the successor queue as `Phase 10 - Guided Delivery and Quick Export`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -29,8 +29,9 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-8 gates, and re
   - milestone `Phase 6 - Automation Activation and Queue Hygiene` is closed
   - milestone `Phase 7 - Operator Handoff and Review Delivery` is closed
   - milestone `Phase 8 - Closeout Delivery and Pickup Routing` is closed
-  - milestone `Phase 9 - Review Delivery Polish and Completeness` is open
-  - Phase 9 queue is initialized through issues `#60-#63`
+  - milestone `Phase 9 - Review Delivery Polish and Completeness` is closed
+  - milestone `Phase 10 - Guided Delivery and Quick Export` is open
+  - Phase 10 queue is initialized through issues `#67-#70`
 
 Local phase audits currently show:
 
@@ -85,7 +86,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): review workbench with Phase 8 closeout and lane-routing surfaces landed and the current Phase 9 delivery-polish queue still consuming the same artifact surface
+- [frontend](/D:/mirror/frontend): review workbench with Phase 9 export guidance and readiness surfaces landed and the current Phase 10 guided-delivery queue still consuming the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -130,10 +131,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 8 closeout are complete. Phase 9 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 9 closeout are complete. Phase 10 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may resume pickup guidance only against the Phase 9 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation may resume pickup guidance only against the Phase 10 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, and Phase 9 is now the active delivery-polish track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, and Phase 10 is now the active guided-delivery track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -28,9 +28,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 8 is closed locally and in GitHub.
 - Phase 8 exit issue `#53` is closed and milestone `Phase 8 - Closeout Delivery and Pickup Routing` is closed.
 - The Phase 8 queue was completed through issues `#53-#56`.
-- Phase 9 is the active successor queue.
-- milestone `Phase 9 - Review Delivery Polish and Completeness` is open.
-- The Phase 9 queue is initialized through issues `#60-#63`.
+- Phase 9 is closed locally and in GitHub.
+- Phase 9 exit issue `#60` is closed and milestone `Phase 9 - Review Delivery Polish and Completeness` is closed.
+- The Phase 9 queue was completed through issues `#60-#63`.
+- Phase 10 is the active successor queue.
+- milestone `Phase 10 - Guided Delivery and Quick Export` is open.
+- The Phase 10 queue is initialized through issues `#67-#70`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 9 active-queue baseline.
+This note is the current Phase 10 active-queue baseline.
 
 ## Snapshot
 
@@ -40,11 +40,15 @@ This note is the current Phase 9 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/issues/53`
     - Phase 8 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/9`
-    - milestone `Phase 9 - Review Delivery Polish and Completeness` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=9"`
-    - Phase 9 queue is initialized through issues `#60-#63`
+    - milestone `Phase 9 - Review Delivery Polish and Completeness` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/60`
+    - Phase 9 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/10`
+    - milestone `Phase 10 - Guided Delivery and Quick Export` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=10"`
+    - Phase 10 queue is initialized through issues `#67-#70`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` because Phase 9 has one blocked protected-core exit gate and multiple ready work items
+    - successor queue currently reports `ready` because Phase 10 has one blocked protected-core exit gate and multiple ready work items
 
 ## Trusted Source Of Truth
 
@@ -61,13 +65,13 @@ This note is the current Phase 9 active-queue baseline.
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
-- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, and lane-aware pickup routing without introducing backend API expansion.
-- The current repository state is in an active Phase 9 successor queue, not a closed Phase 8 baseline.
+- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, and delivery-readiness warnings without introducing backend API expansion.
+- The current repository state is in an active Phase 10 successor queue, not a closed Phase 9 baseline.
 
 ## Next Entry Point
 
-- Phase 9 is the active milestone and the current delivery-polish slice is tracked by issues `#60-#63`.
-- New implementation work should attach to the existing Phase 9 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- Phase 10 is the active milestone and the current guided-delivery slice is tracked by issues `#67-#70`.
+- New implementation work should attach to the existing Phase 10 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
 - The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 9 queue resumption.
+This note records the current post-Day-0 execution status for Mirror after the Phase 10 queue resumption.
 
 ## Current Gate State
 
@@ -12,7 +12,8 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 6 exit gate: closed
 - Phase 7 exit gate: closed
 - Phase 8 exit gate: closed
-- Phase 9 exit gate: open
+- Phase 9 exit gate: closed
+- Phase 10 exit gate: open
 
 Local phase audits currently report:
 
@@ -59,16 +60,24 @@ Local phase audits currently report:
   - closed
 - milestone `Phase 8 - Closeout Delivery and Pickup Routing`
   - closed
+- Phase 9 exit issue `#60`
+  - closed
+- milestone `Phase 9 - Review Delivery Polish and Completeness`
+  - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 9 queue kickoff
+  - no open pull requests remain after the Phase 10 queue kickoff
 
 ## Current Queue
 
-- milestone `Phase 9 - Review Delivery Polish and Completeness` is open.
-- `#60` `Phase 9 exit gate`
+- milestone `Phase 10 - Guided Delivery and Quick Export` is open.
+- `#67` `Phase 10 exit gate`
   - open
-  - blocked until the Phase 9 review delivery polish and completeness slice is complete
-- The current Phase 9 execution slice is tracked through:
+-  - blocked until the Phase 10 guided delivery and quick export slice is complete
+- The current Phase 10 execution slice is tracked through:
+  - `#68` `Phase 10: sync bootstrap spec and docs to the active guided-delivery queue`
+  - `#69` `Phase 10: add destination-aware recommended export banner and quick-copy action in the workbench`
+  - `#70` `Phase 10: add packet coverage matrix and destination inclusion preview in the workbench`
+- The completed Phase 9 slice was tracked through:
   - `#61` `Phase 9: sync bootstrap spec and docs to the active delivery-polish queue`
   - `#62` `Phase 9: add export destination guide and packet chooser in the workbench`
   - `#63` `Phase 9: add delivery completeness summary and missing-input warnings in the workbench`


### PR DESCRIPTION
## Summary
- add Phase 10 milestone, label, and issue definitions to the GitHub bootstrap spec
- update README and planning docs so Phase 10 is the only active execution queue
- record Phase 9 closeout and the newly bootstrapped Phase 10 queue in the current-state notes

## Testing
- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
- ./make.ps1 test
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim

Closes #68