### PR TITLE
[codex] Sync repo truth to Phase 31 queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -119,6 +119,10 @@
     {
       "title": "Phase 30 - Delivery Confirmation and Receiver Response",
       "description": "Turn the current delivery bundle and follow-up surfaces into a usable post-send checkpoint and receiver-response workflow without changing simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 31 - Reply Outcome and Resolution Handoff",
+      "description": "Turn the current delivery checkpoint and receiver-response surfaces into a clearer reply-outcome and resolution handoff workflow without changing simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -271,6 +275,11 @@
       "name": "phase:30",
       "color": "6C7B91",
       "description": "Phase 30 delivery confirmation and receiver response work."
+    },
+    {
+      "name": "phase:31",
+      "color": "7A8796",
+      "description": "Phase 31 reply outcome and resolution handoff work."
     },
     {
       "name": "area:backend",
@@ -1626,6 +1635,51 @@
         "lane:auto-safe"
       ],
       "body": "## goal\nAdd a receiver response packet that combines the current follow-up pack, active route template, and reply cues so the operator can hand over the next receiver-facing response without rebuilding it by hand.\n\n## input\n- current frontend/src/app/review-scorecard.tsx\n- current receiver follow-up pack, grouped response pack, route-filtered response kit, and receiver guidance surfaces\n- existing demo artifacts under artifacts/demo/**\n\n## output\n- a frontend-only receiver response packet derived from the current route cue, receiver role, and follow-up posture\n- copyable acknowledge / request-more-context / escalate context that stays aligned with the current preset workflow\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or response-governance contracts\n- storing receiver-response history\n\n## minimal test\n- npm run build --prefix frontend\n- ./make.ps1 smoke\n- ./make.ps1 eval-demo\n- manual review that the response packet updates with route, receiver role, and follow-up posture\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 30"
+    },
+    {
+      "title": "Phase 31 exit gate",
+      "milestone": "Phase 31 - Reply Outcome and Resolution Handoff",
+      "labels": [
+        "phase:31",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nClose Phase 31 only after the queue-sync issue and both resolution-handoff workflow issues land on main.\n\n## completion standard\n- the Phase 31 queue is fully synced in repo truth\n- the reply outcome tracker and resolution handoff pack are merged\n- smoke/test/eval-demo and audit-phase phase1/phase2/phase3 pass\n- audit-github-queue returns ready with a successor queue already opened\n\n## phase\nPhase 31"
+    },
+    {
+      "title": "Phase 31: sync bootstrap spec and docs to the active reply-resolution queue",
+      "milestone": "Phase 31 - Reply Outcome and Resolution Handoff",
+      "labels": [
+        "phase:31",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nSync the repo source of truth to the active Phase 31 reply-resolution queue so docs, bootstrap metadata, and queue fixtures stop referring to Phase 30 as the active milestone.\n\n## input\n- current README.md\n- current docs/plans/automation-roadmap.md\n- current docs/plans/current-state-baseline.md\n- current docs/plans/phase-execution-queue.md\n- current .github/automation/bootstrap-spec.json\n- current queue-related tests under backend/tests/**\n\n## output\n- Phase 31 becomes the documented active queue across README, plans, bootstrap spec, and queue fixtures\n- Phase 30 is recorded as closed once its exit gate is completed\n- bootstrap metadata includes the Phase 31 milestone, label, and issues created on GitHub\n\n## out-of-scope\n- simulation/report/artifact/schema changes\n- new frontend workflow features beyond queue sync\n- deleting or reopening historical milestones\n\n## minimal test\n- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim\n- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md\n- ./make.ps1 test\n- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim\n\n## touches contract\nNo. Repo governance only.\n\n## phase\nPhase 31"
+    },
+    {
+      "title": "Phase 31: add reply outcome tracker from response packet, route cue, and checkpoint board",
+      "milestone": "Phase 31 - Reply Outcome and Resolution Handoff",
+      "labels": [
+        "phase:31",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a reply outcome tracker that turns the current receiver response packet, route cue, and delivery checkpoint board into one operator-readable outcome surface.\n\n## input\n- current frontend/src/app/review-scorecard.tsx\n- current delivery checkpoint board, receiver response packet, and route-filtered response kit surfaces\n- existing demo artifacts under artifacts/demo/**\n\n## output\n- a frontend-only outcome tracker derived from the current route cue, receiver role, reply posture, and checkpoint state\n- copyable outcome text that can be used to confirm what reply path fired and what state remains open next\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or response-governance contracts\n- storing reply history\n\n## minimal test\n- npm run build --prefix frontend\n- ./make.ps1 smoke\n- ./make.ps1 eval-demo\n- manual review that the outcome tracker updates with route, receiver role, reply posture, and checkpoint state\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 31"
+    },
+    {
+      "title": "Phase 31: add resolution handoff pack from checkpoint board, response packet, and escalation cues",
+      "milestone": "Phase 31 - Reply Outcome and Resolution Handoff",
+      "labels": [
+        "phase:31",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a resolution handoff pack that combines the current checkpoint board, receiver response packet, and escalation cues so the operator can hand over the remaining resolution context without rebuilding it by hand.\n\n## input\n- current frontend/src/app/review-scorecard.tsx\n- current delivery checkpoint board, receiver response packet, and escalation/follow-through cue surfaces\n- existing demo artifacts under artifacts/demo/**\n\n## output\n- a frontend-only resolution handoff pack derived from the current checkpoint posture, response packet, and escalation path\n- copyable resolution handoff cues that stay aligned with the current preset workflow\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or response-governance contracts\n- storing resolution history\n\n## minimal test\n- npm run build --prefix frontend\n- ./make.ps1 smoke\n- ./make.ps1 eval-demo\n- manual review that the resolution handoff pack updates with checkpoint state, response posture, and escalation cues\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 31"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-29 gates, and resumed the successor queue as `Phase 30 - Delivery Confirmation and Receiver Response`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-30 gates, and resumed the successor queue as `Phase 31 - Reply Outcome and Resolution Handoff`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -58,8 +58,10 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-29 gates, and r
   - Phase 28 queue was completed through issues `#193-#196` plus branch-hygiene governance issues `#199-#200`
   - milestone `Phase 29 - Delivery Bundle and Follow-up Pack` is closed
   - Phase 29 queue was completed through issues `#204-#207`
-  - milestone `Phase 30 - Delivery Confirmation and Receiver Response` is open
-  - Phase 30 queue is initialized through issues `#211-#214`
+  - milestone `Phase 30 - Delivery Confirmation and Receiver Response` is closed
+  - Phase 30 queue was completed through issues `#211-#214`
+  - milestone `Phase 31 - Reply Outcome and Resolution Handoff` is open
+  - Phase 31 queue is initialized through issues `#218-#221`
 
 Local phase audits currently show:
 
@@ -114,7 +116,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): review workbench with Phase 29 delivery-bundle and receiver-follow-up surfaces landed while the current Phase 30 delivery-confirmation queue continues to consume the same artifact surface
+- [frontend](/D:/mirror/frontend): review workbench with Phase 30 delivery-checkpoint and receiver-response surfaces landed while the current Phase 31 reply-resolution queue continues to consume the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -159,10 +161,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 29 closeout are complete. Phase 30 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 30 closeout are complete. Phase 31 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may resume pickup guidance only against the Phase 30 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation may resume pickup guidance only against the Phase 31 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, and Phase 30 is now the active delivery-confirmation track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, and Phase 31 is now the active reply-resolution track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -91,9 +91,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 29 is closed locally and in GitHub.
 - Phase 29 exit issue `#204` is closed and milestone `Phase 29 - Delivery Bundle and Follow-up Pack` is closed.
 - The Phase 29 queue was completed through issues `#204-#207`.
-- Phase 30 is the active successor queue.
-- milestone `Phase 30 - Delivery Confirmation and Receiver Response` is open.
-- The Phase 30 queue is initialized through issues `#211-#214`.
+- Phase 30 is closed locally and in GitHub.
+- Phase 30 exit issue `#211` is closed and milestone `Phase 30 - Delivery Confirmation and Receiver Response` is closed.
+- The Phase 30 queue was completed through issues `#211-#214`.
+- Phase 31 is the active successor queue.
+- milestone `Phase 31 - Reply Outcome and Resolution Handoff` is open.
+- The Phase 31 queue is initialized through issues `#218-#221`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 30 active-queue baseline.
+This note is the current Phase 31 active-queue baseline.
 
 ## Snapshot
 
@@ -124,11 +124,15 @@ This note is the current Phase 30 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/issues/204`
     - Phase 29 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/30`
-    - milestone `Phase 30 - Delivery Confirmation and Receiver Response` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=30"`
-    - Phase 30 queue is initialized through issues `#211-#214`
+    - milestone `Phase 30 - Delivery Confirmation and Receiver Response` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/211`
+    - Phase 30 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/31`
+    - milestone `Phase 31 - Reply Outcome and Resolution Handoff` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=31"`
+    - Phase 31 queue is initialized through issues `#218-#221`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` because Phase 30 has one blocked protected-core exit gate and multiple ready work items
+    - successor queue currently reports `ready` because Phase 31 has one blocked protected-core exit gate and multiple ready work items
 
 ## Trusted Source Of Truth
 
@@ -147,13 +151,13 @@ This note is the current Phase 30 active-queue baseline.
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
-- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, and receiver follow-up packs without introducing backend API expansion.
-- The current repository state is in an active Phase 30 successor queue, not a closed Phase 29 baseline.
+- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, and receiver response packets without introducing backend API expansion.
+- The current repository state is in an active Phase 31 successor queue, not a closed Phase 30 baseline.
 
 ## Next Entry Point
 
-- Phase 30 is the active milestone and the current delivery-confirmation slice is tracked by issues `#211-#214`.
-- New implementation work should attach to the existing Phase 30 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- Phase 31 is the active milestone and the current reply-resolution slice is tracked by issues `#218-#221`.
+- New implementation work should attach to the existing Phase 31 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
 - The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 30 queue resumption.
+This note records the current post-Day-0 execution status for Mirror after the Phase 31 queue resumption.
 
 ## Current Gate State
 
@@ -33,7 +33,8 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 27 exit gate: closed
 - Phase 28 exit gate: closed
 - Phase 29 exit gate: closed
-- Phase 30 exit gate: open
+- Phase 30 exit gate: closed
+- Phase 31 exit gate: open
 
 Local phase audits currently report:
 
@@ -192,16 +193,30 @@ Local phase audits currently report:
   - closed
 - milestone `Phase 29 - Delivery Bundle and Follow-up Pack`
   - closed
+- Phase 30 queue sync
+  - merged via PR `#215`
+- Phase 30 delivery checkpoint board
+  - merged via PR `#216`
+- Phase 30 receiver response packet
+  - merged via PR `#217`
+- Phase 30 exit issue `#211`
+  - closed
+- milestone `Phase 30 - Delivery Confirmation and Receiver Response`
+  - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 29 closeout
+  - no open pull requests remain after the Phase 30 closeout
 
 ## Current Queue
 
-- milestone `Phase 30 - Delivery Confirmation and Receiver Response` is open.
-- `#211` `Phase 30 exit gate`
+- milestone `Phase 31 - Reply Outcome and Resolution Handoff` is open.
+- `#218` `Phase 31 exit gate`
   - open
-- blocked until the Phase 30 delivery-confirmation and receiver-response slice is complete
-- The current Phase 30 execution slice is tracked through:
+- blocked until the Phase 31 reply-resolution and resolution-handoff slice is complete
+- The current Phase 31 execution slice is tracked through:
+  - `#221` `Phase 31: sync bootstrap spec and docs to the active reply-resolution queue`
+  - `#219` `Phase 31: add reply outcome tracker from response packet, route cue, and checkpoint board`
+  - `#220` `Phase 31: add resolution handoff pack from checkpoint board, response packet, and escalation cues`
+- The completed Phase 30 slice was tracked through:
   - `#212` `Phase 30: sync bootstrap spec and docs to the active delivery-confirmation queue`
   - `#213` `Phase 30: add delivery checkpoint board from send decision, bundle mode, and follow-up posture`
   - `#214` `Phase 30: add receiver response packet from follow-up pack, route template, and reply cues`


### PR DESCRIPTION
## Summary
- sync README and planning docs to the active Phase 31 queue
- record Phase 30 closeout and the Phase 31 successor objects in bootstrap metadata
- keep the queue baseline aligned with the current live GitHub state and branch reality

## Testing
- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
- ./make.ps1 test
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim

Closes #221