### PR TITLE
[codex] Sync repo truth to Phase 23 queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -87,6 +87,10 @@
     {
       "title": "Phase 22 - Preset Workflow and Packed Responses",
       "description": "Turn the Phase 21 role presets and response shortcuts into smoother preset workflows and grouped response packs without changing core simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 23 - Preset Sessions and Response Kits",
+      "description": "Turn the Phase 22 preset workflow into a more repeatable handoff session by surfacing active preset summaries and route-filtered response kits without changing core simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -199,6 +203,11 @@
       "name": "phase:22",
       "color": "0B5394",
       "description": "Phase 22 preset workflow and packed response work."
+    },
+    {
+      "name": "phase:23",
+      "color": "134F5C",
+      "description": "Phase 23 preset sessions and response kit work."
     },
     {
       "name": "area:backend",
@@ -1170,6 +1179,51 @@
         "lane:auto-safe"
       ],
       "body": "## goal\nAdd grouped response-pack export so the current acknowledge, request-more-context, and escalate templates can be copied together as a single preset-aligned response pack without leaving the final bundle workflow.\n\n## input\n- current `frontend/src/app/review-scorecard.tsx`\n- current decision-template snippets, response shortcuts, role presets, and routing strip\n- existing demo artifacts under `artifacts/demo/**`\n\n## output\n- a frontend-only grouped response-pack export derived from the current role, destination, and routing posture\n- no backend API calls and no new artifact files\n- a copyable response pack that bundles the current shortcut set together\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or queue-governance contracts\n- storing export history\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the grouped response pack updates with role, variant, and routing posture\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 22"
+    },
+    {
+      "title": "Phase 23 exit gate",
+      "milestone": "Phase 23 - Preset Sessions and Response Kits",
+      "labels": [
+        "phase:23",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nConfirm that the Phase 23 preset sessions and response kit criteria are satisfied before the automation system advances again.\n\n## input\n- Phase 23 milestone state\n- merged PR state for queue sync and preset-session work\n- local validation commands and reviewed artifacts\n\n## output\n- explicit Phase 23 closeout decision\n- documented stop condition for the Phase 23 queue\n- gap issues if any execution issue remains incomplete\n\n## out-of-scope\n- opening the next successor milestone before Phase 23 completion\n- simulation, report, claim, evidence, scenario, or artifact contract expansion\n\n## minimal test\n- `./make.ps1 smoke`\n- `./make.ps1 test`\n- `./make.ps1 eval-demo`\n- `python -m backend.app.cli audit-phase phase3`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. Exit gating controls whether the automation queue may advance.\n\n## phase\nPhase 23"
+    },
+    {
+      "title": "Phase 23: sync bootstrap spec and docs to the active preset-session queue",
+      "milestone": "Phase 23 - Preset Sessions and Response Kits",
+      "labels": [
+        "phase:23",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nSync the repository source of truth from the closed Phase 22 baseline to the active Phase 23 queue so docs, bootstrap metadata, and README reflect the new preset-session track.\n\n## input\n- `.github/automation/bootstrap-spec.json`\n- `README.md`\n- `docs/plans/automation-roadmap.md`\n- `docs/plans/current-state-baseline.md`\n- `docs/plans/phase-execution-queue.md`\n- current live GitHub milestone and issue state\n\n## output\n- `phase:23` and Phase 23 queue objects recorded in the bootstrap spec\n- README and planning docs updated to show Phase 23 as the active successor queue\n- no stale Phase 22 active-queue language remains in the active-state docs\n\n## out-of-scope\n- local automation card changes\n- simulation, report, or artifact contract changes\n- preset-session UI changes\n\n## minimal test\n- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`\n- `python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`\n- `./make.ps1 test`\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`\n\n## touches contract\nYes. This work changes the active operational GitHub queue truth surface.\n\n## phase\nPhase 23"
+    },
+    {
+      "title": "Phase 23: add active preset session summary strip for current bundle posture",
+      "milestone": "Phase 23 - Preset Sessions and Response Kits",
+      "labels": [
+        "phase:23",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd an active preset session summary strip so the current role preset, bundle mode, destination, and response posture stay visible as a single handoff session summary without changing artifact contracts.\n\n## input\n- current `frontend/src/app/review-scorecard.tsx`\n- current role preset cards, bundle controls, response shortcuts, and final bundle surface\n- existing demo artifacts under `artifacts/demo/**`\n\n## output\n- a frontend-only session summary strip for the currently active preset posture\n- no backend API calls and no new artifact files\n- copyable summary cues that stay aligned with the current preset workflow\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or review-state contracts\n- storing session history\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the session summary strip updates with preset, role, destination, and response posture\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 23"
+    },
+    {
+      "title": "Phase 23: add route-filtered response kit chooser for grouped template packs",
+      "milestone": "Phase 23 - Preset Sessions and Response Kits",
+      "labels": [
+        "phase:23",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd route-filtered response kit chooser so the current acknowledge, request-more-context, and escalate templates can be grouped and narrowed by the active route without changing artifact contracts.\n\n## input\n- current `frontend/src/app/review-scorecard.tsx`\n- current grouped response pack export, response shortcuts, role presets, and routing strip\n- existing demo artifacts under `artifacts/demo/**`\n\n## output\n- a frontend-only response kit chooser that filters the current response pack by active route\n- no backend API calls and no new artifact files\n- copyable grouped response kits that stay aligned with the active preset workflow\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or queue-governance contracts\n- storing chooser history\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the response kit chooser updates with role, route, and bundle posture\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 23"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-21 gates, and resumed the successor queue as `Phase 22 - Preset Workflow and Packed Responses`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-22 gates, and resumed the successor queue as `Phase 23 - Preset Sessions and Response Kits`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -42,8 +42,10 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-21 gates, and r
   - milestone `Phase 19 - Receiver Roles and Follow-Through Routing` is closed
   - milestone `Phase 20 - Role-Specific Bundle Layout and Decision Templates` is closed
   - milestone `Phase 21 - Role Presets and Response Packaging` is closed
-  - milestone `Phase 22 - Preset Workflow and Packed Responses` is open
-  - Phase 22 queue is initialized through issues `#151-#154`
+  - milestone `Phase 22 - Preset Workflow and Packed Responses` is closed
+  - Phase 22 queue was completed through issues `#151-#154`
+  - milestone `Phase 23 - Preset Sessions and Response Kits` is open
+  - Phase 23 queue is initialized through issues `#158-#161`
 
 Local phase audits currently show:
 
@@ -98,7 +100,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): review workbench with Phase 21 preset-action and response-shortcut surfaces landed and the current Phase 22 preset-workflow queue still consuming the same artifact surface
+- [frontend](/D:/mirror/frontend): review workbench with Phase 22 apply-and-copy preset and grouped response-pack surfaces landed while the current Phase 23 preset-session queue continues to consume the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -143,10 +145,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 21 closeout are complete. Phase 22 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 22 closeout are complete. Phase 23 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may resume pickup guidance only against the Phase 22 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation may resume pickup guidance only against the Phase 23 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, and Phase 22 is now the active preset-workflow track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, and Phase 23 is now the active preset-session track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -67,9 +67,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 21 is closed locally and in GitHub.
 - Phase 21 exit issue `#144` is closed and milestone `Phase 21 - Role Presets and Response Packaging` is closed.
 - The Phase 21 queue was completed through issues `#144-#147`.
-- Phase 22 is the active successor queue.
-- milestone `Phase 22 - Preset Workflow and Packed Responses` is open.
-- The Phase 22 queue is initialized through issues `#151-#154`.
+- Phase 22 is closed locally and in GitHub.
+- Phase 22 exit issue `#151` is closed and milestone `Phase 22 - Preset Workflow and Packed Responses` is closed.
+- The Phase 22 queue was completed through issues `#151-#154`.
+- Phase 23 is the active successor queue.
+- milestone `Phase 23 - Preset Sessions and Response Kits` is open.
+- The Phase 23 queue is initialized through issues `#158-#161`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 22 active-queue baseline.
+This note is the current Phase 23 active-queue baseline.
 
 ## Snapshot
 
@@ -92,11 +92,15 @@ This note is the current Phase 22 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/issues/144`
     - Phase 21 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/22`
-    - milestone `Phase 22 - Preset Workflow and Packed Responses` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=22"`
-    - Phase 22 queue is initialized through issues `#151-#154`
+    - milestone `Phase 22 - Preset Workflow and Packed Responses` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/151`
+    - Phase 22 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/23`
+    - milestone `Phase 23 - Preset Sessions and Response Kits` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=23"`
+    - Phase 23 queue is initialized through issues `#158-#161`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` because Phase 22 has one blocked protected-core exit gate and multiple ready work items
+    - successor queue currently reports `ready` because Phase 23 has one blocked protected-core exit gate and multiple ready work items
 
 ## Trusted Source Of Truth
 
@@ -113,13 +117,13 @@ This note is the current Phase 22 active-queue baseline.
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
-- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, and response-packaging shortcuts without introducing backend API expansion.
-- The current repository state is in an active Phase 22 successor queue, not a closed Phase 21 baseline.
+- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, and grouped response-pack export without introducing backend API expansion.
+- The current repository state is in an active Phase 23 successor queue, not a closed Phase 22 baseline.
 
 ## Next Entry Point
 
-- Phase 22 is the active milestone and the current preset-workflow slice is tracked by issues `#151-#154`.
-- New implementation work should attach to the existing Phase 22 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- Phase 23 is the active milestone and the current preset-session slice is tracked by issues `#158-#161`.
+- New implementation work should attach to the existing Phase 23 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
 - The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 22 queue resumption.
+This note records the current post-Day-0 execution status for Mirror after the Phase 23 queue resumption.
 
 ## Current Gate State
 
@@ -25,7 +25,8 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 19 exit gate: closed
 - Phase 20 exit gate: closed
 - Phase 21 exit gate: closed
-- Phase 22 exit gate: open
+- Phase 22 exit gate: closed
+- Phase 23 exit gate: open
 
 Local phase audits currently report:
 
@@ -100,16 +101,30 @@ Local phase audits currently report:
   - closed
 - milestone `Phase 15 - Override Rationale and Delivery Confidence`
   - closed
+- Phase 22 queue sync
+  - merged via PR `#155`
+- Phase 22 apply-and-copy preset actions
+  - merged via PR `#156`
+- Phase 22 grouped response-pack export
+  - merged via PR `#157`
+- Phase 22 exit issue `#151`
+  - closed
+- milestone `Phase 22 - Preset Workflow and Packed Responses`
+  - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 22 queue kickoff
+  - no open pull requests remain after the Phase 23 queue bootstrap
 
 ## Current Queue
 
-- milestone `Phase 22 - Preset Workflow and Packed Responses` is open.
-- `#151` `Phase 22 exit gate`
+- milestone `Phase 23 - Preset Sessions and Response Kits` is open.
+- `#158` `Phase 23 exit gate`
   - open
-- blocked until the Phase 22 preset workflow and packed response slice is complete
-- The current Phase 22 execution slice is tracked through:
+- blocked until the Phase 23 preset sessions and response kit slice is complete
+- The current Phase 23 execution slice is tracked through:
+  - `#159` `Phase 23: sync bootstrap spec and docs to the active preset-session queue`
+  - `#160` `Phase 23: add active preset session summary strip for current bundle posture`
+  - `#161` `Phase 23: add route-filtered response kit chooser for grouped template packs`
+- The completed Phase 22 slice was tracked through:
   - `#152` `Phase 22: sync bootstrap spec and docs to the active preset-workflow queue`
   - `#153` `Phase 22: add apply-and-copy preset actions for reviewer, approver, and operator modes`
   - `#154` `Phase 22: add grouped response-pack export for acknowledge, request-more-context, and escalate templates`


### PR DESCRIPTION
## Summary
- add Phase 23 milestone, label, and issue metadata to the bootstrap spec
- update README and planning docs so Phase 22 is recorded as closed and Phase 23 is the only active queue
- refresh the current-state baseline to reflect the landed Phase 22 preset workflow surfaces and the live Phase 23 successor queue

## Validation
- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
- ./make.ps1 test
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim