### PR TITLE
[codex] Apply reviewed codex branch cleanup

### DIFF
--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -128,7 +128,9 @@ This note is the current Phase 28 active-queue baseline.
 - Local phase audits remain the contract-aligned source of truth for whether the current repo state is runnable and reviewable.
 - `audit-github-queue` is the executable local rule for whether builder automation should remain `paused` or can resume against the successor queue.
 - `backlog/sprint-01.md` is historical seed material only and should not be used as the live queue.
-- Remote `origin/codex/*` branches are historical and superseded by `main`.
+- Remote `origin/codex/*` branches should now be limited to active open-PR work and reviewed exceptions, not used as a standing backlog.
+- The current reviewed branch-hygiene baseline lives in `docs/plans/codex-branch-classification-baseline.md`.
+- Current live remote exceptions are `origin/codex/phase28-send-checklist` (open PR) and `origin/codex/phase23-session-summary` (`TODO[verify]`).
 - Delete a historical remote branch once it is tied only to merged or closed work and no open issue, PR, or runbook step still references it.
 - Keep a historical remote branch only when an open issue or unresolved forensic comparison explicitly names it.
 - Revive a historical remote branch only by opening a new issue that states why `main` is insufficient.

--- a/docs/plans/long-running-loop-runbook.md
+++ b/docs/plans/long-running-loop-runbook.md
@@ -57,7 +57,7 @@ If the queue becomes `fail`, stop pickup and repair the milestone, exit gate, or
 
 ## Branch Hygiene
 
-- Treat current `origin/codex/*` branches as historical and superseded by `main`.
+- Treat `origin/codex/*` branches as temporary execution state by default; once a branch is no longer tied to open work, it should become historical and be reconciled against `main`.
 - Delete a historical branch once it is tied only to merged or closed work and no open issue, PR, or runbook step still references it.
 - Keep a historical branch only when an open issue or unresolved forensic comparison explicitly depends on it.
 - Revive a historical branch only through a new issue that names the branch and explains why `main` is insufficient.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -291,8 +291,10 @@ Local phase audits currently report:
 
 ## Historical Branch Status
 
-- No remote `origin/codex/*` branches remain after the Phase 6 branch-hygiene closeout.
-- Treat any future recreated `codex/*` remote branch as temporary execution state, not as a standing backlog.
+- Remote `origin/codex/*` branches have been reduced to the current open PR head and reviewed exception set, not fully eliminated.
+- The current reviewed baseline is recorded in `docs/plans/codex-branch-classification-baseline.md`.
+- Remaining live remote branches are `origin/codex/phase28-send-checklist` (active open PR) and `origin/codex/phase23-session-summary` (`TODO[verify]`).
+- Treat any future recreated or still-live `codex/*` remote branch as temporary execution state, not as a standing backlog.
 - Delete a historical branch when it is tied only to closed or merged work and no open issue, PR, or runbook step references it.
 - Keep a historical branch only when an open issue or unresolved forensic comparison explicitly depends on it.
 - Revive a historical branch only through a new issue that names the branch and explains why `main` is insufficient.


### PR DESCRIPTION
## Summary
- delete the reviewed remote codex branches classified as safe delete candidates
- prune local historical codex branches down to active work and reviewed exception branches
- sync branch-hygiene docs so they describe the real remaining remote branch set instead of a stale zero-branches claim

## Validation
- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md docs/plans/long-running-loop-runbook.md docs/plans/codex-branch-classification-baseline.md
- ./make.ps1 test
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
- gh pr list --repo YSCJRH/mirror-sim --state open --limit 50 --json number,title,headRefName,isDraft,url
- gh issue list --repo YSCJRH/mirror-sim --state open --limit 50 --json number,title,labels,milestone

Closes #200