### PR TITLE
[codex] Sync repo truth to Phase 32 queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -123,6 +123,10 @@
     {
       "title": "Phase 31 - Reply Outcome and Resolution Handoff",
       "description": "Turn the current delivery checkpoint and receiver-response surfaces into a clearer reply-outcome and resolution handoff workflow without changing simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 32 - Resolution Status and Next-Step Routing",
+      "description": "Turn the current outcome and resolution handoff surfaces into a clearer resolution-status and next-step routing workflow without changing simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -280,6 +284,11 @@
       "name": "phase:31",
       "color": "7A8796",
       "description": "Phase 31 reply outcome and resolution handoff work."
+    },
+    {
+      "name": "phase:32",
+      "color": "8892A0",
+      "description": "Phase 32 resolution status and next-step routing work."
     },
     {
       "name": "area:backend",
@@ -1680,6 +1689,51 @@
         "lane:auto-safe"
       ],
       "body": "## goal\nAdd a resolution handoff pack that combines the current checkpoint board, receiver response packet, and escalation cues so the operator can hand over the remaining resolution context without rebuilding it by hand.\n\n## input\n- current frontend/src/app/review-scorecard.tsx\n- current delivery checkpoint board, receiver response packet, and escalation/follow-through cue surfaces\n- existing demo artifacts under artifacts/demo/**\n\n## output\n- a frontend-only resolution handoff pack derived from the current checkpoint posture, response packet, and escalation path\n- copyable resolution handoff cues that stay aligned with the current preset workflow\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or response-governance contracts\n- storing resolution history\n\n## minimal test\n- npm run build --prefix frontend\n- ./make.ps1 smoke\n- ./make.ps1 eval-demo\n- manual review that the resolution handoff pack updates with checkpoint state, response posture, and escalation cues\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 31"
+    },
+    {
+      "title": "Phase 32 exit gate",
+      "milestone": "Phase 32 - Resolution Status and Next-Step Routing",
+      "labels": [
+        "phase:32",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nClose Phase 32 only after the queue-sync issue and both resolution-routing workflow issues land on main.\n\n## completion standard\n- the Phase 32 queue is fully synced in repo truth\n- the resolution status board and next-step routing pack are merged\n- smoke/test/eval-demo and audit-phase phase1/phase2/phase3 pass\n- audit-github-queue returns ready with a successor queue already opened\n\n## phase\nPhase 32"
+    },
+    {
+      "title": "Phase 32: sync bootstrap spec and docs to the active resolution-status queue",
+      "milestone": "Phase 32 - Resolution Status and Next-Step Routing",
+      "labels": [
+        "phase:32",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nSync the repo source of truth to the active Phase 32 resolution-status queue so docs, bootstrap metadata, and queue fixtures stop referring to Phase 31 as the active milestone.\n\n## input\n- current README.md\n- current docs/plans/automation-roadmap.md\n- current docs/plans/current-state-baseline.md\n- current docs/plans/phase-execution-queue.md\n- current .github/automation/bootstrap-spec.json\n- current queue-related tests under backend/tests/**\n\n## output\n- Phase 32 becomes the documented active queue across README, plans, bootstrap spec, and queue fixtures\n- Phase 31 is recorded as closed once its exit gate is completed\n- bootstrap metadata includes the Phase 32 milestone, label, and issues created on GitHub\n\n## out-of-scope\n- simulation/report/artifact/schema changes\n- new frontend workflow features beyond queue sync\n- deleting or reopening historical milestones\n\n## minimal test\n- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim\n- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md\n- ./make.ps1 test\n- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim\n\n## touches contract\nNo. Repo governance only.\n\n## phase\nPhase 32"
+    },
+    {
+      "title": "Phase 32: add resolution status board from outcome tracker, handoff pack, and escalation path",
+      "milestone": "Phase 32 - Resolution Status and Next-Step Routing",
+      "labels": [
+        "phase:32",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a resolution status board that turns the current reply outcome tracker, resolution handoff pack, and escalation path into one operator-readable status surface.\n\n## input\n- current frontend/src/app/review-scorecard.tsx\n- current reply outcome tracker, resolution handoff pack, and follow-through routing surfaces\n- existing demo artifacts under artifacts/demo/**\n\n## output\n- a frontend-only status board derived from the current outcome route, checkpoint posture, and escalation path\n- copyable status text that can be used to confirm what has been resolved and what remains open\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or response-governance contracts\n- storing resolution history\n\n## minimal test\n- npm run build --prefix frontend\n- ./make.ps1 smoke\n- ./make.ps1 eval-demo\n- manual review that the status board updates with outcome route, checkpoint posture, and escalation path\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 32"
+    },
+    {
+      "title": "Phase 32: add next-step routing pack from outcome tracker, handoff pack, and open-state cues",
+      "milestone": "Phase 32 - Resolution Status and Next-Step Routing",
+      "labels": [
+        "phase:32",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd a next-step routing pack that combines the current outcome tracker, resolution handoff pack, and open-state cues so the operator can route the next action without rebuilding the context by hand.\n\n## input\n- current frontend/src/app/review-scorecard.tsx\n- current reply outcome tracker, resolution handoff pack, and next-checkpoint/open-state cue surfaces\n- existing demo artifacts under artifacts/demo/**\n\n## output\n- a frontend-only routing pack derived from the current outcome route, open-state cues, and resolution posture\n- copyable next-step routing cues that stay aligned with the current preset workflow\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or response-governance contracts\n- storing routing history\n\n## minimal test\n- npm run build --prefix frontend\n- ./make.ps1 smoke\n- ./make.ps1 eval-demo\n- manual review that the routing pack updates with outcome route, next open state, and resolution posture\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 32"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-30 gates, and resumed the successor queue as `Phase 31 - Reply Outcome and Resolution Handoff`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-31 gates, and resumed the successor queue as `Phase 32 - Resolution Status and Next-Step Routing`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -60,8 +60,10 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-30 gates, and r
   - Phase 29 queue was completed through issues `#204-#207`
   - milestone `Phase 30 - Delivery Confirmation and Receiver Response` is closed
   - Phase 30 queue was completed through issues `#211-#214`
-  - milestone `Phase 31 - Reply Outcome and Resolution Handoff` is open
-  - Phase 31 queue is initialized through issues `#218-#221`
+  - milestone `Phase 31 - Reply Outcome and Resolution Handoff` is closed
+  - Phase 31 queue was completed through issues `#218-#221`
+  - milestone `Phase 32 - Resolution Status and Next-Step Routing` is open
+  - Phase 32 queue is initialized through issues `#225-#228`
 
 Local phase audits currently show:
 
@@ -116,7 +118,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): review workbench with Phase 30 delivery-checkpoint and receiver-response surfaces landed while the current Phase 31 reply-resolution queue continues to consume the same artifact surface
+- [frontend](/D:/mirror/frontend): review workbench with Phase 31 reply-outcome and resolution-handoff surfaces landed while the current Phase 32 resolution-status queue continues to consume the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -161,10 +163,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 30 closeout are complete. Phase 31 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 31 closeout are complete. Phase 32 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may resume pickup guidance only against the Phase 31 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation may resume pickup guidance only against the Phase 32 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, and Phase 31 is now the active reply-resolution track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, and Phase 32 is now the active resolution-status track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -94,9 +94,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 30 is closed locally and in GitHub.
 - Phase 30 exit issue `#211` is closed and milestone `Phase 30 - Delivery Confirmation and Receiver Response` is closed.
 - The Phase 30 queue was completed through issues `#211-#214`.
-- Phase 31 is the active successor queue.
-- milestone `Phase 31 - Reply Outcome and Resolution Handoff` is open.
-- The Phase 31 queue is initialized through issues `#218-#221`.
+- Phase 31 is closed locally and in GitHub.
+- Phase 31 exit issue `#218` is closed and milestone `Phase 31 - Reply Outcome and Resolution Handoff` is closed.
+- The Phase 31 queue was completed through issues `#218-#221`.
+- Phase 32 is the active successor queue.
+- milestone `Phase 32 - Resolution Status and Next-Step Routing` is open.
+- The Phase 32 queue is initialized through issues `#225-#228`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 31 active-queue baseline.
+This note is the current Phase 32 active-queue baseline.
 
 ## Snapshot
 
@@ -128,11 +128,15 @@ This note is the current Phase 31 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/issues/211`
     - Phase 30 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/31`
-    - milestone `Phase 31 - Reply Outcome and Resolution Handoff` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=31"`
-    - Phase 31 queue is initialized through issues `#218-#221`
+    - milestone `Phase 31 - Reply Outcome and Resolution Handoff` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/218`
+    - Phase 31 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/32`
+    - milestone `Phase 32 - Resolution Status and Next-Step Routing` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=32"`
+    - Phase 32 queue is initialized through issues `#225-#228`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` because Phase 31 has one blocked protected-core exit gate and multiple ready work items
+    - successor queue currently reports `ready` because Phase 32 has one blocked protected-core exit gate and multiple ready work items
 
 ## Trusted Source Of Truth
 
@@ -151,13 +155,13 @@ This note is the current Phase 31 active-queue baseline.
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
-- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, and receiver response packets without introducing backend API expansion.
-- The current repository state is in an active Phase 31 successor queue, not a closed Phase 30 baseline.
+- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, and resolution handoff packs without introducing backend API expansion.
+- The current repository state is in an active Phase 32 successor queue, not a closed Phase 31 baseline.
 
 ## Next Entry Point
 
-- Phase 31 is the active milestone and the current reply-resolution slice is tracked by issues `#218-#221`.
-- New implementation work should attach to the existing Phase 31 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- Phase 32 is the active milestone and the current resolution-status slice is tracked by issues `#225-#228`.
+- New implementation work should attach to the existing Phase 32 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
 - The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 31 queue resumption.
+This note records the current post-Day-0 execution status for Mirror after the Phase 32 queue resumption.
 
 ## Current Gate State
 
@@ -34,7 +34,8 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 28 exit gate: closed
 - Phase 29 exit gate: closed
 - Phase 30 exit gate: closed
-- Phase 31 exit gate: open
+- Phase 31 exit gate: closed
+- Phase 32 exit gate: open
 
 Local phase audits currently report:
 
@@ -203,16 +204,30 @@ Local phase audits currently report:
   - closed
 - milestone `Phase 30 - Delivery Confirmation and Receiver Response`
   - closed
+- Phase 31 queue sync
+  - merged via PR `#222`
+- Phase 31 reply outcome tracker
+  - merged via PR `#223`
+- Phase 31 resolution handoff pack
+  - merged via PR `#224`
+- Phase 31 exit issue `#218`
+  - closed
+- milestone `Phase 31 - Reply Outcome and Resolution Handoff`
+  - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 30 closeout
+  - no open pull requests remain after the Phase 31 closeout
 
 ## Current Queue
 
-- milestone `Phase 31 - Reply Outcome and Resolution Handoff` is open.
-- `#218` `Phase 31 exit gate`
+- milestone `Phase 32 - Resolution Status and Next-Step Routing` is open.
+- `#225` `Phase 32 exit gate`
   - open
-- blocked until the Phase 31 reply-resolution and resolution-handoff slice is complete
-- The current Phase 31 execution slice is tracked through:
+- blocked until the Phase 32 resolution-status and next-step-routing slice is complete
+- The current Phase 32 execution slice is tracked through:
+  - `#227` `Phase 32: sync bootstrap spec and docs to the active resolution-status queue`
+  - `#226` `Phase 32: add resolution status board from outcome tracker, handoff pack, and escalation path`
+  - `#228` `Phase 32: add next-step routing pack from outcome tracker, handoff pack, and open-state cues`
+- The completed Phase 31 slice was tracked through:
   - `#221` `Phase 31: sync bootstrap spec and docs to the active reply-resolution queue`
   - `#219` `Phase 31: add reply outcome tracker from response packet, route cue, and checkpoint board`
   - `#220` `Phase 31: add resolution handoff pack from checkpoint board, response packet, and escalation cues`


### PR DESCRIPTION
## Summary
- sync README and planning docs to the active Phase 32 queue
- record Phase 31 closeout and the Phase 32 successor objects in bootstrap metadata
- keep the queue baseline aligned with the current live GitHub state and branch reality

## Testing
- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
- ./make.ps1 test
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim

Closes #227