### PR TITLE
[codex] Sync repo truth to Phase 26 queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -99,6 +99,10 @@
     {
       "title": "Phase 25 - Handoff Delivery and Packet Variants",
       "description": "Turn the preset session handoff packet into clearer delivery surfaces by adding send-readiness cues and compact-versus-full packet variants without changing core simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 26 - Packet Delivery Prep and Sender Notes",
+      "description": "Turn the preset session handoff packet variants into clearer delivery-ready artifacts by adding destination-specific sender notes and packet-diff cues without changing core simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -226,6 +230,11 @@
       "name": "phase:25",
       "color": "2B7A78",
       "description": "Phase 25 handoff delivery and packet variants work."
+    },
+    {
+      "name": "phase:26",
+      "color": "356859",
+      "description": "Phase 26 packet delivery prep and sender note work."
     },
     {
       "name": "area:backend",
@@ -1332,6 +1341,51 @@
         "lane:auto-safe"
       ],
       "body": "## goal\nAdd compact-versus-full preset session handoff packet variants with coverage preview so the operator can choose how much packet context to send without changing artifact contracts.\n\n## input\n- current frontend/src/app/review-scorecard.tsx\n- current preset session handoff packet, final bundle variant cues, and route-filtered response kit surfaces\n- existing demo artifacts under artifacts/demo/**\n\n## output\n- a frontend-only compact/full handoff packet variant chooser with visible coverage differences\n- no backend API calls and no new artifact files\n- copyable packet variants that stay aligned with the current preset workflow\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or review-state contracts\n- storing packet-variant history\n\n## minimal test\n- npm run build --prefix frontend\n- ./make.ps1 smoke\n- ./make.ps1 eval-demo\n- manual review that the compact/full packet variants update with preset, route, destination, and receiver posture\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 25"
+    },
+    {
+      "title": "Phase 26 exit gate",
+      "milestone": "Phase 26 - Packet Delivery Prep and Sender Notes",
+      "labels": [
+        "phase:26",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nConfirm that the Phase 26 packet delivery prep and sender note criteria are satisfied before the automation system advances again.\n\n## input\n- Phase 26 milestone state\n- merged PR state for queue sync and delivery-prep work\n- local validation commands and reviewed artifacts\n\n## output\n- explicit Phase 26 closeout decision\n- documented stop condition for the Phase 26 queue\n- gap issues if any execution issue remains incomplete\n\n## out-of-scope\n- opening the next successor milestone before Phase 26 completion\n- simulation, report, claim, evidence, scenario, or artifact contract expansion\n\n## minimal test\n- ./make.ps1 smoke\n- ./make.ps1 test\n- ./make.ps1 eval-demo\n- python -m backend.app.cli audit-phase phase3\n- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim\n\n## touches contract\nYes. Exit gating controls whether the automation queue may advance.\n\n## phase\nPhase 26"
+    },
+    {
+      "title": "Phase 26: sync bootstrap spec and docs to the active delivery-prep queue",
+      "milestone": "Phase 26 - Packet Delivery Prep and Sender Notes",
+      "labels": [
+        "phase:26",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nSync the repository source of truth from the closed Phase 25 baseline to the active Phase 26 queue so docs, bootstrap metadata, and README reflect the new delivery-prep track.\n\n## input\n- .github/automation/bootstrap-spec.json\n- README.md\n- docs/plans/automation-roadmap.md\n- docs/plans/current-state-baseline.md\n- docs/plans/phase-execution-queue.md\n- current live GitHub milestone and issue state\n\n## output\n- phase:26 and Phase 26 queue objects recorded in the bootstrap spec\n- README and planning docs updated to show Phase 26 as the active successor queue\n- no stale Phase 25 active-queue language remains in the active-state docs\n\n## out-of-scope\n- local automation card changes\n- simulation, report, or artifact contract changes\n- delivery-prep UI changes\n\n## minimal test\n- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim\n- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md\n- ./make.ps1 test\n- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim\n\n## touches contract\nYes. This work changes the active operational GitHub queue truth surface.\n\n## phase\nPhase 26"
+    },
+    {
+      "title": "Phase 26: add destination-specific sender note and subject line for the handoff packet",
+      "milestone": "Phase 26 - Packet Delivery Prep and Sender Notes",
+      "labels": [
+        "phase:26",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a destination-specific sender note and subject line for the preset session handoff packet so the operator can deliver the packet with clearer context without changing artifact contracts.\n\n## input\n- current frontend/src/app/review-scorecard.tsx\n- current preset session handoff packet, destination cue strip, and delivery guidance surfaces\n- existing demo artifacts under artifacts/demo/**\n\n## output\n- a frontend-only sender note and subject-line surface derived from the current destination, route, and receiver posture\n- no backend API calls and no new artifact files\n- copyable delivery notes that stay aligned with the current preset workflow\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or delivery-governance contracts\n- storing sender-note history\n\n## minimal test\n- npm run build --prefix frontend\n- ./make.ps1 smoke\n- ./make.ps1 eval-demo\n- manual review that the sender note updates with preset, destination, route, and receiver posture\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 26"
+    },
+    {
+      "title": "Phase 26: add compact-versus-full handoff packet diff preview and omitted-section cues",
+      "milestone": "Phase 26 - Packet Delivery Prep and Sender Notes",
+      "labels": [
+        "phase:26",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a compact-versus-full handoff packet diff preview and omitted-section cues so the operator can see what changes between the two packet variants before sending without changing artifact contracts.\n\n## input\n- current frontend/src/app/review-scorecard.tsx\n- current handoff packet variants, coverage preview, and route-comparison surfaces\n- existing demo artifacts under artifacts/demo/**\n\n## output\n- a frontend-only compact/full packet diff preview with explicit omitted-section cues\n- no backend API calls and no new artifact files\n- copyable diff cues that stay aligned with the current preset workflow\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or review-state contracts\n- storing diff history\n\n## minimal test\n- npm run build --prefix frontend\n- ./make.ps1 smoke\n- ./make.ps1 eval-demo\n- manual review that the packet diff preview updates with preset, route, destination, and receiver posture\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 26"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-24 gates, and resumed the successor queue as `Phase 25 - Handoff Delivery and Packet Variants`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-25 gates, and resumed the successor queue as `Phase 26 - Packet Delivery Prep and Sender Notes`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -48,8 +48,10 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-24 gates, and r
   - Phase 23 queue was completed through issues `#158-#161`
   - milestone `Phase 24 - Session Handoff and Route Comparison` is closed
   - Phase 24 queue was completed through issues `#165-#168`
-  - milestone `Phase 25 - Handoff Delivery and Packet Variants` is open
-  - Phase 25 queue is initialized through issues `#172-#175`
+  - milestone `Phase 25 - Handoff Delivery and Packet Variants` is closed
+  - Phase 25 queue was completed through issues `#172-#175`
+  - milestone `Phase 26 - Packet Delivery Prep and Sender Notes` is open
+  - Phase 26 queue is initialized through issues `#179-#182`
 
 Local phase audits currently show:
 
@@ -104,7 +106,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): review workbench with Phase 24 response-kit comparison and preset session handoff-packet surfaces landed while the current Phase 25 handoff-delivery queue continues to consume the same artifact surface
+- [frontend](/D:/mirror/frontend): review workbench with Phase 25 send-readiness and handoff-packet variant surfaces landed while the current Phase 26 delivery-prep queue continues to consume the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -149,10 +151,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 24 closeout are complete. Phase 25 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 25 closeout are complete. Phase 26 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may resume pickup guidance only against the Phase 25 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation may resume pickup guidance only against the Phase 26 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, and Phase 25 is now the active handoff-delivery track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, and Phase 26 is now the active delivery-prep track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -76,9 +76,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 24 is closed locally and in GitHub.
 - Phase 24 exit issue `#165` is closed and milestone `Phase 24 - Session Handoff and Route Comparison` is closed.
 - The Phase 24 queue was completed through issues `#165-#168`.
-- Phase 25 is the active successor queue.
-- milestone `Phase 25 - Handoff Delivery and Packet Variants` is open.
-- The Phase 25 queue is initialized through issues `#172-#175`.
+- Phase 25 is closed locally and in GitHub.
+- Phase 25 exit issue `#172` is closed and milestone `Phase 25 - Handoff Delivery and Packet Variants` is closed.
+- The Phase 25 queue was completed through issues `#172-#175`.
+- Phase 26 is the active successor queue.
+- milestone `Phase 26 - Packet Delivery Prep and Sender Notes` is open.
+- The Phase 26 queue is initialized through issues `#179-#182`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 25 active-queue baseline.
+This note is the current Phase 26 active-queue baseline.
 
 ## Snapshot
 
@@ -104,11 +104,15 @@ This note is the current Phase 25 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/issues/165`
     - Phase 24 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/25`
-    - milestone `Phase 25 - Handoff Delivery and Packet Variants` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=25"`
-    - Phase 25 queue is initialized through issues `#172-#175`
+    - milestone `Phase 25 - Handoff Delivery and Packet Variants` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/172`
+    - Phase 25 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/26`
+    - milestone `Phase 26 - Packet Delivery Prep and Sender Notes` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=26"`
+    - Phase 26 queue is initialized through issues `#179-#182`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` because Phase 25 has one blocked protected-core exit gate and multiple ready work items
+    - successor queue currently reports `ready` because Phase 26 has one blocked protected-core exit gate and multiple ready work items
 
 ## Trusted Source Of Truth
 
@@ -125,13 +129,13 @@ This note is the current Phase 25 active-queue baseline.
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
-- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, and preset session handoff packets without introducing backend API expansion.
-- The current repository state is in an active Phase 25 successor queue, not a closed Phase 24 baseline.
+- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, and compact-versus-full handoff packet variants without introducing backend API expansion.
+- The current repository state is in an active Phase 26 successor queue, not a closed Phase 25 baseline.
 
 ## Next Entry Point
 
-- Phase 25 is the active milestone and the current handoff-delivery slice is tracked by issues `#172-#175`.
-- New implementation work should attach to the existing Phase 25 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- Phase 26 is the active milestone and the current delivery-prep slice is tracked by issues `#179-#182`.
+- New implementation work should attach to the existing Phase 26 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
 - The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 25 queue resumption.
+This note records the current post-Day-0 execution status for Mirror after the Phase 26 queue resumption.
 
 ## Current Gate State
 
@@ -28,7 +28,8 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 22 exit gate: closed
 - Phase 23 exit gate: closed
 - Phase 24 exit gate: closed
-- Phase 25 exit gate: open
+- Phase 25 exit gate: closed
+- Phase 26 exit gate: open
 
 Local phase audits currently report:
 
@@ -133,16 +134,30 @@ Local phase audits currently report:
   - closed
 - milestone `Phase 24 - Session Handoff and Route Comparison`
   - closed
+- Phase 25 queue sync
+  - merged via PR `#176`
+- Phase 25 send-readiness cues
+  - merged via PR `#177`
+- Phase 25 handoff packet variants
+  - merged via PR `#178`
+- Phase 25 exit issue `#172`
+  - closed
+- milestone `Phase 25 - Handoff Delivery and Packet Variants`
+  - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 25 queue bootstrap
+  - no open pull requests remain after the Phase 26 queue bootstrap
 
 ## Current Queue
 
-- milestone `Phase 25 - Handoff Delivery and Packet Variants` is open.
-- `#172` `Phase 25 exit gate`
+- milestone `Phase 26 - Packet Delivery Prep and Sender Notes` is open.
+- `#179` `Phase 26 exit gate`
   - open
-- blocked until the Phase 25 handoff delivery and packet variants slice is complete
-- The current Phase 25 execution slice is tracked through:
+- blocked until the Phase 26 packet delivery prep and sender note slice is complete
+- The current Phase 26 execution slice is tracked through:
+  - `#180` `Phase 26: sync bootstrap spec and docs to the active delivery-prep queue`
+  - `#181` `Phase 26: add destination-specific sender note and subject line for the handoff packet`
+  - `#182` `Phase 26: add compact-versus-full handoff packet diff preview and omitted-section cues`
+- The completed Phase 25 slice was tracked through:
   - `#174` `Phase 25: sync bootstrap spec and docs to the active handoff-delivery queue`
   - `#173` `Phase 25: add send-readiness checklist and destination cue strip for the session handoff packet`
   - `#175` `Phase 25: add compact-versus-full preset session handoff packet variants with coverage preview`


### PR DESCRIPTION
## Summary
- add Phase 26 milestone, label, and issue metadata to the bootstrap spec
- update README and planning docs so Phase 25 is recorded as closed and Phase 26 is the only active queue
- refresh the current-state baseline to reflect the landed delivery-prep surfaces and the live Phase 26 successor queue

## Validation
- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
- ./make.ps1 test
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim