### PR TITLE
[codex] Sync repo truth to Phase 30 queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -115,6 +115,10 @@
     {
       "title": "Phase 29 - Delivery Bundle and Follow-up Pack",
       "description": "Turn the current send script, summary, and checklist surfaces into a fuller delivery bundle and receiver follow-up pack without changing core simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 30 - Delivery Confirmation and Receiver Response",
+      "description": "Turn the current delivery bundle and follow-up surfaces into a usable post-send checkpoint and receiver-response workflow without changing simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -262,6 +266,11 @@
       "name": "phase:29",
       "color": "5B6F8C",
       "description": "Phase 29 delivery bundle and follow-up pack work."
+    },
+    {
+      "name": "phase:30",
+      "color": "6C7B91",
+      "description": "Phase 30 delivery confirmation and receiver response work."
     },
     {
       "name": "area:backend",
@@ -1572,6 +1581,51 @@
         "lane:auto-safe"
       ],
       "body": "## goal\nAdd a receiver follow-up pack that combines the current route cue, receiver ask, and send decision so the operator can copy a post-send follow-up note without changing artifact contracts.\n\n## input\n- current frontend/src/app/review-scorecard.tsx\n- current receiver guidance, route kit, delivery script, and final send checklist surfaces\n- existing demo artifacts under artifacts/demo/**\n\n## output\n- a frontend-only follow-up pack derived from the current route, receiver posture, and send decision\n- no backend API calls and no new artifact files\n- copyable follow-up cues that stay aligned with the current preset workflow\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or response-governance contracts\n- storing follow-up history\n\n## minimal test\n- npm run build --prefix frontend\n- ./make.ps1 smoke\n- ./make.ps1 eval-demo\n- manual review that the follow-up pack updates with destination, route, receiver, and send decision posture\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 29"
+    },
+    {
+      "title": "Phase 30 exit gate",
+      "milestone": "Phase 30 - Delivery Confirmation and Receiver Response",
+      "labels": [
+        "phase:30",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nClose Phase 30 only after the queue-sync issue and both receiver-response workflow issues land on main.\n\n## completion standard\n- the Phase 30 queue is fully synced in repo truth\n- the delivery checkpoint board and receiver response packet are merged\n- smoke/test/eval-demo and audit-phase phase1/phase2/phase3 pass\n- audit-github-queue returns ready with a successor queue already opened\n\n## phase\nPhase 30"
+    },
+    {
+      "title": "Phase 30: sync bootstrap spec and docs to the active delivery-confirmation queue",
+      "milestone": "Phase 30 - Delivery Confirmation and Receiver Response",
+      "labels": [
+        "phase:30",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nSync the repo source of truth to the active Phase 30 delivery-confirmation queue so docs, bootstrap metadata, and queue fixtures stop referring to Phase 29 as the active milestone.\n\n## input\n- current README.md\n- current docs/plans/automation-roadmap.md\n- current docs/plans/current-state-baseline.md\n- current docs/plans/phase-execution-queue.md\n- current .github/automation/bootstrap-spec.json\n- current queue-related tests under backend/tests/**\n\n## output\n- Phase 30 becomes the documented active queue across README, plans, bootstrap spec, and queue fixtures\n- Phase 29 is recorded as closed once its exit gate is completed\n- bootstrap metadata includes the Phase 30 milestone, label, and issues created on GitHub\n\n## out-of-scope\n- simulation/report/artifact/schema changes\n- new frontend workflow features beyond queue sync\n- deleting or reopening historical milestones\n\n## minimal test\n- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim\n- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md\n- ./make.ps1 test\n- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim\n\n## touches contract\nNo. Repo governance only.\n\n## phase\nPhase 30"
+    },
+    {
+      "title": "Phase 30: add delivery checkpoint board from send decision, bundle mode, and follow-up posture",
+      "milestone": "Phase 30 - Delivery Confirmation and Receiver Response",
+      "labels": [
+        "phase:30",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a delivery checkpoint board that turns the current send decision, bundle mode, and receiver follow-up posture into one operator-readable post-send checkpoint surface.\n\n## input\n- current frontend/src/app/review-scorecard.tsx\n- current final send summary, delivery bundle, and receiver follow-up pack surfaces\n- existing demo artifacts under artifacts/demo/**\n\n## output\n- a frontend-only checkpoint board derived from the current destination, route cue, bundle mode, send posture, and follow-up posture\n- copyable checkpoint text that can be used to confirm what was sent and what reply posture is expected next\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or response-governance contracts\n- storing checkpoint history\n\n## minimal test\n- npm run build --prefix frontend\n- ./make.ps1 smoke\n- ./make.ps1 eval-demo\n- manual review that the checkpoint board updates with destination, route, bundle mode, and send/follow-up posture\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 30"
+    },
+    {
+      "title": "Phase 30: add receiver response packet from follow-up pack, route template, and reply cues",
+      "milestone": "Phase 30 - Delivery Confirmation and Receiver Response",
+      "labels": [
+        "phase:30",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a receiver response packet that combines the current follow-up pack, active route template, and reply cues so the operator can hand over the next receiver-facing response without rebuilding it by hand.\n\n## input\n- current frontend/src/app/review-scorecard.tsx\n- current receiver follow-up pack, grouped response pack, route-filtered response kit, and receiver guidance surfaces\n- existing demo artifacts under artifacts/demo/**\n\n## output\n- a frontend-only receiver response packet derived from the current route cue, receiver role, and follow-up posture\n- copyable acknowledge / request-more-context / escalate context that stays aligned with the current preset workflow\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or response-governance contracts\n- storing receiver-response history\n\n## minimal test\n- npm run build --prefix frontend\n- ./make.ps1 smoke\n- ./make.ps1 eval-demo\n- manual review that the response packet updates with route, receiver role, and follow-up posture\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 30"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-28 gates, and resumed the successor queue as `Phase 29 - Delivery Bundle and Follow-up Pack`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-29 gates, and resumed the successor queue as `Phase 30 - Delivery Confirmation and Receiver Response`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -56,8 +56,10 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-28 gates, and r
   - Phase 27 queue was completed through issues `#186-#189`
   - milestone `Phase 28 - Send Decision and Delivery Checklist` is closed
   - Phase 28 queue was completed through issues `#193-#196` plus branch-hygiene governance issues `#199-#200`
-  - milestone `Phase 29 - Delivery Bundle and Follow-up Pack` is open
-  - Phase 29 queue is initialized through issues `#204-#207`
+  - milestone `Phase 29 - Delivery Bundle and Follow-up Pack` is closed
+  - Phase 29 queue was completed through issues `#204-#207`
+  - milestone `Phase 30 - Delivery Confirmation and Receiver Response` is open
+  - Phase 30 queue is initialized through issues `#211-#214`
 
 Local phase audits currently show:
 
@@ -112,7 +114,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): review workbench with Phase 28 final-send-checklist and delivery-script surfaces landed while the current Phase 29 delivery-bundle queue continues to consume the same artifact surface
+- [frontend](/D:/mirror/frontend): review workbench with Phase 29 delivery-bundle and receiver-follow-up surfaces landed while the current Phase 30 delivery-confirmation queue continues to consume the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -157,10 +159,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 28 closeout are complete. Phase 29 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 29 closeout are complete. Phase 30 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may resume pickup guidance only against the Phase 29 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation may resume pickup guidance only against the Phase 30 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, and Phase 29 is now the active delivery-bundle track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, and Phase 30 is now the active delivery-confirmation track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -88,9 +88,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 28 is closed locally and in GitHub.
 - Phase 28 exit issue `#193` is closed and milestone `Phase 28 - Send Decision and Delivery Checklist` is closed.
 - The Phase 28 queue was completed through issues `#193-#196` plus branch-hygiene governance issues `#199-#200`.
-- Phase 29 is the active successor queue.
-- milestone `Phase 29 - Delivery Bundle and Follow-up Pack` is open.
-- The Phase 29 queue is initialized through issues `#204-#207`.
+- Phase 29 is closed locally and in GitHub.
+- Phase 29 exit issue `#204` is closed and milestone `Phase 29 - Delivery Bundle and Follow-up Pack` is closed.
+- The Phase 29 queue was completed through issues `#204-#207`.
+- Phase 30 is the active successor queue.
+- milestone `Phase 30 - Delivery Confirmation and Receiver Response` is open.
+- The Phase 30 queue is initialized through issues `#211-#214`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 29 active-queue baseline.
+This note is the current Phase 30 active-queue baseline.
 
 ## Snapshot
 
@@ -120,11 +120,15 @@ This note is the current Phase 29 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/issues/193`
     - Phase 28 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/29`
-    - milestone `Phase 29 - Delivery Bundle and Follow-up Pack` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=29"`
-    - Phase 29 queue is initialized through issues `#204-#207`
+    - milestone `Phase 29 - Delivery Bundle and Follow-up Pack` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/204`
+    - Phase 29 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/30`
+    - milestone `Phase 30 - Delivery Confirmation and Receiver Response` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=30"`
+    - Phase 30 queue is initialized through issues `#211-#214`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` because Phase 29 has one blocked protected-core exit gate and multiple ready work items
+    - successor queue currently reports `ready` because Phase 30 has one blocked protected-core exit gate and multiple ready work items
 
 ## Trusted Source Of Truth
 
@@ -134,7 +138,7 @@ This note is the current Phase 29 active-queue baseline.
 - `backlog/sprint-01.md` is historical seed material only and should not be used as the live queue.
 - Remote `origin/codex/*` branches should now be limited to active open-PR work and reviewed exceptions, not used as a standing backlog.
 - The current reviewed branch-hygiene baseline lives in `docs/plans/codex-branch-classification-baseline.md`.
-- Current live remote exceptions are `origin/codex/phase28-send-checklist` (open PR) and `origin/codex/phase23-session-summary` (`TODO[verify]`).
+- Current live remote exception is `origin/codex/phase23-session-summary` (`TODO[verify]`).
 - Delete a historical remote branch once it is tied only to merged or closed work and no open issue, PR, or runbook step still references it.
 - Keep a historical remote branch only when an open issue or unresolved forensic comparison explicitly names it.
 - Revive a historical remote branch only by opening a new issue that states why `main` is insufficient.
@@ -143,13 +147,13 @@ This note is the current Phase 29 active-queue baseline.
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
-- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, and destination-aware packet recommendation banners without introducing backend API expansion.
-- The current repository state is in an active Phase 29 successor queue, not a closed Phase 28 baseline.
+- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, and receiver follow-up packs without introducing backend API expansion.
+- The current repository state is in an active Phase 30 successor queue, not a closed Phase 29 baseline.
 
 ## Next Entry Point
 
-- Phase 29 is the active milestone and the current delivery-bundle slice is tracked by issues `#204-#207`.
-- New implementation work should attach to the existing Phase 29 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- Phase 30 is the active milestone and the current delivery-confirmation slice is tracked by issues `#211-#214`.
+- New implementation work should attach to the existing Phase 30 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
 - The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 29 queue resumption.
+This note records the current post-Day-0 execution status for Mirror after the Phase 30 queue resumption.
 
 ## Current Gate State
 
@@ -32,7 +32,8 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 26 exit gate: closed
 - Phase 27 exit gate: closed
 - Phase 28 exit gate: closed
-- Phase 29 exit gate: open
+- Phase 29 exit gate: closed
+- Phase 30 exit gate: open
 
 Local phase audits currently report:
 
@@ -181,16 +182,30 @@ Local phase audits currently report:
   - closed
 - milestone `Phase 28 - Send Decision and Delivery Checklist`
   - closed
+- Phase 29 queue sync
+  - merged via PR `#208`
+- Phase 29 delivery bundle export
+  - merged via PR `#209`
+- Phase 29 receiver follow-up pack
+  - merged via PR `#210`
+- Phase 29 exit issue `#204`
+  - closed
+- milestone `Phase 29 - Delivery Bundle and Follow-up Pack`
+  - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 29 queue bootstrap
+  - no open pull requests remain after the Phase 29 closeout
 
 ## Current Queue
 
-- milestone `Phase 29 - Delivery Bundle and Follow-up Pack` is open.
-- `#204` `Phase 29 exit gate`
+- milestone `Phase 30 - Delivery Confirmation and Receiver Response` is open.
+- `#211` `Phase 30 exit gate`
   - open
-- blocked until the Phase 29 delivery-bundle and follow-up slice is complete
-- The current Phase 29 execution slice is tracked through:
+- blocked until the Phase 30 delivery-confirmation and receiver-response slice is complete
+- The current Phase 30 execution slice is tracked through:
+  - `#212` `Phase 30: sync bootstrap spec and docs to the active delivery-confirmation queue`
+  - `#213` `Phase 30: add delivery checkpoint board from send decision, bundle mode, and follow-up posture`
+  - `#214` `Phase 30: add receiver response packet from follow-up pack, route template, and reply cues`
+- The completed Phase 29 slice was tracked through:
   - `#205` `Phase 29: sync bootstrap spec and docs to the active delivery-bundle queue`
   - `#206` `Phase 29: add delivery bundle export from sender note, script, summary, and checklist`
   - `#207` `Phase 29: add receiver follow-up pack from route cue, receiver ask, and send decision`
@@ -311,7 +326,7 @@ Local phase audits currently report:
 
 - Remote `origin/codex/*` branches have been reduced to the current open PR head and reviewed exception set, not fully eliminated.
 - The current reviewed baseline is recorded in `docs/plans/codex-branch-classification-baseline.md`.
-- Remaining live remote branches are `origin/codex/phase28-send-checklist` (active open PR) and `origin/codex/phase23-session-summary` (`TODO[verify]`).
+- Remaining live remote branch is `origin/codex/phase23-session-summary` (`TODO[verify]`).
 - Treat any future recreated or still-live `codex/*` remote branch as temporary execution state, not as a standing backlog.
 - Delete a historical branch when it is tied only to closed or merged work and no open issue, PR, or runbook step references it.
 - Keep a historical branch only when an open issue or unresolved forensic comparison explicitly depends on it.


### PR DESCRIPTION
## Summary
- sync README and planning docs to the active Phase 30 queue
- record Phase 29 closeout and the Phase 30 successor objects in bootstrap metadata
- keep the queue baseline aligned with the current live GitHub state and remote branch reality

## Testing
- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
- ./make.ps1 test
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim

Closes #212