### PR TITLE
[codex] Sync repo truth to Phase 12 queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -43,6 +43,10 @@
     {
       "title": "Phase 11 - Export Presets and Delivery Shortcuts",
       "description": "Reduce operator decision friction by adding export presets, delivery shortcuts, and clearer guided handoff entry points without changing core simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 12 - Delivery Preset Refinement and Comparison Flow",
+      "description": "Refine the new delivery presets and shortcut surfaces with clearer comparison and context carry-forward, without changing core simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -100,6 +104,11 @@
       "name": "phase:11",
       "color": "4b4fb6",
       "description": "Phase 11 export presets and delivery shortcuts work."
+    },
+    {
+      "name": "phase:12",
+      "color": "5b48c8",
+      "description": "Phase 12 delivery preset refinement and comparison work."
     },
     {
       "name": "area:backend",
@@ -576,6 +585,51 @@
         "lane:auto-safe"
       ],
       "body": "## goal\nAdd a compact quick-export shortcut strip to the workbench so the operator can copy the current recommended export, jump to its detailed card, or pivot to the next-best export without scrolling through the full sidebar.\n\n## input\n- current destination-aware recommendation banner\n- current packet chooser and coverage matrix\n- current workbench layout\n\n## output\n- a shortcut strip for the current recommended path with copy and jump actions\n- a lightweight path to alternative exports when the operator does not want the default recommendation\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas, scoring contracts, or queue-governance rules\n- removing the existing detailed export cards\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the shortcut strip stays aligned with the current recommended export\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 11"
+    },
+    {
+      "title": "Phase 12 exit gate",
+      "milestone": "Phase 12 - Delivery Preset Refinement and Comparison Flow",
+      "labels": [
+        "phase:12",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nConfirm that the Phase 12 delivery preset refinement and comparison criteria are satisfied before the automation system advances again.\n\n## input\n- Phase 12 milestone state\n- merged PR state for queue sync and preset-refinement work\n- local validation commands and reviewed artifacts\n\n## output\n- explicit Phase 12 closeout decision\n- documented stop condition for the Phase 12 queue\n- gap issues if any execution issue remains incomplete\n\n## out-of-scope\n- opening the next successor milestone before Phase 12 completion\n- simulation, report, claim, evidence, scenario, or artifact contract expansion\n\n## minimal test\n- `./make.ps1 smoke`\n- `./make.ps1 test`\n- `./make.ps1 eval-demo`\n- `python -m backend.app.cli audit-phase phase3`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. Exit gating controls whether the automation queue may advance.\n\n## phase\nPhase 12"
+    },
+    {
+      "title": "Phase 12: sync bootstrap spec and docs to the active preset-refinement queue",
+      "milestone": "Phase 12 - Delivery Preset Refinement and Comparison Flow",
+      "labels": [
+        "phase:12",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nSync the repository source of truth from the closed Phase 11 baseline to the active Phase 12 queue so docs, bootstrap metadata, and README reflect the new preset-refinement track.\n\n## input\n- `.github/automation/bootstrap-spec.json`\n- `README.md`\n- `docs/plans/automation-roadmap.md`\n- `docs/plans/current-state-baseline.md`\n- `docs/plans/phase-execution-queue.md`\n- current live GitHub milestone and issue state\n\n## output\n- `phase:12` and Phase 12 queue objects recorded in the bootstrap spec\n- README and planning docs updated to show Phase 12 as the active successor queue\n- no stale Phase 11 active-queue language remains in the active-state docs\n\n## out-of-scope\n- local automation card changes\n- simulation, report, or artifact contract changes\n- preset-refinement UI changes\n\n## minimal test\n- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`\n- `python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`\n- `./make.ps1 test`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. This work changes the active operational GitHub queue truth surface.\n\n## phase\nPhase 12"
+    },
+    {
+      "title": "Phase 12: add preset comparison cards with expected omissions and best-fit destinations",
+      "milestone": "Phase 12 - Delivery Preset Refinement and Comparison Flow",
+      "labels": [
+        "phase:12",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd richer preset comparison cards to the workbench so an operator can compare the current PR-comment, closeout, and pickup presets by what they omit, what they emphasize, and where they fit best before choosing one.\n\n## input\n- current delivery preset cards\n- current destination-aware recommendation banner and coverage matrix\n- current workbench layout\n\n## output\n- more informative preset cards with clearer omission and best-fit signals\n- no backend API calls and no new artifact files\n- the existing detailed export controls remain available\n\n## out-of-scope\n- changing packet schemas or queue-governance rules\n- posting directly to GitHub\n- removing the current preset entry points\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the preset cards better differentiate when to use each flow\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 12"
+    },
+    {
+      "title": "Phase 12: add context carry-forward chips for claims, blockers, and validation steps across guided exports",
+      "milestone": "Phase 12 - Delivery Preset Refinement and Comparison Flow",
+      "labels": [
+        "phase:12",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd context carry-forward chips to the guided export area so an operator can see at a glance which claims, blockers, and validation steps will travel with the current preset or recommended export.\n\n## input\n- current recommendation banner, readiness panel, coverage matrix, and detailed export surfaces\n- current claim, blocker, and validation-command context already rendered in the workbench\n- current workbench layout\n\n## output\n- lightweight carry-forward chips or tags that make the export payload more legible before copy\n- no backend API calls and no new artifact files\n- no packet schema changes\n\n## out-of-scope\n- persistent selection state across sessions\n- posting directly to GitHub\n- changing existing packet contents or queue-governance rules\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the carry-forward chips visibly track the current preset/recommended export context\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 12"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-10 gates, and resumed the successor queue as `Phase 11 - Export Presets and Delivery Shortcuts`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-11 gates, and resumed the successor queue as `Phase 12 - Delivery Preset Refinement and Comparison Flow`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -31,8 +31,9 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-10 gates, and r
   - milestone `Phase 8 - Closeout Delivery and Pickup Routing` is closed
   - milestone `Phase 9 - Review Delivery Polish and Completeness` is closed
   - milestone `Phase 10 - Guided Delivery and Quick Export` is closed
-  - milestone `Phase 11 - Export Presets and Delivery Shortcuts` is open
-  - Phase 11 queue is initialized through issues `#74-#77`
+  - milestone `Phase 11 - Export Presets and Delivery Shortcuts` is closed
+  - milestone `Phase 12 - Delivery Preset Refinement and Comparison Flow` is open
+  - Phase 12 queue is initialized through issues `#81-#84`
 
 Local phase audits currently show:
 
@@ -87,7 +88,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): review workbench with Phase 10 guided-export surfaces landed and the current Phase 11 export-shortcut queue still consuming the same artifact surface
+- [frontend](/D:/mirror/frontend): review workbench with Phase 11 preset and shortcut surfaces landed and the current Phase 12 preset-refinement queue still consuming the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -132,10 +133,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 10 closeout are complete. Phase 11 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 11 closeout are complete. Phase 12 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may resume pickup guidance only against the Phase 11 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation may resume pickup guidance only against the Phase 12 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, and Phase 11 is now the active export-shortcut track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, and Phase 12 is now the active preset-refinement track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -34,9 +34,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 10 is closed locally and in GitHub.
 - Phase 10 exit issue `#67` is closed and milestone `Phase 10 - Guided Delivery and Quick Export` is closed.
 - The Phase 10 queue was completed through issues `#67-#70`.
-- Phase 11 is the active successor queue.
-- milestone `Phase 11 - Export Presets and Delivery Shortcuts` is open.
-- The Phase 11 queue is initialized through issues `#74-#77`.
+- Phase 11 is closed locally and in GitHub.
+- Phase 11 exit issue `#74` is closed and milestone `Phase 11 - Export Presets and Delivery Shortcuts` is closed.
+- The Phase 11 queue was completed through issues `#74-#77`.
+- Phase 12 is the active successor queue.
+- milestone `Phase 12 - Delivery Preset Refinement and Comparison Flow` is open.
+- The Phase 12 queue is initialized through issues `#81-#84`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 11 active-queue baseline.
+This note is the current Phase 12 active-queue baseline.
 
 ## Snapshot
 
@@ -48,11 +48,15 @@ This note is the current Phase 11 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/issues/67`
     - Phase 10 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/11`
-    - milestone `Phase 11 - Export Presets and Delivery Shortcuts` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=11"`
-    - Phase 11 queue is initialized through issues `#74-#77`
+    - milestone `Phase 11 - Export Presets and Delivery Shortcuts` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/74`
+    - Phase 11 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/12`
+    - milestone `Phase 12 - Delivery Preset Refinement and Comparison Flow` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=12"`
+    - Phase 12 queue is initialized through issues `#81-#84`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` because Phase 11 has one blocked protected-core exit gate and multiple ready work items
+    - successor queue currently reports `ready` because Phase 12 has one blocked protected-core exit gate and multiple ready work items
 
 ## Trusted Source Of Truth
 
@@ -69,13 +73,13 @@ This note is the current Phase 11 active-queue baseline.
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
-- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, and packet coverage previews without introducing backend API expansion.
-- The current repository state is in an active Phase 11 successor queue, not a closed Phase 10 baseline.
+- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, and quick-export shortcuts without introducing backend API expansion.
+- The current repository state is in an active Phase 12 successor queue, not a closed Phase 11 baseline.
 
 ## Next Entry Point
 
-- Phase 11 is the active milestone and the current export-shortcut slice is tracked by issues `#74-#77`.
-- New implementation work should attach to the existing Phase 11 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- Phase 12 is the active milestone and the current preset-refinement slice is tracked by issues `#81-#84`.
+- New implementation work should attach to the existing Phase 12 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
 - The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 11 queue resumption.
+This note records the current post-Day-0 execution status for Mirror after the Phase 12 queue resumption.
 
 ## Current Gate State
 
@@ -14,7 +14,8 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 8 exit gate: closed
 - Phase 9 exit gate: closed
 - Phase 10 exit gate: closed
-- Phase 11 exit gate: open
+- Phase 11 exit gate: closed
+- Phase 12 exit gate: open
 
 Local phase audits currently report:
 
@@ -69,16 +70,24 @@ Local phase audits currently report:
   - closed
 - milestone `Phase 10 - Guided Delivery and Quick Export`
   - closed
+- Phase 11 exit issue `#74`
+  - closed
+- milestone `Phase 11 - Export Presets and Delivery Shortcuts`
+  - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 11 queue kickoff
+  - no open pull requests remain after the Phase 12 queue kickoff
 
 ## Current Queue
 
-- milestone `Phase 11 - Export Presets and Delivery Shortcuts` is open.
-- `#74` `Phase 11 exit gate`
+- milestone `Phase 12 - Delivery Preset Refinement and Comparison Flow` is open.
+- `#81` `Phase 12 exit gate`
   - open
-  - blocked until the Phase 11 export presets and delivery shortcuts slice is complete
-- The current Phase 11 execution slice is tracked through:
+-  - blocked until the Phase 12 delivery preset refinement and comparison slice is complete
+- The current Phase 12 execution slice is tracked through:
+  - `#82` `Phase 12: sync bootstrap spec and docs to the active preset-refinement queue`
+  - `#83` `Phase 12: add preset comparison cards with expected omissions and best-fit destinations`
+  - `#84` `Phase 12: add context carry-forward chips for claims, blockers, and validation steps across guided exports`
+- The completed Phase 11 slice was tracked through:
   - `#75` `Phase 11: sync bootstrap spec and docs to the active export-shortcut queue`
   - `#76` `Phase 11: add delivery preset cards for PR comment, closeout, and pickup handoff`
   - `#77` `Phase 11: add quick-export shortcut strip with copy and jump actions for the current recommended path`


### PR DESCRIPTION
## Summary
- add Phase 12 milestone, label, and issue definitions to the GitHub bootstrap spec
- update README and planning docs so Phase 12 is the only active execution queue
- record Phase 11 closeout and the newly bootstrapped Phase 12 queue in the current-state notes

## Testing
- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
- ./make.ps1 test
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim

Closes #82