### PR TITLE
[codex] Sync repo truth to Phase 24 queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -91,6 +91,10 @@
     {
       "title": "Phase 23 - Preset Sessions and Response Kits",
       "description": "Turn the Phase 22 preset workflow into a more repeatable handoff session by surfacing active preset summaries and route-filtered response kits without changing core simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 24 - Session Handoff and Route Comparison",
+      "description": "Turn the preset session strip and route-filtered response kits into clearer send-ready handoff surfaces by comparing alternate routes and packaging the active session for downstream delivery without changing core simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -208,6 +212,11 @@
       "name": "phase:23",
       "color": "134F5C",
       "description": "Phase 23 preset sessions and response kit work."
+    },
+    {
+      "name": "phase:24",
+      "color": "1F6D78",
+      "description": "Phase 24 session handoff and route comparison work."
     },
     {
       "name": "area:backend",
@@ -1224,6 +1233,51 @@
         "lane:auto-safe"
       ],
       "body": "## goal\nAdd route-filtered response kit chooser so the current acknowledge, request-more-context, and escalate templates can be grouped and narrowed by the active route without changing artifact contracts.\n\n## input\n- current `frontend/src/app/review-scorecard.tsx`\n- current grouped response pack export, response shortcuts, role presets, and routing strip\n- existing demo artifacts under `artifacts/demo/**`\n\n## output\n- a frontend-only response kit chooser that filters the current response pack by active route\n- no backend API calls and no new artifact files\n- copyable grouped response kits that stay aligned with the active preset workflow\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or queue-governance contracts\n- storing chooser history\n\n## minimal test\n- `npm run build --prefix frontend`\n- `./make.ps1 smoke`\n- `./make.ps1 eval-demo`\n- manual review that the response kit chooser updates with role, route, and bundle posture\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 23"
+    },
+    {
+      "title": "Phase 24 exit gate",
+      "milestone": "Phase 24 - Session Handoff and Route Comparison",
+      "labels": [
+        "phase:24",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nConfirm that the Phase 24 session handoff and route comparison criteria are satisfied before the automation system advances again.\n\n## input\n- Phase 24 milestone state\n- merged PR state for queue sync and session-handoff work\n- local validation commands and reviewed artifacts\n\n## output\n- explicit Phase 24 closeout decision\n- documented stop condition for the Phase 24 queue\n- gap issues if any execution issue remains incomplete\n\n## out-of-scope\n- opening the next successor milestone before Phase 24 completion\n- simulation, report, claim, evidence, scenario, or artifact contract expansion\n\n## minimal test\n- ./make.ps1 smoke\n- ./make.ps1 test\n- ./make.ps1 eval-demo\n- python -m backend.app.cli audit-phase phase3\n- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim\n\n## touches contract\nYes. Exit gating controls whether the automation queue may advance.\n\n## phase\nPhase 24"
+    },
+    {
+      "title": "Phase 24: sync bootstrap spec and docs to the active session-handoff queue",
+      "milestone": "Phase 24 - Session Handoff and Route Comparison",
+      "labels": [
+        "phase:24",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nSync the repository source of truth from the closed Phase 23 baseline to the active Phase 24 queue so docs, bootstrap metadata, and README reflect the new session-handoff track.\n\n## input\n- .github/automation/bootstrap-spec.json\n- README.md\n- docs/plans/automation-roadmap.md\n- docs/plans/current-state-baseline.md\n- docs/plans/phase-execution-queue.md\n- current live GitHub milestone and issue state\n\n## output\n- phase:24 and Phase 24 queue objects recorded in the bootstrap spec\n- README and planning docs updated to show Phase 24 as the active successor queue\n- no stale Phase 23 active-queue language remains in the active-state docs\n\n## out-of-scope\n- local automation card changes\n- simulation, report, or artifact contract changes\n- session-handoff UI changes\n\n## minimal test\n- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim\n- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md\n- ./make.ps1 test\n- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim\n\n## touches contract\nYes. This work changes the active operational GitHub queue truth surface.\n\n## phase\nPhase 24"
+    },
+    {
+      "title": "Phase 24: add active-versus-alternate response kit comparison cards",
+      "milestone": "Phase 24 - Session Handoff and Route Comparison",
+      "labels": [
+        "phase:24",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd active-versus-alternate response kit comparison cards so the current route kit can be compared against nearby response paths without leaving the workbench or changing artifact contracts.\n\n## input\n- current frontend/src/app/review-scorecard.tsx\n- current route-filtered response kit chooser, response shortcuts, and follow-through routing strip\n- existing demo artifacts under artifacts/demo/**\n\n## output\n- a frontend-only comparison board for the active route kit and nearby alternate response kits\n- no backend API calls and no new artifact files\n- copyable comparison cues that stay aligned with the current preset workflow\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or queue-governance contracts\n- storing comparison history\n\n## minimal test\n- npm run build --prefix frontend\n- ./make.ps1 smoke\n- ./make.ps1 eval-demo\n- manual review that the active and alternate route kits update with role, destination, and bundle posture\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 24"
+    },
+    {
+      "title": "Phase 24: add copyable preset session handoff packet from summary strip and selected route kit",
+      "milestone": "Phase 24 - Session Handoff and Route Comparison",
+      "labels": [
+        "phase:24",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a copyable preset session handoff packet that combines the active session summary strip and the selected route kit into one send-ready handoff artifact without changing artifact contracts.\n\n## input\n- current frontend/src/app/review-scorecard.tsx\n- current preset session summary strip, route-filtered response kit chooser, and final bundle surface\n- existing demo artifacts under artifacts/demo/**\n\n## output\n- a frontend-only handoff packet built from the current preset session summary and selected route kit\n- no backend API calls and no new artifact files\n- a copyable send-ready packet that stays aligned with the current preset workflow\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or review-state contracts\n- storing handoff history\n\n## minimal test\n- npm run build --prefix frontend\n- ./make.ps1 smoke\n- ./make.ps1 eval-demo\n- manual review that the handoff packet updates with preset, route, role, and bundle posture\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 24"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-22 gates, and resumed the successor queue as `Phase 23 - Preset Sessions and Response Kits`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-23 gates, and resumed the successor queue as `Phase 24 - Session Handoff and Route Comparison`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -44,8 +44,10 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-22 gates, and r
   - milestone `Phase 21 - Role Presets and Response Packaging` is closed
   - milestone `Phase 22 - Preset Workflow and Packed Responses` is closed
   - Phase 22 queue was completed through issues `#151-#154`
-  - milestone `Phase 23 - Preset Sessions and Response Kits` is open
-  - Phase 23 queue is initialized through issues `#158-#161`
+  - milestone `Phase 23 - Preset Sessions and Response Kits` is closed
+  - Phase 23 queue was completed through issues `#158-#161`
+  - milestone `Phase 24 - Session Handoff and Route Comparison` is open
+  - Phase 24 queue is initialized through issues `#165-#168`
 
 Local phase audits currently show:
 
@@ -100,7 +102,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): review workbench with Phase 22 apply-and-copy preset and grouped response-pack surfaces landed while the current Phase 23 preset-session queue continues to consume the same artifact surface
+- [frontend](/D:/mirror/frontend): review workbench with Phase 23 preset session summary and route-filtered response-kit surfaces landed while the current Phase 24 session-handoff queue continues to consume the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -145,10 +147,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 22 closeout are complete. Phase 23 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 23 closeout are complete. Phase 24 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may resume pickup guidance only against the Phase 23 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation may resume pickup guidance only against the Phase 24 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, and Phase 23 is now the active preset-session track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, and Phase 24 is now the active session-handoff track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -70,9 +70,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 22 is closed locally and in GitHub.
 - Phase 22 exit issue `#151` is closed and milestone `Phase 22 - Preset Workflow and Packed Responses` is closed.
 - The Phase 22 queue was completed through issues `#151-#154`.
-- Phase 23 is the active successor queue.
-- milestone `Phase 23 - Preset Sessions and Response Kits` is open.
-- The Phase 23 queue is initialized through issues `#158-#161`.
+- Phase 23 is closed locally and in GitHub.
+- Phase 23 exit issue `#158` is closed and milestone `Phase 23 - Preset Sessions and Response Kits` is closed.
+- The Phase 23 queue was completed through issues `#158-#161`.
+- Phase 24 is the active successor queue.
+- milestone `Phase 24 - Session Handoff and Route Comparison` is open.
+- The Phase 24 queue is initialized through issues `#165-#168`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 23 active-queue baseline.
+This note is the current Phase 24 active-queue baseline.
 
 ## Snapshot
 
@@ -96,11 +96,15 @@ This note is the current Phase 23 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/issues/151`
     - Phase 22 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/23`
-    - milestone `Phase 23 - Preset Sessions and Response Kits` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=23"`
-    - Phase 23 queue is initialized through issues `#158-#161`
+    - milestone `Phase 23 - Preset Sessions and Response Kits` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/158`
+    - Phase 23 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/24`
+    - milestone `Phase 24 - Session Handoff and Route Comparison` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=24"`
+    - Phase 24 queue is initialized through issues `#165-#168`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` because Phase 23 has one blocked protected-core exit gate and multiple ready work items
+    - successor queue currently reports `ready` because Phase 24 has one blocked protected-core exit gate and multiple ready work items
 
 ## Trusted Source Of Truth
 
@@ -117,13 +121,13 @@ This note is the current Phase 23 active-queue baseline.
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
-- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, and grouped response-pack export without introducing backend API expansion.
-- The current repository state is in an active Phase 23 successor queue, not a closed Phase 22 baseline.
+- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, and route-filtered response kit choosers without introducing backend API expansion.
+- The current repository state is in an active Phase 24 successor queue, not a closed Phase 23 baseline.
 
 ## Next Entry Point
 
-- Phase 23 is the active milestone and the current preset-session slice is tracked by issues `#158-#161`.
-- New implementation work should attach to the existing Phase 23 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- Phase 24 is the active milestone and the current session-handoff slice is tracked by issues `#165-#168`.
+- New implementation work should attach to the existing Phase 24 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
 - The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 23 queue resumption.
+This note records the current post-Day-0 execution status for Mirror after the Phase 24 queue resumption.
 
 ## Current Gate State
 
@@ -26,7 +26,8 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 20 exit gate: closed
 - Phase 21 exit gate: closed
 - Phase 22 exit gate: closed
-- Phase 23 exit gate: open
+- Phase 23 exit gate: closed
+- Phase 24 exit gate: open
 
 Local phase audits currently report:
 
@@ -111,16 +112,30 @@ Local phase audits currently report:
   - closed
 - milestone `Phase 22 - Preset Workflow and Packed Responses`
   - closed
+- Phase 23 queue sync
+  - merged via PR `#162`
+- Phase 23 preset session summary strip
+  - merged via PR `#163`
+- Phase 23 route-filtered response kit chooser
+  - merged via PR `#164`
+- Phase 23 exit issue `#158`
+  - closed
+- milestone `Phase 23 - Preset Sessions and Response Kits`
+  - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 23 queue bootstrap
+  - no open pull requests remain after the Phase 24 queue bootstrap
 
 ## Current Queue
 
-- milestone `Phase 23 - Preset Sessions and Response Kits` is open.
-- `#158` `Phase 23 exit gate`
+- milestone `Phase 24 - Session Handoff and Route Comparison` is open.
+- `#165` `Phase 24 exit gate`
   - open
-- blocked until the Phase 23 preset sessions and response kit slice is complete
-- The current Phase 23 execution slice is tracked through:
+- blocked until the Phase 24 session handoff and route comparison slice is complete
+- The current Phase 24 execution slice is tracked through:
+  - `#168` `Phase 24: sync bootstrap spec and docs to the active session-handoff queue`
+  - `#166` `Phase 24: add active-versus-alternate response kit comparison cards`
+  - `#167` `Phase 24: add copyable preset session handoff packet from summary strip and selected route kit`
+- The completed Phase 23 slice was tracked through:
   - `#159` `Phase 23: sync bootstrap spec and docs to the active preset-session queue`
   - `#160` `Phase 23: add active preset session summary strip for current bundle posture`
   - `#161` `Phase 23: add route-filtered response kit chooser for grouped template packs`


### PR DESCRIPTION
## Summary
- add Phase 24 milestone, label, and issue metadata to the bootstrap spec
- update README and planning docs so Phase 23 is recorded as closed and Phase 24 is the only active queue
- refresh the current-state baseline to reflect the landed preset-session surfaces and the live Phase 24 successor queue

## Validation
- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
- ./make.ps1 test
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim