### PR TITLE
[codex] Sync repo truth to Phase 17 queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -63,6 +63,10 @@
     {
       "title": "Phase 16 - Export Bundle Composition and Handoff Packaging",
       "description": "Turn the guided export choice into a clearer final handoff package by composing export companions and destination-specific attachment order without changing core simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 17 - Final Bundle Delivery and Handoff Manifest",
+      "description": "Turn the Phase 16 handoff package preview into a final, low-friction delivery step by adding recipient-facing cover context and one-step bundle copy surfaces without changing core simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -145,6 +149,11 @@
       "name": "phase:16",
       "color": "9730ef",
       "description": "Phase 16 export bundle composition and handoff packaging work."
+    },
+    {
+      "name": "phase:17",
+      "color": "B45F06",
+      "description": "Phase 17 final bundle delivery and handoff manifest work."
     },
     {
       "name": "area:backend",
@@ -846,6 +855,51 @@
         "lane:auto-safe"
       ],
       "body": "## goal\nAdd destination-specific attachment order and companion checklist cues so an operator knows how to package the current export, rationale note, and sidecar for the selected handoff destination.\n\n## input\n- current destination-aware recommendation flow\n- current rationale layer, copy sidecar, and copy preflight surfaces\n- current guided export layout\n\n## output\n- clear attachment-order guidance for PR comments, closeout notes, and pickup handoffs\n- a lightweight companion checklist that shows which pieces should travel together\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- auto-posting to GitHub\n- changing export packet schemas or backend review state\n- adding persistent package templates\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the attachment guidance changes with destination and selected export state\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 16"
+    },
+    {
+      "title": "Phase 17 exit gate",
+      "milestone": "Phase 17 - Final Bundle Delivery and Handoff Manifest",
+      "labels": [
+        "phase:17",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nConfirm that the Phase 17 final bundle delivery and handoff manifest criteria are satisfied before the automation system advances again.\n\n## input\n- Phase 17 milestone state\n- merged PR state for queue sync and final-bundle-delivery work\n- local validation commands and reviewed artifacts\n\n## output\n- explicit Phase 17 closeout decision\n- documented stop condition for the Phase 17 queue\n- gap issues if any execution issue remains incomplete\n\n## out-of-scope\n- opening the next successor milestone before Phase 17 completion\n- simulation, report, claim, evidence, scenario, or artifact contract expansion\n\n## minimal test\n- `./make.ps1 smoke`\n- `./make.ps1 test`\n- `./make.ps1 eval-demo`\n- `python -m backend.app.cli audit-phase phase3`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. Exit gating controls whether the automation queue may advance.\n\n## phase\nPhase 17"
+    },
+    {
+      "title": "Phase 17: sync bootstrap spec and docs to the active final-bundle-delivery queue",
+      "milestone": "Phase 17 - Final Bundle Delivery and Handoff Manifest",
+      "labels": [
+        "phase:17",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nSync the repository source of truth from the closed Phase 16 baseline to the active Phase 17 queue so docs, bootstrap metadata, and README reflect the new final-bundle-delivery track.\n\n## input\n- `.github/automation/bootstrap-spec.json`\n- `README.md`\n- `docs/plans/automation-roadmap.md`\n- `docs/plans/current-state-baseline.md`\n- `docs/plans/phase-execution-queue.md`\n- current live GitHub milestone and issue state\n\n## output\n- `phase:17` and Phase 17 queue objects recorded in the bootstrap spec\n- README and planning docs updated to show Phase 17 as the active successor queue\n- no stale Phase 16 active-queue language remains in the active-state docs\n\n## out-of-scope\n- local automation card changes\n- simulation, report, or artifact contract changes\n- final-bundle-delivery UI changes\n\n## minimal test\n- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`\n- `python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`\n- `./make.ps1 test`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. This work changes the active operational GitHub queue truth surface.\n\n## phase\nPhase 17"
+    },
+    {
+      "title": "Phase 17: add recipient-facing handoff cover sheet for the composed bundle",
+      "milestone": "Phase 17 - Final Bundle Delivery and Handoff Manifest",
+      "labels": [
+        "phase:17",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a recipient-facing handoff cover sheet so an operator can lead the final package with a concise summary of destination, selected export, rationale posture, blocker state, and included companions.\n\n## input\n- current `frontend/src/app/review-scorecard.tsx`\n- current destination-aware recommendation, rationale, sidecar, and bundle-preview surfaces\n- existing demo artifacts under `artifacts/demo/**`\n\n## output\n- a cover-sheet panel derived entirely in the frontend\n- copyable summary content that names the selected destination, chosen export, rationale stance, blocker posture, and bundle companions\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or bundle-generation contracts\n- persistent reviewer storage\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the cover sheet updates as destination, export selection, blockers, and rationale change\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 17"
+    },
+    {
+      "title": "Phase 17: add one-step final bundle copy and package manifest for handoff delivery",
+      "milestone": "Phase 17 - Final Bundle Delivery and Handoff Manifest",
+      "labels": [
+        "phase:17",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a one-step final bundle copy surface and package manifest so an operator can copy the current export plus companions as a coherent delivery artifact without manually stitching the pieces together.\n\n## input\n- current `frontend/src/app/review-scorecard.tsx`\n- current bundle preview, attachment-order guidance, and destination-aware export state\n- existing demo artifacts under `artifacts/demo/**`\n\n## output\n- a copyable final-bundle payload derived entirely in the frontend\n- package-manifest cues that show which companions are included, optional, or intentionally omitted for the current destination\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- auto-posting to GitHub\n- changing export packet schemas or review-state contracts\n- writing bundle files under `artifacts/`\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the final bundle copy and manifest change with destination, rationale, and blocker state\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 17"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-15 gates, and resumed the successor queue as `Phase 16 - Export Bundle Composition and Handoff Packaging`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-16 gates, and resumed the successor queue as `Phase 17 - Final Bundle Delivery and Handoff Manifest`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -36,8 +36,9 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-15 gates, and r
   - milestone `Phase 13 - Guided Export Payload Review` is closed
   - milestone `Phase 14 - Export Delta and Copy Confidence` is closed
   - milestone `Phase 15 - Override Rationale and Delivery Confidence` is closed
-  - milestone `Phase 16 - Export Bundle Composition and Handoff Packaging` is open
-  - Phase 16 queue is initialized through issues `#109-#112`
+  - milestone `Phase 16 - Export Bundle Composition and Handoff Packaging` is closed
+  - milestone `Phase 17 - Final Bundle Delivery and Handoff Manifest` is open
+  - Phase 17 queue is initialized through issues `#116-#119`
 
 Local phase audits currently show:
 
@@ -92,7 +93,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): review workbench with Phase 15 rationale and copy-sidecar surfaces landed and the current Phase 16 handoff-packaging queue still consuming the same artifact surface
+- [frontend](/D:/mirror/frontend): review workbench with Phase 16 bundle-preview and attachment-order surfaces landed and the current Phase 17 final-bundle-delivery queue still consuming the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -137,10 +138,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 15 closeout are complete. Phase 16 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 16 closeout are complete. Phase 17 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may resume pickup guidance only against the Phase 16 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation may resume pickup guidance only against the Phase 17 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, and Phase 16 is now the active handoff-packaging track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, and Phase 17 is now the active final-bundle-delivery track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -49,9 +49,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 15 is closed locally and in GitHub.
 - Phase 15 exit issue `#102` is closed and milestone `Phase 15 - Override Rationale and Delivery Confidence` is closed.
 - The Phase 15 queue was completed through issues `#102-#105`.
-- Phase 16 is the active successor queue.
-- milestone `Phase 16 - Export Bundle Composition and Handoff Packaging` is open.
-- The Phase 16 queue is initialized through issues `#109-#112`.
+- Phase 16 is closed locally and in GitHub.
+- Phase 16 exit issue `#109` is closed and milestone `Phase 16 - Export Bundle Composition and Handoff Packaging` is closed.
+- The Phase 16 queue was completed through issues `#109-#112`.
+- Phase 17 is the active successor queue.
+- milestone `Phase 17 - Final Bundle Delivery and Handoff Manifest` is open.
+- The Phase 17 queue is initialized through issues `#116-#119`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 16 active-queue baseline.
+This note is the current Phase 17 active-queue baseline.
 
 ## Snapshot
 
@@ -68,11 +68,15 @@ This note is the current Phase 16 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/issues/102`
     - Phase 15 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/16`
-    - milestone `Phase 16 - Export Bundle Composition and Handoff Packaging` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=16"`
-    - Phase 16 queue is initialized through issues `#109-#112`
+    - milestone `Phase 16 - Export Bundle Composition and Handoff Packaging` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/109`
+    - Phase 16 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/17`
+    - milestone `Phase 17 - Final Bundle Delivery and Handoff Manifest` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=17"`
+    - Phase 17 queue is initialized through issues `#116-#119`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` because Phase 16 has one blocked protected-core exit gate and multiple ready work items
+    - successor queue currently reports `ready` because Phase 17 has one blocked protected-core exit gate and multiple ready work items
 
 ## Trusted Source Of Truth
 
@@ -89,13 +93,13 @@ This note is the current Phase 16 active-queue baseline.
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
-- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, and copy-sidecar summaries without introducing backend API expansion.
-- The current repository state is in an active Phase 16 successor queue, not a closed Phase 15 baseline.
+- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, and destination-specific attachment-order guidance without introducing backend API expansion.
+- The current repository state is in an active Phase 17 successor queue, not a closed Phase 16 baseline.
 
 ## Next Entry Point
 
-- Phase 16 is the active milestone and the current handoff-packaging slice is tracked by issues `#109-#112`.
-- New implementation work should attach to the existing Phase 16 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- Phase 17 is the active milestone and the current final-bundle-delivery slice is tracked by issues `#116-#119`.
+- New implementation work should attach to the existing Phase 17 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
 - The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 16 queue resumption.
+This note records the current post-Day-0 execution status for Mirror after the Phase 17 queue resumption.
 
 ## Current Gate State
 
@@ -19,7 +19,8 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 13 exit gate: closed
 - Phase 14 exit gate: closed
 - Phase 15 exit gate: closed
-- Phase 16 exit gate: open
+- Phase 16 exit gate: closed
+- Phase 17 exit gate: open
 
 Local phase audits currently report:
 
@@ -95,15 +96,19 @@ Local phase audits currently report:
 - milestone `Phase 15 - Override Rationale and Delivery Confidence`
   - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 16 queue kickoff
+  - no open pull requests remain after the Phase 17 queue kickoff
 
 ## Current Queue
 
-- milestone `Phase 16 - Export Bundle Composition and Handoff Packaging` is open.
-- `#109` `Phase 16 exit gate`
+- milestone `Phase 17 - Final Bundle Delivery and Handoff Manifest` is open.
+- `#116` `Phase 17 exit gate`
   - open
-- blocked until the Phase 16 export bundle composition and handoff packaging slice is complete
-- The current Phase 16 execution slice is tracked through:
+- blocked until the Phase 17 final bundle delivery and handoff manifest slice is complete
+- The current Phase 17 execution slice is tracked through:
+  - `#117` `Phase 17: sync bootstrap spec and docs to the active final-bundle-delivery queue`
+  - `#118` `Phase 17: add recipient-facing handoff cover sheet for the composed bundle`
+  - `#119` `Phase 17: add one-step final bundle copy and package manifest for handoff delivery`
+- The completed Phase 16 slice was tracked through:
   - `#110` `Phase 16: sync bootstrap spec and docs to the active handoff-packaging queue`
   - `#111` `Phase 16: add composed handoff-bundle preview for export, rationale note, and sidecar summary`
   - `#112` `Phase 16: add destination-specific attachment order and companion checklist for handoff packaging`


### PR DESCRIPTION
## Summary
- sync the repo source of truth from the closed Phase 16 baseline to the active Phase 17 queue
- record the Phase 17 milestone, label, and issue set in the bootstrap spec
- update README and planning docs so the active queue, milestone status, and heartbeat guidance all point at Phase 17

## Why
Phase 16 is closed as of 2026-04-16 and the live queue has already moved to `Phase 17 - Final Bundle Delivery and Handoff Manifest`. The repo docs and bootstrap metadata need to reflect that live state before the next implementation issues proceed.

## Validation
- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`
- `python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`
- `./make.ps1 test`
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`

Closes #117
