### PR TITLE
[codex] Add packet coverage matrix

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -484,6 +484,39 @@ code {
   border-color: rgba(15, 107, 99, 0.22);
 }
 
+.coverageGrid {
+  display: grid;
+  gap: 14px;
+}
+
+.coverageCard {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.74);
+  border: 1px solid var(--border);
+}
+
+.coverageCardActive {
+  border-color: rgba(15, 107, 99, 0.32);
+  box-shadow: 0 14px 30px rgba(15, 107, 99, 0.1);
+}
+
+.coverageLists {
+  display: grid;
+  gap: 12px;
+}
+
+.coverageList {
+  display: grid;
+  gap: 8px;
+}
+
+.coverageList h3 {
+  margin: 0;
+}
+
 .laneToggleGroup {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/app/review-scorecard.tsx
+++ b/frontend/src/app/review-scorecard.tsx
@@ -62,6 +62,12 @@ type DeliveryReadiness = {
 
 type DeliveryDestination = "pr-comment" | "closeout" | "pickup-handoff";
 
+type ExportCoverage = {
+  includes: string[];
+  omits: string[];
+  note: string;
+};
+
 type ReviewScorecardProps = {
   rubricRows: RubricRow[];
   claimCount: number;
@@ -167,6 +173,33 @@ const deliveryDestinations: Record<DeliveryDestination, { label: string; summary
   "pickup-handoff": {
     label: "Pickup handoff",
     summary: "Use when the next operator needs the clearest next step for continuing the work."
+  }
+};
+const exportCoverage: Record<ExportSurfaceId, ExportCoverage> = {
+  "decision-brief": {
+    includes: ["Claim context", "Blockers", "Reviewer notes"],
+    omits: ["Validation commands", "Lane guidance"],
+    note: "Optimized for a concise narrative handoff rather than a full validation or governance bundle."
+  },
+  "review-packet": {
+    includes: ["Claim context", "Reviewer notes"],
+    omits: ["Blockers", "Validation commands", "Lane guidance"],
+    note: "Best when the next reader still needs the broadest artifact context."
+  },
+  "issue-comment": {
+    includes: ["Claim context", "Reviewer notes"],
+    omits: ["Blockers", "Validation commands", "Lane guidance"],
+    note: "Trimmed for GitHub comments, so it favors concise context over full delivery scaffolding."
+  },
+  "closeout-packet": {
+    includes: ["Claim context", "Blockers", "Validation commands", "Reviewer notes"],
+    omits: ["Lane guidance"],
+    note: "Designed for exit gates and milestone notes where validation evidence must stay visible."
+  },
+  "pickup-routing": {
+    includes: ["Claim context", "Blockers", "Validation commands", "Lane guidance", "Reviewer notes"],
+    omits: [],
+    note: "Carries the fullest operator-routing context, especially when lane rules and post-merge checks matter."
   }
 };
 
@@ -927,6 +960,63 @@ export function ReviewScorecard({
                   ))}
                 </ul>
               </div>
+            </div>
+          </article>
+
+          <article className="artifactCard handoffCard">
+            <div className="artifactMeta">
+              <span>coverage</span>
+              <code>destination inclusion preview</code>
+            </div>
+            <div className="claimHeader">
+              <strong>Coverage matrix</strong>
+              <span className="pill">{deliveryDestinations[selectedDestination].label}</span>
+            </div>
+            <p className="scoreHint">
+              Compare what each export includes before you copy it. The highlighted card matches the current recommended export.
+            </p>
+
+            <div className="coverageGrid">
+              {(Object.keys(exportSurfaces) as ExportSurfaceId[]).map((exportId) => {
+                const coverage = exportCoverage[exportId];
+                const isRecommended = recommendedExport.exportId === exportId;
+                return (
+                  <article
+                    key={exportId}
+                    className={`coverageCard${isRecommended ? " coverageCardActive" : ""}`}
+                  >
+                    <div className="claimHeader">
+                      <strong>{exportSurfaces[exportId].label}</strong>
+                      {isRecommended ? <span className="statusPill statusPillready">recommended</span> : null}
+                    </div>
+                    <p className="scoreHint">{exportSurfaces[exportId].destination}</p>
+
+                    <div className="coverageLists">
+                      <div className="coverageList">
+                        <h3>Includes</h3>
+                        <ul className="checklist compact">
+                          {coverage.includes.map((item) => (
+                            <li key={item}>{item}</li>
+                          ))}
+                        </ul>
+                      </div>
+
+                      <div className="coverageList">
+                        <h3>Omits</h3>
+                        <ul className="checklist compact">
+                          {coverage.omits.length > 0 ? (
+                            coverage.omits.map((item) => <li key={item}>{item}</li>)
+                          ) : (
+                            <li>No key delivery fields omitted in this export.</li>
+                          )}
+                        </ul>
+                      </div>
+                    </div>
+
+                    <p className="scoreHint">{coverage.note}</p>
+                  </article>
+                );
+              })}
             </div>
           </article>
 


### PR DESCRIPTION
## Summary
- add a destination inclusion preview that compares packet coverage across the current export surfaces
- highlight the currently recommended export in the coverage matrix for faster operator scanning
- clarify what each export includes and omits without changing the export schemas themselves

## Testing
- python -m backend.app.cli classify-lane --files frontend/src/app/review-scorecard.tsx frontend/src/app/globals.css
- ./make.ps1 smoke
- ./make.ps1 eval-demo
- ./make.ps1 test
- npm.cmd run build --prefix frontend

Closes #70