### PR TITLE
[codex] Add quick export shortcut strip

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -507,6 +507,30 @@ code {
   margin: 0;
 }
 
+.shortcutStrip {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 20px;
+  background: rgba(15, 107, 99, 0.08);
+  border: 1px solid rgba(15, 107, 99, 0.14);
+}
+
+.shortcutHeader {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.shortcutActions,
+.shortcutAltList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
 .coverageGrid {
   display: grid;
   gap: 14px;

--- a/frontend/src/app/review-scorecard.tsx
+++ b/frontend/src/app/review-scorecard.tsx
@@ -497,6 +497,23 @@ function recommendedExportForDestination(
   };
 }
 
+function alternativeExportsForDestination(
+  destination: DeliveryDestination,
+  recommendedExportId: ExportSurfaceId,
+  pickupLane: PickupLane
+) {
+  const candidates: ExportSurfaceId[] =
+    destination === "pr-comment"
+      ? ["decision-brief", "review-packet", "pickup-routing"]
+      : destination === "closeout"
+        ? ["pickup-routing", "decision-brief", "issue-comment"]
+        : pickupLane === "lane:protected-core"
+          ? ["decision-brief", "issue-comment", "closeout-packet"]
+          : ["pickup-routing", "issue-comment", "review-packet"];
+
+  return candidates.filter((exportId) => exportId !== recommendedExportId).slice(0, 2);
+}
+
 export function ReviewScorecard({
   rubricRows,
   claimCount,
@@ -519,6 +536,7 @@ export function ReviewScorecard({
   const [selectedExport, setSelectedExport] = useState<ExportSurfaceId>("issue-comment");
   const [selectedDestination, setSelectedDestination] = useState<DeliveryDestination>("pr-comment");
   const [recommendedCopyState, setRecommendedCopyState] = useState<"idle" | "copied" | "failed">("idle");
+  const [shortcutCopyState, setShortcutCopyState] = useState<"idle" | "copied" | "failed">("idle");
 
   const filledCount = Object.values(scores).filter((value) => value !== null).length;
   const decision = decisionFromScores(scores, rubricRows.length);
@@ -552,6 +570,11 @@ export function ReviewScorecard({
   );
   const recommendedExport = recommendedExportForDestination(selectedDestination, pickupLane, deliveryReadiness);
   const recommendedExportSurface = exportSurfaces[recommendedExport.exportId];
+  const shortcutAlternatives = alternativeExportsForDestination(
+    selectedDestination,
+    recommendedExport.exportId,
+    pickupLane
+  );
   const presetRecommendations = deliveryDestinationOrder.map((destination) => {
     const recommendation = recommendedExportForDestination(destination, pickupLane, deliveryReadiness);
     return {
@@ -890,6 +913,69 @@ export function ReviewScorecard({
                   </article>
                 );
               })}
+            </div>
+
+            <div className="shortcutStrip">
+              <div className="shortcutHeader">
+                <strong>Quick-export strip</strong>
+                <span className="pill">{recommendedExportSurface.label}</span>
+              </div>
+              <p className="scoreHint">
+                Use the fastest path for the current destination, or pivot to one of the nearby alternatives without leaving the guide surface.
+              </p>
+              <div className="shortcutActions">
+                <button
+                  type="button"
+                  className="actionButton"
+                  onClick={async () => {
+                    try {
+                      await navigator.clipboard.writeText(exportMarkdownById[recommendedExport.exportId]);
+                      setShortcutCopyState("copied");
+                    } catch {
+                      setShortcutCopyState("failed");
+                    }
+                  }}
+                >
+                  Copy {recommendedExportSurface.label}
+                </button>
+                <button
+                  type="button"
+                  className="actionButton"
+                  onClick={() => {
+                    document.getElementById(recommendedExportSurface.targetId)?.scrollIntoView({
+                      behavior: "smooth",
+                      block: "start"
+                    });
+                  }}
+                >
+                  Jump to {recommendedExportSurface.label}
+                </button>
+              </div>
+              <div className="shortcutAltList">
+                {shortcutAlternatives.map((exportId) => (
+                  <button
+                    key={exportId}
+                    type="button"
+                    className="laneToggleButton"
+                    onClick={() => {
+                      setSelectedExport(exportId);
+                      document.getElementById(exportSurfaces[exportId].targetId)?.scrollIntoView({
+                        behavior: "smooth",
+                        block: "start"
+                      });
+                    }}
+                  >
+                    Try {exportSurfaces[exportId].label}
+                  </button>
+                ))}
+              </div>
+              <p className="scoreHint">
+                {shortcutCopyState === "copied"
+                  ? `${recommendedExportSurface.label} copied from the shortcut strip.`
+                  : shortcutCopyState === "failed"
+                    ? "Clipboard copy failed. You can still copy from the recommended export card below."
+                    : "Use the shortcut strip when you already trust the current recommendation and want the fastest copy or jump action."}
+              </p>
             </div>
 
             <div className="handoffSections">


### PR DESCRIPTION
## Summary
- add a compact quick-export strip for the current recommended delivery path
- support one-step copy and jump actions for the recommended export from the guide card
- add lightweight pivot buttons for nearby alternative exports without removing the detailed export cards

## Testing
- python -m backend.app.cli classify-lane --files frontend/src/app/review-scorecard.tsx frontend/src/app/globals.css
- ./make.ps1 smoke
- ./make.ps1 eval-demo
- ./make.ps1 test
- npm.cmd run build --prefix frontend

Closes #77