### PR TITLE
[codex] Sync repo truth to Phase 28 queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -107,6 +107,10 @@
     {
       "title": "Phase 27 - Sendoff Summary and Packet Recommendation",
       "description": "Turn the new sender notes and packet diff cues into clearer sendoff decisions by surfacing a final send summary and destination-aware packet recommendation without changing core simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 28 - Send Decision and Delivery Checklist",
+      "description": "Turn the new send summary and packet recommendation surfaces into a clearer final send-decision workflow by adding a delivery checklist and destination-specific send script without changing core simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -244,6 +248,11 @@
       "name": "phase:27",
       "color": "3D6B6B",
       "description": "Phase 27 sendoff summary and packet recommendation work."
+    },
+    {
+      "name": "phase:28",
+      "color": "4C6A92",
+      "description": "Phase 28 send decision and delivery checklist work."
     },
     {
       "name": "area:backend",
@@ -1440,6 +1449,51 @@
         "lane:auto-safe"
       ],
       "body": "## goal\nAdd a destination-aware packet recommendation banner with fallback rationale so the operator can tell which handoff packet variant is preferred for the current delivery target without changing artifact contracts.\n\n## input\n- current frontend/src/app/review-scorecard.tsx\n- current packet variants, sender note, send-readiness cues, and packet diff preview surfaces\n- existing demo artifacts under artifacts/demo/**\n\n## output\n- a frontend-only recommended-packet banner with fallback rationale for the current destination and receiver posture\n- no backend API calls and no new artifact files\n- copyable recommendation cues that stay aligned with the current preset workflow\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or review-state contracts\n- storing recommendation history\n\n## minimal test\n- npm run build --prefix frontend\n- ./make.ps1 smoke\n- ./make.ps1 eval-demo\n- manual review that the recommendation banner updates with destination, route, receiver, and packet variant state\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 27"
+    },
+    {
+      "title": "Phase 28 exit gate",
+      "milestone": "Phase 28 - Send Decision and Delivery Checklist",
+      "labels": [
+        "phase:28",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nConfirm that the Phase 28 send-decision and delivery-checklist criteria are satisfied before the automation system advances again.\n\n## input\n- Phase 28 milestone state\n- merged PR state for queue sync and send-decision work\n- local validation commands and reviewed artifacts\n\n## output\n- explicit Phase 28 closeout decision\n- documented stop condition for the Phase 28 queue\n- gap issues if any execution issue remains incomplete\n\n## out-of-scope\n- opening the next successor milestone before Phase 28 completion\n- simulation, report, claim, evidence, scenario, or artifact contract expansion\n\n## minimal test\n- ./make.ps1 smoke\n- ./make.ps1 test\n- ./make.ps1 eval-demo\n- python -m backend.app.cli audit-phase phase3\n- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim\n\n## touches contract\nYes. Exit gating controls whether the automation queue may advance.\n\n## phase\nPhase 28"
+    },
+    {
+      "title": "Phase 28: sync bootstrap spec and docs to the active send-decision queue",
+      "milestone": "Phase 28 - Send Decision and Delivery Checklist",
+      "labels": [
+        "phase:28",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nSync the repository source of truth from the closed Phase 27 baseline to the active Phase 28 queue so docs, bootstrap metadata, and README reflect the new send-decision track.\n\n## input\n- .github/automation/bootstrap-spec.json\n- README.md\n- docs/plans/automation-roadmap.md\n- docs/plans/current-state-baseline.md\n- docs/plans/phase-execution-queue.md\n- current live GitHub milestone and issue state\n\n## output\n- phase:28 and Phase 28 queue objects recorded in the bootstrap spec\n- README and planning docs updated to show Phase 28 as the active successor queue\n- no stale Phase 27 active-queue language remains in the active-state docs\n\n## out-of-scope\n- local automation card changes\n- simulation, report, or artifact contract changes\n- send-decision UI changes\n\n## minimal test\n- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim\n- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md\n- ./make.ps1 test\n- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim\n\n## touches contract\nYes. This work changes the active operational GitHub queue truth surface.\n\n## phase\nPhase 28"
+    },
+    {
+      "title": "Phase 28: add destination-specific delivery script from sender note, recommendation, and receiver cue",
+      "milestone": "Phase 28 - Send Decision and Delivery Checklist",
+      "labels": [
+        "phase:28",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a destination-specific delivery script that combines the sender note, packet recommendation, and receiver cue so the operator can copy a final outgoing handoff message without changing artifact contracts.\n\n## input\n- current frontend/src/app/review-scorecard.tsx\n- current sender note, final send summary, packet recommendation, and receiver guidance surfaces\n- existing demo artifacts under artifacts/demo/**\n\n## output\n- a frontend-only delivery script derived from the current destination, recommendation, sender note, and receiver posture\n- no backend API calls and no new artifact files\n- copyable final delivery script cues that stay aligned with the current preset workflow\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or delivery-governance contracts\n- storing delivery-script history\n\n## minimal test\n- npm run build --prefix frontend\n- ./make.ps1 smoke\n- ./make.ps1 eval-demo\n- manual review that the delivery script updates with destination, route, receiver, and packet recommendation\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 28"
+    },
+    {
+      "title": "Phase 28: add final send checklist from packet recommendation, summary, and readiness cues",
+      "milestone": "Phase 28 - Send Decision and Delivery Checklist",
+      "labels": [
+        "phase:28",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a final send checklist that combines the packet recommendation, final send summary, and send-readiness cues so the operator can confirm whether to send, hold, or widen the packet without changing artifact contracts.\n\n## input\n- current frontend/src/app/review-scorecard.tsx\n- current packet recommendation, final send summary, sender note, and send-readiness surfaces\n- existing demo artifacts under artifacts/demo/**\n\n## output\n- a frontend-only send checklist derived from the current recommendation, readiness, and route posture\n- no backend API calls and no new artifact files\n- copyable send/hold checklist cues that stay aligned with the current preset workflow\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or review-state contracts\n- storing send decisions\n\n## minimal test\n- npm run build --prefix frontend\n- ./make.ps1 smoke\n- ./make.ps1 eval-demo\n- manual review that the checklist updates with destination, route, receiver, recommendation, and readiness posture\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 28"
     }
   ]
 }

--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -1494,6 +1494,30 @@
         "lane:auto-safe"
       ],
       "body": "## goal\nAdd a final send checklist that combines the packet recommendation, final send summary, and send-readiness cues so the operator can confirm whether to send, hold, or widen the packet without changing artifact contracts.\n\n## input\n- current frontend/src/app/review-scorecard.tsx\n- current packet recommendation, final send summary, sender note, and send-readiness surfaces\n- existing demo artifacts under artifacts/demo/**\n\n## output\n- a frontend-only send checklist derived from the current recommendation, readiness, and route posture\n- no backend API calls and no new artifact files\n- copyable send/hold checklist cues that stay aligned with the current preset workflow\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or review-state contracts\n- storing send decisions\n\n## minimal test\n- npm run build --prefix frontend\n- ./make.ps1 smoke\n- ./make.ps1 eval-demo\n- manual review that the checklist updates with destination, route, receiver, recommendation, and readiness posture\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 28"
+    },
+    {
+      "title": "Phase 28: classify superseded remote codex branches against live GitHub state",
+      "milestone": "Phase 28 - Send Decision and Delivery Checklist",
+      "labels": [
+        "phase:28",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nProduce a live inventory and classification baseline for remote origin/codex/* branches so branch hygiene decisions are driven by current GitHub state instead of stale docs or ancestry-only heuristics.\n\n## input\n- authenticated gh pr list / gh issue list / milestone state\n- git branch -r and remote merge ancestry checks\n- merged PR head refs\n- repo docs and runbook references to branch hygiene\n\n## output\n- a per-branch classification baseline for origin/codex/* using delete / keep / revive / TODO[verify]\n- evidence for PR state, issue/milestone linkage, merged PR head matches, and docs/runbook references\n- explicit identification of any branches that must remain protected because they are tied to open work\n\n## out-of-scope\n- deleting branches\n- mutating GitHub branch protection or queue structure beyond classification artifacts\n- changing simulation, report, claim, evidence, scenario, or artifact contracts\n\n## minimal test\n- authenticated gh pr list --state open\n- authenticated gh issue list --state open\n- git branch -r\n- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim\n\n## touches contract\nYes. This work defines the operational branch-hygiene truth surface that later cleanup will execute against.\n\n## phase\nPhase 28"
+    },
+    {
+      "title": "Phase 28: apply reviewed codex branch cleanup and sync branch-hygiene docs",
+      "milestone": "Phase 28 - Send Decision and Delivery Checklist",
+      "labels": [
+        "phase:28",
+        "area:docs-evals",
+        "risk:ci",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nApply the reviewed remote/local codex branch cleanup set and sync branch-hygiene docs after the classification baseline is complete.\n\n## input\n- reviewed branch classification baseline from the preceding Phase 28 classification issue\n- live GitHub PR/issue state\n- remote and local branch inventories\n- current branch-hygiene docs\n\n## output\n- remote branch deletions only for branches classified as delete\n- local tracking-ref pruning and local historical branch cleanup consistent with the reviewed classification\n- docs updated so branch-hygiene state descriptions match live GitHub reality\n\n## out-of-scope\n- deleting any branch that is still tied to open PRs, open issues, runbook references, or unresolved forensic comparisons\n- opening a second execution milestone\n- changing simulation, report, claim, evidence, scenario, or artifact contracts\n\n## minimal test\n- authenticated gh pr list --state open\n- authenticated gh issue list --state open\n- git branch -r\n- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim\n- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md docs/plans/long-running-loop-runbook.md\n- ./make.ps1 test\n- authenticated python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim\n\n## touches contract\nYes. This work changes the operational GitHub branch surface and the docs that define branch-hygiene truth.\n\n## phase\nPhase 28"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-27 gates, and r
   - milestone `Phase 27 - Sendoff Summary and Packet Recommendation` is closed
   - Phase 27 queue was completed through issues `#186-#189`
   - milestone `Phase 28 - Send Decision and Delivery Checklist` is open
-  - Phase 28 queue is initialized through issues `#193-#196`
+  - Phase 28 queue is initialized through issues `#193-#196` plus branch-hygiene governance issues `#199-#200`
 
 Local phase audits currently show:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-26 gates, and resumed the successor queue as `Phase 27 - Sendoff Summary and Packet Recommendation`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-27 gates, and resumed the successor queue as `Phase 28 - Send Decision and Delivery Checklist`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -52,8 +52,10 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-26 gates, and r
   - Phase 25 queue was completed through issues `#172-#175`
   - milestone `Phase 26 - Packet Delivery Prep and Sender Notes` is closed
   - Phase 26 queue was completed through issues `#179-#182`
-  - milestone `Phase 27 - Sendoff Summary and Packet Recommendation` is open
-  - Phase 27 queue is initialized through issues `#186-#189`
+  - milestone `Phase 27 - Sendoff Summary and Packet Recommendation` is closed
+  - Phase 27 queue was completed through issues `#186-#189`
+  - milestone `Phase 28 - Send Decision and Delivery Checklist` is open
+  - Phase 28 queue is initialized through issues `#193-#196`
 
 Local phase audits currently show:
 
@@ -108,7 +110,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): review workbench with Phase 26 sender-note and handoff-packet diff surfaces landed while the current Phase 27 sendoff-summary queue continues to consume the same artifact surface
+- [frontend](/D:/mirror/frontend): review workbench with Phase 27 final-send-summary and packet-recommendation surfaces landed while the current Phase 28 send-decision queue continues to consume the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -153,10 +155,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 26 closeout are complete. Phase 27 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 27 closeout are complete. Phase 28 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may resume pickup guidance only against the Phase 27 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation may resume pickup guidance only against the Phase 28 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, and Phase 27 is now the active sendoff-summary track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, and Phase 28 is now the active send-decision track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -82,9 +82,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 26 is closed locally and in GitHub.
 - Phase 26 exit issue `#179` is closed and milestone `Phase 26 - Packet Delivery Prep and Sender Notes` is closed.
 - The Phase 26 queue was completed through issues `#179-#182`.
-- Phase 27 is the active successor queue.
-- milestone `Phase 27 - Sendoff Summary and Packet Recommendation` is open.
-- The Phase 27 queue is initialized through issues `#186-#189`.
+- Phase 27 is closed locally and in GitHub.
+- Phase 27 exit issue `#186` is closed and milestone `Phase 27 - Sendoff Summary and Packet Recommendation` is closed.
+- The Phase 27 queue was completed through issues `#186-#189`.
+- Phase 28 is the active successor queue.
+- milestone `Phase 28 - Send Decision and Delivery Checklist` is open.
+- The Phase 28 queue is initialized through issues `#193-#196`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -87,7 +87,7 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - The Phase 27 queue was completed through issues `#186-#189`.
 - Phase 28 is the active successor queue.
 - milestone `Phase 28 - Send Decision and Delivery Checklist` is open.
-- The Phase 28 queue is initialized through issues `#193-#196`.
+- The Phase 28 queue is initialized through issues `#193-#196` plus branch-hygiene governance issues `#199-#200`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -118,7 +118,7 @@ This note is the current Phase 28 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/milestones/28`
     - milestone `Phase 28 - Send Decision and Delivery Checklist` is `open`
   - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=28"`
-    - Phase 28 queue is initialized through issues `#193-#196`
+    - Phase 28 queue is initialized through issues `#193-#196` plus branch-hygiene governance issues `#199-#200`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
     - successor queue currently reports `ready` because Phase 28 has one blocked protected-core exit gate and multiple ready work items
 
@@ -142,7 +142,7 @@ This note is the current Phase 28 active-queue baseline.
 
 ## Next Entry Point
 
-- Phase 28 is the active milestone and the current send-decision slice is tracked by issues `#193-#196`.
+- Phase 28 is the active milestone and the current send-decision-plus-branch-hygiene slice is tracked by issues `#193-#196` and `#199-#200`.
 - New implementation work should attach to the existing Phase 28 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 27 active-queue baseline.
+This note is the current Phase 28 active-queue baseline.
 
 ## Snapshot
 
@@ -112,11 +112,15 @@ This note is the current Phase 27 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/issues/179`
     - Phase 26 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/27`
-    - milestone `Phase 27 - Sendoff Summary and Packet Recommendation` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=27"`
-    - Phase 27 queue is initialized through issues `#186-#189`
+    - milestone `Phase 27 - Sendoff Summary and Packet Recommendation` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/186`
+    - Phase 27 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/28`
+    - milestone `Phase 28 - Send Decision and Delivery Checklist` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=28"`
+    - Phase 28 queue is initialized through issues `#193-#196`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` because Phase 27 has one blocked protected-core exit gate and multiple ready work items
+    - successor queue currently reports `ready` because Phase 28 has one blocked protected-core exit gate and multiple ready work items
 
 ## Trusted Source Of Truth
 
@@ -133,13 +137,13 @@ This note is the current Phase 27 active-queue baseline.
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
-- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, and compact-versus-full handoff packet diff previews without introducing backend API expansion.
-- The current repository state is in an active Phase 27 successor queue, not a closed Phase 26 baseline.
+- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, and destination-aware packet recommendation banners without introducing backend API expansion.
+- The current repository state is in an active Phase 28 successor queue, not a closed Phase 27 baseline.
 
 ## Next Entry Point
 
-- Phase 27 is the active milestone and the current sendoff-summary slice is tracked by issues `#186-#189`.
-- New implementation work should attach to the existing Phase 27 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- Phase 28 is the active milestone and the current send-decision slice is tracked by issues `#193-#196`.
+- New implementation work should attach to the existing Phase 28 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
 - The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -174,11 +174,14 @@ Local phase audits currently report:
 - milestone `Phase 28 - Send Decision and Delivery Checklist` is open.
 - `#193` `Phase 28 exit gate`
   - open
-- blocked until the Phase 28 send-decision slice is complete
+- blocked until the Phase 28 send-decision and branch-hygiene slice is complete
 - The current Phase 28 execution slice is tracked through:
   - `#194` `Phase 28: sync bootstrap spec and docs to the active send-decision queue`
+  - `#199` `Phase 28: classify superseded remote codex branches against live GitHub state`
   - `#196` `Phase 28: add final send checklist from packet recommendation, summary, and readiness cues`
   - `#195` `Phase 28: add destination-specific delivery script from sender note, recommendation, and receiver cue`
+  - `#200` `Phase 28: apply reviewed codex branch cleanup and sync branch-hygiene docs`
+    - blocked until the classification baseline is complete and reviewed
 - The completed Phase 27 slice was tracked through:
   - `#188` `Phase 27: sync bootstrap spec and docs to the active sendoff-summary queue`
   - `#187` `Phase 27: add final send summary card from sender note, packet variant, and route cues`

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 27 queue resumption.
+This note records the current post-Day-0 execution status for Mirror after the Phase 28 queue resumption.
 
 ## Current Gate State
 
@@ -30,7 +30,8 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 24 exit gate: closed
 - Phase 25 exit gate: closed
 - Phase 26 exit gate: closed
-- Phase 27 exit gate: open
+- Phase 27 exit gate: closed
+- Phase 28 exit gate: open
 
 Local phase audits currently report:
 
@@ -155,16 +156,30 @@ Local phase audits currently report:
   - closed
 - milestone `Phase 26 - Packet Delivery Prep and Sender Notes`
   - closed
+- Phase 27 queue sync
+  - merged via PR `#190`
+- Phase 27 final send summary
+  - merged via PR `#191`
+- Phase 27 packet recommendation
+  - merged via PR `#192`
+- Phase 27 exit issue `#186`
+  - closed
+- milestone `Phase 27 - Sendoff Summary and Packet Recommendation`
+  - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 27 queue bootstrap
+  - no open pull requests remain after the Phase 28 queue bootstrap
 
 ## Current Queue
 
-- milestone `Phase 27 - Sendoff Summary and Packet Recommendation` is open.
-- `#186` `Phase 27 exit gate`
+- milestone `Phase 28 - Send Decision and Delivery Checklist` is open.
+- `#193` `Phase 28 exit gate`
   - open
-- blocked until the Phase 27 sendoff-summary slice is complete
-- The current Phase 27 execution slice is tracked through:
+- blocked until the Phase 28 send-decision slice is complete
+- The current Phase 28 execution slice is tracked through:
+  - `#194` `Phase 28: sync bootstrap spec and docs to the active send-decision queue`
+  - `#196` `Phase 28: add final send checklist from packet recommendation, summary, and readiness cues`
+  - `#195` `Phase 28: add destination-specific delivery script from sender note, recommendation, and receiver cue`
+- The completed Phase 27 slice was tracked through:
   - `#188` `Phase 27: sync bootstrap spec and docs to the active sendoff-summary queue`
   - `#187` `Phase 27: add final send summary card from sender note, packet variant, and route cues`
   - `#189` `Phase 27: add destination-aware packet recommendation banner with fallback rationale`


### PR DESCRIPTION
## Summary
- sync the bootstrap spec to the live Phase 28 milestone, label, and issue set
- update README and planning docs so Phase 27 is closed and Phase 28 is the only active execution queue
- keep the repo-facing queue truth aligned with the current GitHub successor state

## Validation
- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
- ./make.ps1 test
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim

Closes #194