### PR TITLE
[codex] Sync repo truth to Phase 11 queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -39,6 +39,10 @@
     {
       "title": "Phase 10 - Guided Delivery and Quick Export",
       "description": "Turn the growing set of workbench delivery surfaces into a more guided, lower-friction operator flow with destination-aware recommendations and quick export actions, without changing core simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 11 - Export Presets and Delivery Shortcuts",
+      "description": "Reduce operator decision friction by adding export presets, delivery shortcuts, and clearer guided handoff entry points without changing core simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -91,6 +95,11 @@
       "name": "phase:10",
       "color": "4157a5",
       "description": "Phase 10 guided delivery and quick export work."
+    },
+    {
+      "name": "phase:11",
+      "color": "4b4fb6",
+      "description": "Phase 11 export presets and delivery shortcuts work."
     },
     {
       "name": "area:backend",
@@ -522,6 +531,51 @@
         "lane:auto-safe"
       ],
       "body": "## goal\nAdd a packet coverage matrix to the workbench so an operator can see which current export includes claims, blockers, validation commands, lane guidance, and reviewer notes before copying it to a destination.\n\n## input\n- current review packet, issue-comment packet, closeout packet, decision brief, and pickup-routing packet surfaces\n- current export destination guide and delivery-readiness panel\n- current workbench layout\n\n## output\n- a matrix or inclusion preview that compares packet coverage by destination and content type\n- a clearer explanation of what each export omits as well as what it includes\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- packet schema changes\n- removing existing packet surfaces\n- storing user preferences or persistent delivery presets\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the matrix helps distinguish packet coverage and omissions at a glance\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 10"
+    },
+    {
+      "title": "Phase 11 exit gate",
+      "milestone": "Phase 11 - Export Presets and Delivery Shortcuts",
+      "labels": [
+        "phase:11",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nConfirm that the Phase 11 export presets and delivery shortcuts criteria are satisfied before the automation system advances again.\n\n## input\n- Phase 11 milestone state\n- merged PR state for queue sync and delivery-shortcut work\n- local validation commands and reviewed artifacts\n\n## output\n- explicit Phase 11 closeout decision\n- documented stop condition for the Phase 11 queue\n- gap issues if any execution issue remains incomplete\n\n## out-of-scope\n- opening the next successor milestone before Phase 11 completion\n- simulation, report, claim, evidence, scenario, or artifact contract expansion\n\n## minimal test\n- `./make.ps1 smoke`\n- `./make.ps1 test`\n- `./make.ps1 eval-demo`\n- `python -m backend.app.cli audit-phase phase3`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. Exit gating controls whether the automation queue may advance.\n\n## phase\nPhase 11"
+    },
+    {
+      "title": "Phase 11: sync bootstrap spec and docs to the active export-shortcut queue",
+      "milestone": "Phase 11 - Export Presets and Delivery Shortcuts",
+      "labels": [
+        "phase:11",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nSync the repository source of truth from the closed Phase 10 baseline to the active Phase 11 queue so docs, bootstrap metadata, and README reflect the new export-shortcut track.\n\n## input\n- `.github/automation/bootstrap-spec.json`\n- `README.md`\n- `docs/plans/automation-roadmap.md`\n- `docs/plans/current-state-baseline.md`\n- `docs/plans/phase-execution-queue.md`\n- current live GitHub milestone and issue state\n\n## output\n- `phase:11` and Phase 11 queue objects recorded in the bootstrap spec\n- README and planning docs updated to show Phase 11 as the active successor queue\n- no stale Phase 10 active-queue language remains in the active-state docs\n\n## out-of-scope\n- local automation card changes\n- simulation, report, or artifact contract changes\n- export-shortcut UI changes\n\n## minimal test\n- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`\n- `python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`\n- `./make.ps1 test`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. This work changes the active operational GitHub queue truth surface.\n\n## phase\nPhase 11"
+    },
+    {
+      "title": "Phase 11: add delivery preset cards for PR comment, closeout, and pickup handoff",
+      "milestone": "Phase 11 - Export Presets and Delivery Shortcuts",
+      "labels": [
+        "phase:11",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd delivery preset cards to the workbench so an operator can jump into a PR-comment, closeout, or pickup-handoff flow from one clear entry point instead of assembling the path from multiple widgets.\n\n## input\n- current destination-aware recommendation banner\n- current packet chooser, readiness panel, and coverage matrix\n- current workbench layout\n\n## output\n- three clear delivery preset cards that set destination context and focus the operator on the most relevant export path\n- no backend API calls and no new artifact files\n- existing detailed export surfaces remain available underneath\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or queue-governance rules\n- removing the existing guided-export controls\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that selecting a preset updates the guided export state and shortcut path\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 11"
+    },
+    {
+      "title": "Phase 11: add quick-export shortcut strip with copy and jump actions for the current recommended path",
+      "milestone": "Phase 11 - Export Presets and Delivery Shortcuts",
+      "labels": [
+        "phase:11",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a compact quick-export shortcut strip to the workbench so the operator can copy the current recommended export, jump to its detailed card, or pivot to the next-best export without scrolling through the full sidebar.\n\n## input\n- current destination-aware recommendation banner\n- current packet chooser and coverage matrix\n- current workbench layout\n\n## output\n- a shortcut strip for the current recommended path with copy and jump actions\n- a lightweight path to alternative exports when the operator does not want the default recommendation\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas, scoring contracts, or queue-governance rules\n- removing the existing detailed export cards\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the shortcut strip stays aligned with the current recommended export\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 11"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-9 gates, and resumed the successor queue as `Phase 10 - Guided Delivery and Quick Export`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-10 gates, and resumed the successor queue as `Phase 11 - Export Presets and Delivery Shortcuts`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -30,8 +30,9 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-9 gates, and re
   - milestone `Phase 7 - Operator Handoff and Review Delivery` is closed
   - milestone `Phase 8 - Closeout Delivery and Pickup Routing` is closed
   - milestone `Phase 9 - Review Delivery Polish and Completeness` is closed
-  - milestone `Phase 10 - Guided Delivery and Quick Export` is open
-  - Phase 10 queue is initialized through issues `#67-#70`
+  - milestone `Phase 10 - Guided Delivery and Quick Export` is closed
+  - milestone `Phase 11 - Export Presets and Delivery Shortcuts` is open
+  - Phase 11 queue is initialized through issues `#74-#77`
 
 Local phase audits currently show:
 
@@ -86,7 +87,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): review workbench with Phase 9 export guidance and readiness surfaces landed and the current Phase 10 guided-delivery queue still consuming the same artifact surface
+- [frontend](/D:/mirror/frontend): review workbench with Phase 10 guided-export surfaces landed and the current Phase 11 export-shortcut queue still consuming the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -131,10 +132,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 9 closeout are complete. Phase 10 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 10 closeout are complete. Phase 11 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may resume pickup guidance only against the Phase 10 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation may resume pickup guidance only against the Phase 11 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, and Phase 10 is now the active guided-delivery track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, and Phase 11 is now the active export-shortcut track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -31,9 +31,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 9 is closed locally and in GitHub.
 - Phase 9 exit issue `#60` is closed and milestone `Phase 9 - Review Delivery Polish and Completeness` is closed.
 - The Phase 9 queue was completed through issues `#60-#63`.
-- Phase 10 is the active successor queue.
-- milestone `Phase 10 - Guided Delivery and Quick Export` is open.
-- The Phase 10 queue is initialized through issues `#67-#70`.
+- Phase 10 is closed locally and in GitHub.
+- Phase 10 exit issue `#67` is closed and milestone `Phase 10 - Guided Delivery and Quick Export` is closed.
+- The Phase 10 queue was completed through issues `#67-#70`.
+- Phase 11 is the active successor queue.
+- milestone `Phase 11 - Export Presets and Delivery Shortcuts` is open.
+- The Phase 11 queue is initialized through issues `#74-#77`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 10 active-queue baseline.
+This note is the current Phase 11 active-queue baseline.
 
 ## Snapshot
 
@@ -44,11 +44,15 @@ This note is the current Phase 10 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/issues/60`
     - Phase 9 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/10`
-    - milestone `Phase 10 - Guided Delivery and Quick Export` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=10"`
-    - Phase 10 queue is initialized through issues `#67-#70`
+    - milestone `Phase 10 - Guided Delivery and Quick Export` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/67`
+    - Phase 10 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/11`
+    - milestone `Phase 11 - Export Presets and Delivery Shortcuts` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=11"`
+    - Phase 11 queue is initialized through issues `#74-#77`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` because Phase 10 has one blocked protected-core exit gate and multiple ready work items
+    - successor queue currently reports `ready` because Phase 11 has one blocked protected-core exit gate and multiple ready work items
 
 ## Trusted Source Of Truth
 
@@ -65,13 +69,13 @@ This note is the current Phase 10 active-queue baseline.
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
-- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, and delivery-readiness warnings without introducing backend API expansion.
-- The current repository state is in an active Phase 10 successor queue, not a closed Phase 9 baseline.
+- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, and packet coverage previews without introducing backend API expansion.
+- The current repository state is in an active Phase 11 successor queue, not a closed Phase 10 baseline.
 
 ## Next Entry Point
 
-- Phase 10 is the active milestone and the current guided-delivery slice is tracked by issues `#67-#70`.
-- New implementation work should attach to the existing Phase 10 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- Phase 11 is the active milestone and the current export-shortcut slice is tracked by issues `#74-#77`.
+- New implementation work should attach to the existing Phase 11 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
 - The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 10 queue resumption.
+This note records the current post-Day-0 execution status for Mirror after the Phase 11 queue resumption.
 
 ## Current Gate State
 
@@ -13,7 +13,8 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 7 exit gate: closed
 - Phase 8 exit gate: closed
 - Phase 9 exit gate: closed
-- Phase 10 exit gate: open
+- Phase 10 exit gate: closed
+- Phase 11 exit gate: open
 
 Local phase audits currently report:
 
@@ -64,16 +65,24 @@ Local phase audits currently report:
   - closed
 - milestone `Phase 9 - Review Delivery Polish and Completeness`
   - closed
+- Phase 10 exit issue `#67`
+  - closed
+- milestone `Phase 10 - Guided Delivery and Quick Export`
+  - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 10 queue kickoff
+  - no open pull requests remain after the Phase 11 queue kickoff
 
 ## Current Queue
 
-- milestone `Phase 10 - Guided Delivery and Quick Export` is open.
-- `#67` `Phase 10 exit gate`
+- milestone `Phase 11 - Export Presets and Delivery Shortcuts` is open.
+- `#74` `Phase 11 exit gate`
   - open
--  - blocked until the Phase 10 guided delivery and quick export slice is complete
-- The current Phase 10 execution slice is tracked through:
+  - blocked until the Phase 11 export presets and delivery shortcuts slice is complete
+- The current Phase 11 execution slice is tracked through:
+  - `#75` `Phase 11: sync bootstrap spec and docs to the active export-shortcut queue`
+  - `#76` `Phase 11: add delivery preset cards for PR comment, closeout, and pickup handoff`
+  - `#77` `Phase 11: add quick-export shortcut strip with copy and jump actions for the current recommended path`
+- The completed Phase 10 slice was tracked through:
   - `#68` `Phase 10: sync bootstrap spec and docs to the active guided-delivery queue`
   - `#69` `Phase 10: add destination-aware recommended export banner and quick-copy action in the workbench`
   - `#70` `Phase 10: add packet coverage matrix and destination inclusion preview in the workbench`


### PR DESCRIPTION
## Summary
- add Phase 11 milestone, label, and issue definitions to the GitHub bootstrap spec
- update README and planning docs so Phase 11 is the only active execution queue
- record Phase 10 closeout and the newly bootstrapped Phase 11 queue in the current-state notes

## Testing
- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
- ./make.ps1 test
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim

Closes #75