### PR TITLE
[codex] Add delivery preset cards

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -484,6 +484,29 @@ code {
   border-color: rgba(15, 107, 99, 0.22);
 }
 
+.presetGrid {
+  display: grid;
+  gap: 12px;
+}
+
+.presetCard {
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.74);
+  border: 1px solid var(--border);
+}
+
+.presetCardActive {
+  border-color: rgba(15, 107, 99, 0.32);
+  box-shadow: 0 14px 30px rgba(15, 107, 99, 0.1);
+}
+
+.presetCard p {
+  margin: 0;
+}
+
 .coverageGrid {
   display: grid;
   gap: 14px;

--- a/frontend/src/app/review-scorecard.tsx
+++ b/frontend/src/app/review-scorecard.tsx
@@ -175,6 +175,7 @@ const deliveryDestinations: Record<DeliveryDestination, { label: string; summary
     summary: "Use when the next operator needs the clearest next step for continuing the work."
   }
 };
+const deliveryDestinationOrder: DeliveryDestination[] = ["pr-comment", "closeout", "pickup-handoff"];
 const exportCoverage: Record<ExportSurfaceId, ExportCoverage> = {
   "decision-brief": {
     includes: ["Claim context", "Blockers", "Reviewer notes"],
@@ -551,6 +552,14 @@ export function ReviewScorecard({
   );
   const recommendedExport = recommendedExportForDestination(selectedDestination, pickupLane, deliveryReadiness);
   const recommendedExportSurface = exportSurfaces[recommendedExport.exportId];
+  const presetRecommendations = deliveryDestinationOrder.map((destination) => {
+    const recommendation = recommendedExportForDestination(destination, pickupLane, deliveryReadiness);
+    return {
+      destination,
+      recommendation,
+      exportSurface: exportSurfaces[recommendation.exportId]
+    };
+  });
   const packetMarkdown = [
     "# Mirror Review Packet",
     "",
@@ -848,6 +857,39 @@ export function ReviewScorecard({
                   {deliveryDestinations[destination].label}
                 </button>
               ))}
+            </div>
+
+            <div className="presetGrid">
+              {presetRecommendations.map(({ destination, recommendation, exportSurface }) => {
+                const isActive = selectedDestination === destination;
+
+                return (
+                  <article
+                    key={destination}
+                    className={`presetCard${isActive ? " presetCardActive" : ""}`}
+                  >
+                    <div className="claimHeader">
+                      <strong>{deliveryDestinations[destination].label}</strong>
+                      {isActive ? <span className="statusPill statusPillready">active</span> : null}
+                    </div>
+                    <p className="scoreHint">{deliveryDestinations[destination].summary}</p>
+                    <p>
+                      <strong>Recommended export:</strong> {exportSurface.label}
+                    </p>
+                    <p className="scoreHint">{recommendation.reason}</p>
+                    <button
+                      type="button"
+                      className="actionButton"
+                      onClick={() => {
+                        setSelectedDestination(destination);
+                        setSelectedExport(recommendation.exportId);
+                      }}
+                    >
+                      {isActive ? "Preset active" : "Use preset"}
+                    </button>
+                  </article>
+                );
+              })}
             </div>
 
             <div className="handoffSections">


### PR DESCRIPTION
## Summary
- add delivery preset cards for PR comment, closeout, and pickup handoff flows
- let operators switch destination context from one clear entry point before using the detailed export controls
- keep the existing packet chooser and export surfaces available underneath

## Testing
- python -m backend.app.cli classify-lane --files frontend/src/app/review-scorecard.tsx frontend/src/app/globals.css
- ./make.ps1 smoke
- ./make.ps1 eval-demo
- ./make.ps1 test
- npm.cmd run build --prefix frontend

Closes #76