### PR TITLE
[codex] Sync repo truth to Phase 21 queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -79,6 +79,10 @@
     {
       "title": "Phase 20 - Role-Specific Bundle Layout and Decision Templates",
       "description": "Turn the Phase 19 role-aware routing bundle into clearer role-specific packet layouts and decision-ready response templates without changing core simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 21 - Role Presets and Response Packaging",
+      "description": "Turn the Phase 20 role-aware bundle layouts and decision templates into faster role presets and response packaging flows without changing core simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -181,6 +185,11 @@
       "name": "phase:20",
       "color": "674EA7",
       "description": "Phase 20 role-specific bundle layout and decision template work."
+    },
+    {
+      "name": "phase:21",
+      "color": "3D85C6",
+      "description": "Phase 21 role presets and response packaging work."
     },
     {
       "name": "area:backend",
@@ -1062,6 +1071,51 @@
         "lane:auto-safe"
       ],
       "body": "## goal\nAdd decision-template snippets for acknowledge, request-more-context, and escalate follow-through so the final bundle can provide role-aware response text that is easier to reuse directly.\n\n## input\n- current `frontend/src/app/review-scorecard.tsx`\n- current follow-through routing strip, role chooser, reply prompt, and blocker state\n- existing demo artifacts under `artifacts/demo/**`\n\n## output\n- a frontend-only set of decision-template snippets derived from the current role, destination, and routing posture\n- copyable response text for acknowledge, request-more-context, and escalate paths\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- posting directly to GitHub\n- changing queue-governance rules or packet schemas\n- storing response history\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the decision-template snippets update with role, destination, and blocker posture\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 20"
+    },
+    {
+      "title": "Phase 21 exit gate",
+      "milestone": "Phase 21 - Role Presets and Response Packaging",
+      "labels": [
+        "phase:21",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nConfirm that the Phase 21 role presets and response packaging criteria are satisfied before the automation system advances again.\n\n## input\n- Phase 21 milestone state\n- merged PR state for queue sync and role-preset work\n- local validation commands and reviewed artifacts\n\n## output\n- explicit Phase 21 closeout decision\n- documented stop condition for the Phase 21 queue\n- gap issues if any execution issue remains incomplete\n\n## out-of-scope\n- opening the next successor milestone before Phase 21 completion\n- simulation, report, claim, evidence, scenario, or artifact contract expansion\n\n## minimal test\n- `./make.ps1 smoke`\n- `./make.ps1 test`\n- `./make.ps1 eval-demo`\n- `python -m backend.app.cli audit-phase phase3`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. Exit gating controls whether the automation queue may advance.\n\n## phase\nPhase 21"
+    },
+    {
+      "title": "Phase 21: sync bootstrap spec and docs to the active role-preset queue",
+      "milestone": "Phase 21 - Role Presets and Response Packaging",
+      "labels": [
+        "phase:21",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nSync the repository source of truth from the closed Phase 20 baseline to the active Phase 21 queue so docs, bootstrap metadata, and README reflect the new role-preset track.\n\n## input\n- `.github/automation/bootstrap-spec.json`\n- `README.md`\n- `docs/plans/automation-roadmap.md`\n- `docs/plans/current-state-baseline.md`\n- `docs/plans/phase-execution-queue.md`\n- current live GitHub milestone and issue state\n\n## output\n- `phase:21` and Phase 21 queue objects recorded in the bootstrap spec\n- README and planning docs updated to show Phase 21 as the active successor queue\n- no stale Phase 20 active-queue language remains in the active-state docs\n\n## out-of-scope\n- local automation card changes\n- simulation, report, or artifact contract changes\n- role-preset UI changes\n\n## minimal test\n- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`\n- `python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`\n- `./make.ps1 test`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. This work changes the active operational GitHub queue truth surface.\n\n## phase\nPhase 21"
+    },
+    {
+      "title": "Phase 21: add role preset cards for reviewer, approver, and operator bundle modes",
+      "milestone": "Phase 21 - Role Presets and Response Packaging",
+      "labels": [
+        "phase:21",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd role preset cards so reviewer, approver, and operator modes can switch the final bundle to a recommended section mix and copy posture without manually toggling every control.\n\n## input\n- current `frontend/src/app/review-scorecard.tsx`\n- current role chooser, bundle variant chooser, routing strip, and decision-template surfaces\n- existing demo artifacts under `artifacts/demo/**`\n\n## output\n- a frontend-only role preset layer that applies role-aware bundle defaults and packaging emphasis\n- no backend API calls and no new artifact files\n- a clearer preset-driven entrypoint into the existing role-specific bundle workflow\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or review-state contracts\n- storing preset preferences\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that switching presets changes the bundle posture without mutating the underlying artifacts\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 21"
+    },
+    {
+      "title": "Phase 21: add response-packaging shortcuts for acknowledge, request-more-context, and escalate templates",
+      "milestone": "Phase 21 - Role Presets and Response Packaging",
+      "labels": [
+        "phase:21",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd response-packaging shortcuts so the final bundle can expose quicker copy paths for the current acknowledge, request-more-context, and escalate templates without leaving the role-specific handoff workflow.\n\n## input\n- current `frontend/src/app/review-scorecard.tsx`\n- current routing strip, decision-template snippets, role chooser, and bundle structure\n- existing demo artifacts under `artifacts/demo/**`\n\n## output\n- a frontend-only shortcut layer for the current response-template set\n- copyable packaging shortcuts for acknowledge, request-more-context, and escalate paths\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or queue-governance contracts\n- storing shortcut history\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the shortcut actions update with role, variant, and routing posture\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 21"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-19 gates, and resumed the successor queue as `Phase 20 - Role-Specific Bundle Layout and Decision Templates`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-20 gates, and resumed the successor queue as `Phase 21 - Role Presets and Response Packaging`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -40,8 +40,9 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-19 gates, and r
   - milestone `Phase 17 - Final Bundle Delivery and Handoff Manifest` is closed
   - milestone `Phase 18 - Bundle Variants and Receiver Guidance` is closed
   - milestone `Phase 19 - Receiver Roles and Follow-Through Routing` is closed
-  - milestone `Phase 20 - Role-Specific Bundle Layout and Decision Templates` is open
-  - Phase 20 queue is initialized through issues `#137-#140`
+  - milestone `Phase 20 - Role-Specific Bundle Layout and Decision Templates` is closed
+  - milestone `Phase 21 - Role Presets and Response Packaging` is open
+  - Phase 21 queue is initialized through issues `#144-#147`
 
 Local phase audits currently show:
 
@@ -96,7 +97,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): review workbench with Phase 19 role-aware routing surfaces landed and the current Phase 20 role-template queue still consuming the same artifact surface
+- [frontend](/D:/mirror/frontend): review workbench with Phase 20 role-specific layout and decision-template surfaces landed and the current Phase 21 role-preset queue still consuming the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -141,10 +142,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 19 closeout are complete. Phase 20 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 20 closeout are complete. Phase 21 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may resume pickup guidance only against the Phase 20 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation may resume pickup guidance only against the Phase 21 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, and Phase 20 is now the active role-template track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, and Phase 21 is now the active role-preset track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -61,9 +61,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 19 is closed locally and in GitHub.
 - Phase 19 exit issue `#130` is closed and milestone `Phase 19 - Receiver Roles and Follow-Through Routing` is closed.
 - The Phase 19 queue was completed through issues `#130-#133`.
-- Phase 20 is the active successor queue.
-- milestone `Phase 20 - Role-Specific Bundle Layout and Decision Templates` is open.
-- The Phase 20 queue is initialized through issues `#137-#140`.
+- Phase 20 is closed locally and in GitHub.
+- Phase 20 exit issue `#137` is closed and milestone `Phase 20 - Role-Specific Bundle Layout and Decision Templates` is closed.
+- The Phase 20 queue was completed through issues `#137-#140`.
+- Phase 21 is the active successor queue.
+- milestone `Phase 21 - Role Presets and Response Packaging` is open.
+- The Phase 21 queue is initialized through issues `#144-#147`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 20 active-queue baseline.
+This note is the current Phase 21 active-queue baseline.
 
 ## Snapshot
 
@@ -84,11 +84,15 @@ This note is the current Phase 20 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/issues/130`
     - Phase 19 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/20`
-    - milestone `Phase 20 - Role-Specific Bundle Layout and Decision Templates` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=20"`
-    - Phase 20 queue is initialized through issues `#137-#140`
+    - milestone `Phase 20 - Role-Specific Bundle Layout and Decision Templates` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/137`
+    - Phase 20 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/21`
+    - milestone `Phase 21 - Role Presets and Response Packaging` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=21"`
+    - Phase 21 queue is initialized through issues `#144-#147`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` because Phase 20 has one blocked protected-core exit gate and multiple ready work items
+    - successor queue currently reports `ready` because Phase 21 has one blocked protected-core exit gate and multiple ready work items
 
 ## Trusted Source Of Truth
 
@@ -105,13 +109,13 @@ This note is the current Phase 20 active-queue baseline.
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
-- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, and routing-strip follow-through guidance without introducing backend API expansion.
-- The current repository state is in an active Phase 20 successor queue, not a closed Phase 19 baseline.
+- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, and decision-template snippets without introducing backend API expansion.
+- The current repository state is in an active Phase 21 successor queue, not a closed Phase 20 baseline.
 
 ## Next Entry Point
 
-- Phase 20 is the active milestone and the current role-template slice is tracked by issues `#137-#140`.
-- New implementation work should attach to the existing Phase 20 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- Phase 21 is the active milestone and the current role-preset slice is tracked by issues `#144-#147`.
+- New implementation work should attach to the existing Phase 21 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
 - The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 20 queue resumption.
+This note records the current post-Day-0 execution status for Mirror after the Phase 21 queue resumption.
 
 ## Current Gate State
 
@@ -23,7 +23,8 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 17 exit gate: closed
 - Phase 18 exit gate: closed
 - Phase 19 exit gate: closed
-- Phase 20 exit gate: open
+- Phase 20 exit gate: closed
+- Phase 21 exit gate: open
 
 Local phase audits currently report:
 
@@ -99,15 +100,19 @@ Local phase audits currently report:
 - milestone `Phase 15 - Override Rationale and Delivery Confidence`
   - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 20 queue kickoff
+  - no open pull requests remain after the Phase 21 queue kickoff
 
 ## Current Queue
 
-- milestone `Phase 20 - Role-Specific Bundle Layout and Decision Templates` is open.
-- `#137` `Phase 20 exit gate`
+- milestone `Phase 21 - Role Presets and Response Packaging` is open.
+- `#144` `Phase 21 exit gate`
   - open
-- blocked until the Phase 20 role-specific bundle layout and decision template slice is complete
-- The current Phase 20 execution slice is tracked through:
+- blocked until the Phase 21 role presets and response packaging slice is complete
+- The current Phase 21 execution slice is tracked through:
+  - `#145` `Phase 21: sync bootstrap spec and docs to the active role-preset queue`
+  - `#146` `Phase 21: add role preset cards for reviewer, approver, and operator bundle modes`
+  - `#147` `Phase 21: add response-packaging shortcuts for acknowledge, request-more-context, and escalate templates`
+- The completed Phase 20 slice was tracked through:
   - `#138` `Phase 20: sync bootstrap spec and docs to the active role-template queue`
   - `#139` `Phase 20: add role-specific bundle emphasis and section pinning for reviewer, approver, and operator modes`
   - `#140` `Phase 20: add decision-template snippets for acknowledge, request-more-context, and escalate paths`


### PR DESCRIPTION
## Summary
- sync the repo source of truth from the closed Phase 20 baseline to the active Phase 21 queue
- record the Phase 21 milestone, label, and issue set in the bootstrap spec
- update README and planning docs so the active queue, milestone status, and heartbeat guidance all point at Phase 21

## Why
Phase 20 is closed as of 2026-04-17 and the live queue has already moved to `Phase 21 - Role Presets and Response Packaging`. The repo docs and bootstrap metadata need to reflect that live state before the next implementation issues proceed.

## Validation
- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`
- `python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`
- `./make.ps1 test`
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`

Closes #145
