### PR TITLE
Phase 15: sync bootstrap spec and docs to the active override-confidence queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -55,6 +55,10 @@
     {
       "title": "Phase 14 - Export Delta and Copy Confidence",
       "description": "Turn guided export selection into a higher-confidence handoff step by surfacing export deltas and destination-specific copy preflight cues without changing core simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 15 - Override Rationale and Delivery Confidence",
+      "description": "Turn guided export selection into a clearer operator commitment step by surfacing override rationale and copy-sidecar handoff context without changing core simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -127,6 +131,11 @@
       "name": "phase:14",
       "color": "7a39de",
       "description": "Phase 14 export delta and copy confidence work."
+    },
+    {
+      "name": "phase:15",
+      "color": "8a32e6",
+      "description": "Phase 15 override rationale and delivery confidence work."
     },
     {
       "name": "area:backend",
@@ -738,6 +747,51 @@
         "lane:auto-safe"
       ],
       "body": "## goal\nAdd destination-specific copy preflight checklist and blocker acknowledgements to the guided export area so an operator can tell whether the current export is safe to copy as-is for the selected destination.\n\n## input\n- current tradeoff notes, readiness panel, blocker state, and export controls\n- current guided export layout\n- current destination-aware recommendation flow\n\n## output\n- pre-copy checklist cues tied to the selected destination and recommendation\n- clearer acknowledgement of blockers or missing inputs before copy\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- blocking the copy action behind persistence or modal workflows\n- changing packet schemas or queue-governance rules\n- adding backend review state\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the preflight cues change with destination, blockers, and readiness\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 14"
+    },
+    {
+      "title": "Phase 15 exit gate",
+      "milestone": "Phase 15 - Override Rationale and Delivery Confidence",
+      "labels": [
+        "phase:15",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nConfirm that the Phase 15 override rationale and delivery confidence criteria are satisfied before the automation system advances again.\n\n## input\n- Phase 15 milestone state\n- merged PR state for queue sync and delivery-confidence work\n- local validation commands and reviewed artifacts\n\n## output\n- explicit Phase 15 closeout decision\n- documented stop condition for the Phase 15 queue\n- gap issues if any execution issue remains incomplete\n\n## out-of-scope\n- opening the next successor milestone before Phase 15 completion\n- simulation, report, claim, evidence, scenario, or artifact contract expansion\n\n## minimal test\n- `./make.ps1 smoke`\n- `./make.ps1 test`\n- `./make.ps1 eval-demo`\n- `python -m backend.app.cli audit-phase phase3`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. Exit gating controls whether the automation queue may advance.\n\n## phase\nPhase 15"
+    },
+    {
+      "title": "Phase 15: sync bootstrap spec and docs to the active override-confidence queue",
+      "milestone": "Phase 15 - Override Rationale and Delivery Confidence",
+      "labels": [
+        "phase:15",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nSync the repository source of truth from the closed Phase 14 baseline to the active Phase 15 queue so docs, bootstrap metadata, and README reflect the new override-confidence track.\n\n## input\n- `.github/automation/bootstrap-spec.json`\n- `README.md`\n- `docs/plans/automation-roadmap.md`\n- `docs/plans/current-state-baseline.md`\n- `docs/plans/phase-execution-queue.md`\n- current live GitHub milestone and issue state\n\n## output\n- `phase:15` and Phase 15 queue objects recorded in the bootstrap spec\n- README and planning docs updated to show Phase 15 as the active successor queue\n- no stale Phase 14 active-queue language remains in the active-state docs\n\n## out-of-scope\n- local automation card changes\n- simulation, report, or artifact contract changes\n- override-confidence UI changes\n\n## minimal test\n- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`\n- `python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`\n- `./make.ps1 test`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. This work changes the active operational GitHub queue truth surface.\n\n## phase\nPhase 15"
+    },
+    {
+      "title": "Phase 15: add explicit keep-vs-override rationale cues for guided exports",
+      "milestone": "Phase 15 - Override Rationale and Delivery Confidence",
+      "labels": [
+        "phase:15",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd an explicit override rationale layer to the guided export area so an operator can record why they are keeping the recommendation or deliberately choosing a fallback export.\n\n## input\n- current recommendation banner, payload preview, diff highlights, tradeoff notes, and copy preflight surfaces\n- current destination-aware export guidance flow\n- current guided export layout\n\n## output\n- explicit keep-vs-override cues tied to the current recommendation and selected fallback\n- lightweight rationale prompts or derived notes that help future readers understand why a fallback was chosen\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- persistent operator storage\n- changing export packet schemas or queue-governance rules\n- posting directly to GitHub\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that fallback selection produces clearer rationale cues before copy\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 15"
+    },
+    {
+      "title": "Phase 15: add copy-sidecar summary for destination fit, blocker acknowledgement, and selection confidence",
+      "milestone": "Phase 15 - Override Rationale and Delivery Confidence",
+      "labels": [
+        "phase:15",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a compact copy-sidecar summary to the guided export area so an operator can carry destination fit, blocker acknowledgements, and export-selection confidence into the final handoff without re-reading the whole workbench.\n\n## input\n- current copy preflight, blocker acknowledgement, recommendation, and payload compare surfaces\n- current selected destination and export state\n- current guided export layout\n\n## output\n- a concise sidecar summary that can travel with the copied export or sit beside it during handoff\n- clearer copy-confidence cues for the selected destination and current blocker state\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- changing packet schemas or backend review state\n- auto-posting to GitHub\n- gating copy behind modal confirmation flows\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the sidecar summary tracks destination, blocker, and selection changes\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 15"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-13 gates, and resumed the successor queue as `Phase 14 - Export Delta and Copy Confidence`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-14 gates, and resumed the successor queue as `Phase 15 - Override Rationale and Delivery Confidence`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -34,8 +34,9 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-13 gates, and r
   - milestone `Phase 11 - Export Presets and Delivery Shortcuts` is closed
   - milestone `Phase 12 - Delivery Preset Refinement and Comparison Flow` is closed
   - milestone `Phase 13 - Guided Export Payload Review` is closed
-  - milestone `Phase 14 - Export Delta and Copy Confidence` is open
-  - Phase 14 queue is initialized through issues `#95-#98`
+  - milestone `Phase 14 - Export Delta and Copy Confidence` is closed
+  - milestone `Phase 15 - Override Rationale and Delivery Confidence` is open
+  - Phase 15 queue is initialized through issues `#102-#105`
 
 Local phase audits currently show:
 
@@ -90,7 +91,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): review workbench with Phase 13 payload-preview and tradeoff-guidance surfaces landed and the current Phase 14 export-delta queue still consuming the same artifact surface
+- [frontend](/D:/mirror/frontend): review workbench with Phase 14 diff-highlights and copy-preflight surfaces landed and the current Phase 15 override-confidence queue still consuming the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -135,10 +136,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 13 closeout are complete. Phase 14 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 14 closeout are complete. Phase 15 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may resume pickup guidance only against the Phase 14 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation may resume pickup guidance only against the Phase 15 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, and Phase 14 is now the active export-delta track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, and Phase 15 is now the active override-confidence track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -43,9 +43,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 13 is closed locally and in GitHub.
 - Phase 13 exit issue `#88` is closed and milestone `Phase 13 - Guided Export Payload Review` is closed.
 - The Phase 13 queue was completed through issues `#88-#91`.
-- Phase 14 is the active successor queue.
-- milestone `Phase 14 - Export Delta and Copy Confidence` is open.
-- The Phase 14 queue is initialized through issues `#95-#98`.
+- Phase 14 is closed locally and in GitHub.
+- Phase 14 exit issue `#95` is closed and milestone `Phase 14 - Export Delta and Copy Confidence` is closed.
+- The Phase 14 queue was completed through issues `#95-#98`.
+- Phase 15 is the active successor queue.
+- milestone `Phase 15 - Override Rationale and Delivery Confidence` is open.
+- The Phase 15 queue is initialized through issues `#102-#105`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 14 active-queue baseline.
+This note is the current Phase 15 active-queue baseline.
 
 ## Snapshot
 
@@ -60,11 +60,15 @@ This note is the current Phase 14 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/issues/88`
     - Phase 13 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/14`
-    - milestone `Phase 14 - Export Delta and Copy Confidence` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=14"`
-    - Phase 14 queue is initialized through issues `#95-#98`
+    - milestone `Phase 14 - Export Delta and Copy Confidence` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/95`
+    - Phase 14 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/15`
+    - milestone `Phase 15 - Override Rationale and Delivery Confidence` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=15"`
+    - Phase 15 queue is initialized through issues `#102-#105`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` because Phase 14 has one blocked protected-core exit gate and multiple ready work items
+    - successor queue currently reports `ready` because Phase 15 has one blocked protected-core exit gate and multiple ready work items
 
 ## Trusted Source Of Truth
 
@@ -81,13 +85,13 @@ This note is the current Phase 14 active-queue baseline.
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
-- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, and tradeoff-guidance cards without introducing backend API expansion.
-- The current repository state is in an active Phase 14 successor queue, not a closed Phase 13 baseline.
+- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, and copy-preflight checklists without introducing backend API expansion.
+- The current repository state is in an active Phase 15 successor queue, not a closed Phase 14 baseline.
 
 ## Next Entry Point
 
-- Phase 14 is the active milestone and the current export-delta slice is tracked by issues `#95-#98`.
-- New implementation work should attach to the existing Phase 14 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- Phase 15 is the active milestone and the current override-confidence slice is tracked by issues `#102-#105`.
+- New implementation work should attach to the existing Phase 15 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
 - The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 14 queue resumption.
+This note records the current post-Day-0 execution status for Mirror after the Phase 15 queue resumption.
 
 ## Current Gate State
 
@@ -17,7 +17,8 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 11 exit gate: closed
 - Phase 12 exit gate: closed
 - Phase 13 exit gate: closed
-- Phase 14 exit gate: open
+- Phase 14 exit gate: closed
+- Phase 15 exit gate: open
 
 Local phase audits currently report:
 
@@ -84,16 +85,24 @@ Local phase audits currently report:
   - closed
 - milestone `Phase 13 - Guided Export Payload Review`
   - closed
+- Phase 14 exit issue `#95`
+  - closed
+- milestone `Phase 14 - Export Delta and Copy Confidence`
+  - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 14 queue kickoff
+  - no open pull requests remain after the Phase 15 queue kickoff
 
 ## Current Queue
 
-- milestone `Phase 14 - Export Delta and Copy Confidence` is open.
-- `#95` `Phase 14 exit gate`
+- milestone `Phase 15 - Override Rationale and Delivery Confidence` is open.
+- `#102` `Phase 15 exit gate`
   - open
-- blocked until the Phase 14 export delta and copy confidence slice is complete
-- The current Phase 14 execution slice is tracked through:
+- blocked until the Phase 15 override rationale and delivery confidence slice is complete
+- The current Phase 15 execution slice is tracked through:
+  - `#103` `Phase 15: sync bootstrap spec and docs to the active override-confidence queue`
+  - `#104` `Phase 15: add explicit keep-vs-override rationale cues for guided exports`
+  - `#105` `Phase 15: add copy-sidecar summary for destination fit, blocker acknowledgement, and selection confidence`
+- The completed Phase 14 slice was tracked through:
   - `#96` `Phase 14: sync bootstrap spec and docs to the active export-delta queue`
   - `#97` `Phase 14: add section-level diff highlights between the recommended export and the selected fallback`
   - `#98` `Phase 14: add destination-specific copy preflight checklist and blocker acknowledgements`


### PR DESCRIPTION
## Summary
- sync the bootstrap spec to the live Phase 15 milestone, label, and issue objects
- update README and planning docs so Phase 14 is closed and Phase 15 is the only active queue
- refresh the current-state baseline and execution queue notes to match the live GitHub queue audit

## Testing
- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
- ./make.ps1 test
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim

Closes #103