### PR TITLE
Phase 16: sync bootstrap spec and docs to the active handoff-packaging queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -59,6 +59,10 @@
     {
       "title": "Phase 15 - Override Rationale and Delivery Confidence",
       "description": "Turn guided export selection into a clearer operator commitment step by surfacing override rationale and copy-sidecar handoff context without changing core simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 16 - Export Bundle Composition and Handoff Packaging",
+      "description": "Turn the guided export choice into a clearer final handoff package by composing export companions and destination-specific attachment order without changing core simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -136,6 +140,11 @@
       "name": "phase:15",
       "color": "8a32e6",
       "description": "Phase 15 override rationale and delivery confidence work."
+    },
+    {
+      "name": "phase:16",
+      "color": "9730ef",
+      "description": "Phase 16 export bundle composition and handoff packaging work."
     },
     {
       "name": "area:backend",
@@ -792,6 +801,51 @@
         "lane:auto-safe"
       ],
       "body": "## goal\nAdd a compact copy-sidecar summary to the guided export area so an operator can carry destination fit, blocker acknowledgements, and export-selection confidence into the final handoff without re-reading the whole workbench.\n\n## input\n- current copy preflight, blocker acknowledgement, recommendation, and payload compare surfaces\n- current selected destination and export state\n- current guided export layout\n\n## output\n- a concise sidecar summary that can travel with the copied export or sit beside it during handoff\n- clearer copy-confidence cues for the selected destination and current blocker state\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- changing packet schemas or backend review state\n- auto-posting to GitHub\n- gating copy behind modal confirmation flows\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the sidecar summary tracks destination, blocker, and selection changes\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 15"
+    },
+    {
+      "title": "Phase 16 exit gate",
+      "milestone": "Phase 16 - Export Bundle Composition and Handoff Packaging",
+      "labels": [
+        "phase:16",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nConfirm that the Phase 16 export bundle composition and handoff packaging criteria are satisfied before the automation system advances again.\n\n## input\n- Phase 16 milestone state\n- merged PR state for queue sync and handoff-packaging work\n- local validation commands and reviewed artifacts\n\n## output\n- explicit Phase 16 closeout decision\n- documented stop condition for the Phase 16 queue\n- gap issues if any execution issue remains incomplete\n\n## out-of-scope\n- opening the next successor milestone before Phase 16 completion\n- simulation, report, claim, evidence, scenario, or artifact contract expansion\n\n## minimal test\n- `./make.ps1 smoke`\n- `./make.ps1 test`\n- `./make.ps1 eval-demo`\n- `python -m backend.app.cli audit-phase phase3`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. Exit gating controls whether the automation queue may advance.\n\n## phase\nPhase 16"
+    },
+    {
+      "title": "Phase 16: sync bootstrap spec and docs to the active handoff-packaging queue",
+      "milestone": "Phase 16 - Export Bundle Composition and Handoff Packaging",
+      "labels": [
+        "phase:16",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nSync the repository source of truth from the closed Phase 15 baseline to the active Phase 16 queue so docs, bootstrap metadata, and README reflect the new handoff-packaging track.\n\n## input\n- `.github/automation/bootstrap-spec.json`\n- `README.md`\n- `docs/plans/automation-roadmap.md`\n- `docs/plans/current-state-baseline.md`\n- `docs/plans/phase-execution-queue.md`\n- current live GitHub milestone and issue state\n\n## output\n- `phase:16` and Phase 16 queue objects recorded in the bootstrap spec\n- README and planning docs updated to show Phase 16 as the active successor queue\n- no stale Phase 15 active-queue language remains in the active-state docs\n\n## out-of-scope\n- local automation card changes\n- simulation, report, or artifact contract changes\n- handoff-packaging UI changes\n\n## minimal test\n- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`\n- `python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`\n- `./make.ps1 test`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. This work changes the active operational GitHub queue truth surface.\n\n## phase\nPhase 16"
+    },
+    {
+      "title": "Phase 16: add composed handoff-bundle preview for export, rationale note, and sidecar summary",
+      "milestone": "Phase 16 - Export Bundle Composition and Handoff Packaging",
+      "labels": [
+        "phase:16",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a composed handoff-bundle preview so an operator can see the current export, rationale note, and sidecar summary together before copy or handoff.\n\n## input\n- current selected export\n- current rationale note preview and copy-sidecar summary surfaces\n- current guided export layout\n\n## output\n- a combined bundle preview that shows how the current export companions fit together\n- no backend API calls and no new artifact files\n- no packet schema changes\n\n## out-of-scope\n- auto-posting to GitHub\n- changing the underlying export payload generation rules\n- queue-governance changes\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the bundle preview updates when export selection or rationale changes\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 16"
+    },
+    {
+      "title": "Phase 16: add destination-specific attachment order and companion checklist for handoff packaging",
+      "milestone": "Phase 16 - Export Bundle Composition and Handoff Packaging",
+      "labels": [
+        "phase:16",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd destination-specific attachment order and companion checklist cues so an operator knows how to package the current export, rationale note, and sidecar for the selected handoff destination.\n\n## input\n- current destination-aware recommendation flow\n- current rationale layer, copy sidecar, and copy preflight surfaces\n- current guided export layout\n\n## output\n- clear attachment-order guidance for PR comments, closeout notes, and pickup handoffs\n- a lightweight companion checklist that shows which pieces should travel together\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- auto-posting to GitHub\n- changing export packet schemas or backend review state\n- adding persistent package templates\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the attachment guidance changes with destination and selected export state\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 16"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-14 gates, and resumed the successor queue as `Phase 15 - Override Rationale and Delivery Confidence`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-15 gates, and resumed the successor queue as `Phase 16 - Export Bundle Composition and Handoff Packaging`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -35,8 +35,9 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-14 gates, and r
   - milestone `Phase 12 - Delivery Preset Refinement and Comparison Flow` is closed
   - milestone `Phase 13 - Guided Export Payload Review` is closed
   - milestone `Phase 14 - Export Delta and Copy Confidence` is closed
-  - milestone `Phase 15 - Override Rationale and Delivery Confidence` is open
-  - Phase 15 queue is initialized through issues `#102-#105`
+  - milestone `Phase 15 - Override Rationale and Delivery Confidence` is closed
+  - milestone `Phase 16 - Export Bundle Composition and Handoff Packaging` is open
+  - Phase 16 queue is initialized through issues `#109-#112`
 
 Local phase audits currently show:
 
@@ -91,7 +92,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): review workbench with Phase 14 diff-highlights and copy-preflight surfaces landed and the current Phase 15 override-confidence queue still consuming the same artifact surface
+- [frontend](/D:/mirror/frontend): review workbench with Phase 15 rationale and copy-sidecar surfaces landed and the current Phase 16 handoff-packaging queue still consuming the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -136,10 +137,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 14 closeout are complete. Phase 15 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 15 closeout are complete. Phase 16 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may resume pickup guidance only against the Phase 15 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation may resume pickup guidance only against the Phase 16 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, and Phase 15 is now the active override-confidence track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, and Phase 16 is now the active handoff-packaging track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -46,9 +46,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 14 is closed locally and in GitHub.
 - Phase 14 exit issue `#95` is closed and milestone `Phase 14 - Export Delta and Copy Confidence` is closed.
 - The Phase 14 queue was completed through issues `#95-#98`.
-- Phase 15 is the active successor queue.
-- milestone `Phase 15 - Override Rationale and Delivery Confidence` is open.
-- The Phase 15 queue is initialized through issues `#102-#105`.
+- Phase 15 is closed locally and in GitHub.
+- Phase 15 exit issue `#102` is closed and milestone `Phase 15 - Override Rationale and Delivery Confidence` is closed.
+- The Phase 15 queue was completed through issues `#102-#105`.
+- Phase 16 is the active successor queue.
+- milestone `Phase 16 - Export Bundle Composition and Handoff Packaging` is open.
+- The Phase 16 queue is initialized through issues `#109-#112`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 15 active-queue baseline.
+This note is the current Phase 16 active-queue baseline.
 
 ## Snapshot
 
@@ -64,11 +64,15 @@ This note is the current Phase 15 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/issues/95`
     - Phase 14 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/15`
-    - milestone `Phase 15 - Override Rationale and Delivery Confidence` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=15"`
-    - Phase 15 queue is initialized through issues `#102-#105`
+    - milestone `Phase 15 - Override Rationale and Delivery Confidence` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/102`
+    - Phase 15 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/16`
+    - milestone `Phase 16 - Export Bundle Composition and Handoff Packaging` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=16"`
+    - Phase 16 queue is initialized through issues `#109-#112`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` because Phase 15 has one blocked protected-core exit gate and multiple ready work items
+    - successor queue currently reports `ready` because Phase 16 has one blocked protected-core exit gate and multiple ready work items
 
 ## Trusted Source Of Truth
 
@@ -85,13 +89,13 @@ This note is the current Phase 15 active-queue baseline.
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
-- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, and copy-preflight checklists without introducing backend API expansion.
-- The current repository state is in an active Phase 15 successor queue, not a closed Phase 14 baseline.
+- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, and copy-sidecar summaries without introducing backend API expansion.
+- The current repository state is in an active Phase 16 successor queue, not a closed Phase 15 baseline.
 
 ## Next Entry Point
 
-- Phase 15 is the active milestone and the current override-confidence slice is tracked by issues `#102-#105`.
-- New implementation work should attach to the existing Phase 15 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- Phase 16 is the active milestone and the current handoff-packaging slice is tracked by issues `#109-#112`.
+- New implementation work should attach to the existing Phase 16 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
 - The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 15 queue resumption.
+This note records the current post-Day-0 execution status for Mirror after the Phase 16 queue resumption.
 
 ## Current Gate State
 
@@ -18,7 +18,8 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 12 exit gate: closed
 - Phase 13 exit gate: closed
 - Phase 14 exit gate: closed
-- Phase 15 exit gate: open
+- Phase 15 exit gate: closed
+- Phase 16 exit gate: open
 
 Local phase audits currently report:
 
@@ -89,16 +90,24 @@ Local phase audits currently report:
   - closed
 - milestone `Phase 14 - Export Delta and Copy Confidence`
   - closed
+- Phase 15 exit issue `#102`
+  - closed
+- milestone `Phase 15 - Override Rationale and Delivery Confidence`
+  - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 15 queue kickoff
+  - no open pull requests remain after the Phase 16 queue kickoff
 
 ## Current Queue
 
-- milestone `Phase 15 - Override Rationale and Delivery Confidence` is open.
-- `#102` `Phase 15 exit gate`
+- milestone `Phase 16 - Export Bundle Composition and Handoff Packaging` is open.
+- `#109` `Phase 16 exit gate`
   - open
-- blocked until the Phase 15 override rationale and delivery confidence slice is complete
-- The current Phase 15 execution slice is tracked through:
+- blocked until the Phase 16 export bundle composition and handoff packaging slice is complete
+- The current Phase 16 execution slice is tracked through:
+  - `#110` `Phase 16: sync bootstrap spec and docs to the active handoff-packaging queue`
+  - `#111` `Phase 16: add composed handoff-bundle preview for export, rationale note, and sidecar summary`
+  - `#112` `Phase 16: add destination-specific attachment order and companion checklist for handoff packaging`
+- The completed Phase 15 slice was tracked through:
   - `#103` `Phase 15: sync bootstrap spec and docs to the active override-confidence queue`
   - `#104` `Phase 15: add explicit keep-vs-override rationale cues for guided exports`
   - `#105` `Phase 15: add copy-sidecar summary for destination fit, blocker acknowledgement, and selection confidence`


### PR DESCRIPTION
## Summary
- sync the bootstrap spec to the live Phase 16 milestone, label, and issue objects
- update README and planning docs so Phase 15 is closed and Phase 16 is the only active queue
- refresh the current-state baseline and execution queue notes to match the live GitHub queue audit

## Testing
- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
- ./make.ps1 test
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim

Closes #110