### PR TITLE
[codex] Sync repo truth to Phase 35 queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -135,6 +135,10 @@
     {
       "title": "Phase 34 - Execution Kickoff and Escalation Decision",
       "description": "Turn the current action-readiness and escalation-handoff surfaces into a clearer execution-kickoff and escalation-decision workflow without changing simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 35 - Execution Tracking and Escalation Trigger",
+      "description": "Turn the current kickoff-decision surfaces into explicit execution-progress and escalation-trigger workflow guidance without changing simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -307,6 +311,11 @@
       "name": "phase:34",
       "color": "A3ACB8",
       "description": "Phase 34 execution kickoff and escalation decision work."
+    },
+    {
+      "name": "phase:35",
+      "color": "B1B9C3",
+      "description": "Phase 35 execution tracking and escalation trigger work."
     },
     {
       "name": "area:backend",
@@ -1842,6 +1851,51 @@
         "lane:auto-safe"
       ],
       "body": "## goal\nAdd an escalation decision guide that combines the current action readiness board, escalation handoff packet, and fallback thresholds so the operator can decide whether to escalate without rebuilding the context by hand.\n\n## input\n- current frontend/src/app/review-scorecard.tsx\n- current action readiness board, escalation handoff packet, and fallback/escalation cue surfaces\n- existing demo artifacts under artifacts/demo/**\n\n## output\n- a frontend-only escalation decision guide derived from the current readiness state, blocker posture, and fallback route\n- copyable escalation-decision cues that stay aligned with the current preset workflow\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or response-governance contracts\n- storing escalation decision history\n\n## minimal test\n- npm run build --prefix frontend\n- ./make.ps1 smoke\n- ./make.ps1 eval-demo\n- manual review that the escalation decision guide updates with readiness state, blocker posture, and fallback route\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 34"
+    },
+    {
+      "title": "Phase 35 exit gate",
+      "milestone": "Phase 35 - Execution Tracking and Escalation Trigger",
+      "labels": [
+        "phase:35",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nClose Phase 35 only after the queue-sync issue and both execution-tracking workflow issues land on main.\n\n## completion standard\n- the Phase 35 queue is fully synced in repo truth\n- the execution progress tracker and escalation trigger packet are merged\n- smoke/test/eval-demo and audit-phase phase1/phase2/phase3 pass\n- audit-github-queue returns ready with a successor queue already opened\n\n## phase\nPhase 35"
+    },
+    {
+      "title": "Phase 35: sync repo truth to the execution-tracking and escalation-trigger queue",
+      "milestone": "Phase 35 - Execution Tracking and Escalation Trigger",
+      "labels": [
+        "phase:35",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## goal\nSync the repo source of truth to the active Phase 35 execution-tracking queue so docs and bootstrap metadata stop referring to Phase 34 as the active milestone.\n\n## input\n- current README.md\n- current docs/plans/automation-roadmap.md\n- current docs/plans/current-state-baseline.md\n- current docs/plans/phase-execution-queue.md\n- current .github/automation/bootstrap-spec.json\n\n## output\n- Phase 35 becomes the documented active queue across README, plans, and bootstrap spec\n- Phase 34 is recorded as closed once its exit gate is completed\n- bootstrap metadata includes the Phase 35 milestone, label, and issues created on GitHub\n\n## out-of-scope\n- simulation/report/artifact/schema changes\n- new frontend workflow features beyond queue sync\n- deleting or reopening historical milestones\n\n## minimal test\n- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim\n- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md\n- ./make.ps1 test\n- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim\n\n## touches contract\nNo. Repo governance only.\n\n## phase\nPhase 35"
+    },
+    {
+      "title": "Phase 35: add execution progress tracker from kickoff board, checkpoint board, and receiver response packet",
+      "milestone": "Phase 35 - Execution Tracking and Escalation Trigger",
+      "labels": [
+        "phase:35",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd an execution progress tracker that turns the current execution kickoff board, delivery checkpoint board, and receiver response packet into one operator-readable progress surface.\n\n## input\n- current frontend/src/app/review-scorecard.tsx\n- current execution kickoff board, delivery checkpoint board, and receiver response packet surfaces\n- existing demo artifacts under artifacts/demo/**\n\n## output\n- a frontend-only execution progress tracker derived from the current kickoff posture, checkpoint state, and receiver response path\n- copyable progress text that can be used to confirm whether the current route has started, moved, or stalled\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or response-governance contracts\n- storing execution history outside the current workbench state\n\n## minimal test\n- npm run build --prefix frontend\n- ./make.ps1 smoke\n- ./make.ps1 eval-demo\n- manual review that the execution progress tracker updates with kickoff state, checkpoint posture, and receiver response cues\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 35"
+    },
+    {
+      "title": "Phase 35: add escalation trigger packet from decision guide, handoff packet, and blocker cues",
+      "milestone": "Phase 35 - Execution Tracking and Escalation Trigger",
+      "labels": [
+        "phase:35",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## goal\nAdd an escalation trigger packet that combines the current escalation decision guide, escalation handoff packet, and blocker cues so the operator can escalate from a clearer trigger-focused surface.\n\n## input\n- current frontend/src/app/review-scorecard.tsx\n- current escalation decision guide, escalation handoff packet, and blocker/open-state cue surfaces\n- existing demo artifacts under artifacts/demo/**\n\n## output\n- a frontend-only escalation trigger packet derived from the current decision posture, fallback route, and blocker cues\n- copyable escalation-trigger cues that stay aligned with the current preset workflow\n- no backend API calls and no new artifact files\n\n## out-of-scope\n- posting directly to GitHub\n- changing packet schemas or response-governance contracts\n- storing escalation trigger history\n\n## minimal test\n- npm run build --prefix frontend\n- ./make.ps1 smoke\n- ./make.ps1 eval-demo\n- manual review that the escalation trigger packet updates with decision posture, fallback route, and blocker cues\n\n## touches contract\nNo. This issue must remain frontend-only and artifact-read-only.\n\n## phase\nPhase 35"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-33 gates, and resumed the successor queue as `Phase 34 - Execution Kickoff and Escalation Decision`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-34 gates, and resumed the successor queue as `Phase 35 - Execution Tracking and Escalation Trigger`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -19,7 +19,7 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-33 gates, and r
   - CI upgraded to a long-running quality gate
   - local lane-classification, phase-audit, and GitHub queue-audit commands
   - protected `main` with required status checks and auto-merge for safe-lane PRs
-  - a browser workbench that now supports claim -> evidence drill-down, trace review, reviewer scorecards, issue-comment packets, and operator handoff briefs
+  - a browser workbench that now supports claim -> evidence drill-down, trace review, reviewer scorecards, issue-comment packets, operator handoff briefs, execution kickoff boards, and escalation decision guides
   - a documented worktree-based pickup and handoff path for long-running queue execution
 - GitHub queue state is aligned with the local baseline:
   - Phase 3 exit issue `#4` is closed
@@ -66,8 +66,10 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-33 gates, and r
   - Phase 32 queue was completed through issues `#225-#228`
   - milestone `Phase 33 - Action Readiness and Escalation Packet` is closed
   - Phase 33 queue was completed through issues `#232-#235`
-  - milestone `Phase 34 - Execution Kickoff and Escalation Decision` is open
-  - Phase 34 queue is initialized through issues `#239-#242`
+  - milestone `Phase 34 - Execution Kickoff and Escalation Decision` is closed
+  - Phase 34 queue was completed through issues `#239-#242`
+  - milestone `Phase 35 - Execution Tracking and Escalation Trigger` is open
+  - Phase 35 queue is initialized through issues `#246-#249`
 
 Local phase audits currently show:
 
@@ -122,7 +124,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): review workbench with Phase 33 action-readiness and escalation-handoff surfaces landed while the current Phase 34 kickoff-decision queue continues to consume the same artifact surface
+- [frontend](/D:/mirror/frontend): review workbench with Phase 34 kickoff and escalation-decision surfaces landed while the current Phase 35 execution-tracking queue continues to consume the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -167,10 +169,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 33 closeout are complete. Phase 34 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 34 closeout are complete. Phase 35 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may resume pickup guidance only against the Phase 34 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation may resume pickup guidance only against the Phase 35 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, and Phase 34 is now the active kickoff-decision track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, and Phase 35 is now the active execution-tracking track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -103,9 +103,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 33 is closed locally and in GitHub.
 - Phase 33 exit issue `#234` is closed and milestone `Phase 33 - Action Readiness and Escalation Packet` is closed.
 - The Phase 33 queue was completed through issues `#232-#235`.
-- Phase 34 is the active successor queue.
-- milestone `Phase 34 - Execution Kickoff and Escalation Decision` is open.
-- The Phase 34 queue is initialized through issues `#239-#242`.
+- Phase 34 is closed locally and in GitHub.
+- Phase 34 exit issue `#239` is closed and milestone `Phase 34 - Execution Kickoff and Escalation Decision` is closed.
+- The Phase 34 queue was completed through issues `#239-#242`.
+- Phase 35 is the active successor queue.
+- milestone `Phase 35 - Execution Tracking and Escalation Trigger` is open.
+- The Phase 35 queue is initialized through issues `#246-#249`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 34 active-queue baseline.
+This note is the current Phase 35 active-queue baseline.
 
 ## Snapshot
 
@@ -139,12 +139,16 @@ This note is the current Phase 34 active-queue baseline.
     - milestone `Phase 33 - Action Readiness and Escalation Packet` is `closed`
   - `gh api repos/YSCJRH/mirror-sim/issues/234`
     - Phase 33 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/239`
+    - Phase 34 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/34`
-    - milestone `Phase 34 - Execution Kickoff and Escalation Decision` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=34"`
-    - Phase 34 queue is initialized through issues `#239-#242`
+    - milestone `Phase 34 - Execution Kickoff and Escalation Decision` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/35`
+    - milestone `Phase 35 - Execution Tracking and Escalation Trigger` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=35"`
+    - Phase 35 queue is initialized through issues `#246-#249`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` because Phase 34 has one blocked protected-core exit gate and multiple ready work items
+    - successor queue currently reports `ready` because Phase 35 has one blocked protected-core exit gate and multiple ready work items
 
 ## Trusted Source Of Truth
 
@@ -163,13 +167,13 @@ This note is the current Phase 34 active-queue baseline.
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
-- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, and escalation handoff packets without introducing backend API expansion.
-- The current repository state is in an active Phase 34 successor queue, not a closed Phase 33 baseline.
+- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, and escalation decision guides without introducing backend API expansion.
+- The current repository state is in an active Phase 35 successor queue, not a closed Phase 34 baseline.
 
 ## Next Entry Point
 
-- Phase 34 is the active milestone and the current kickoff-decision slice is tracked by issues `#239-#242`.
-- New implementation work should attach to the existing Phase 34 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- Phase 35 is the active milestone and the current execution-tracking slice is tracked by issues `#246-#249`.
+- New implementation work should attach to the existing Phase 35 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
 - The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 34 queue resumption.
+This note records the current post-Day-0 execution status for Mirror after the Phase 35 queue resumption.
 
 ## Current Gate State
 
@@ -37,7 +37,8 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 31 exit gate: closed
 - Phase 32 exit gate: closed
 - Phase 33 exit gate: closed
-- Phase 34 exit gate: open
+- Phase 34 exit gate: closed
+- Phase 35 exit gate: open
 
 Local phase audits currently report:
 
@@ -236,16 +237,30 @@ Local phase audits currently report:
   - closed
 - milestone `Phase 33 - Action Readiness and Escalation Packet`
   - closed
+- Phase 34 queue sync
+  - merged via PR `#243`
+- Phase 34 execution kickoff board
+  - merged via PR `#244`
+- Phase 34 escalation decision guide
+  - merged via PR `#245`
+- Phase 34 exit issue `#239`
+  - closed
+- milestone `Phase 34 - Execution Kickoff and Escalation Decision`
+  - closed
 - GitHub remote state
   - no open pull requests remain after the Phase 33 closeout
 
 ## Current Queue
 
-- milestone `Phase 34 - Execution Kickoff and Escalation Decision` is open.
-- `#239` `Phase 34 exit gate`
+- milestone `Phase 35 - Execution Tracking and Escalation Trigger` is open.
+- `#246` `Phase 35 exit gate`
   - open
-- blocked until the Phase 34 execution-kickoff and escalation-decision slice is complete
-- The current Phase 34 execution slice is tracked through:
+- blocked until the Phase 35 execution-tracking and escalation-trigger slice is complete
+- The current Phase 35 execution slice is tracked through:
+  - `#247` `Phase 35: sync repo truth to the execution-tracking and escalation-trigger queue`
+  - `#248` `Phase 35: add execution progress tracker from kickoff board, checkpoint board, and receiver response packet`
+  - `#249` `Phase 35: add escalation trigger packet from decision guide, handoff packet, and blocker cues`
+- The completed Phase 34 slice was tracked through:
   - `#240` `Phase 34: sync bootstrap spec and docs to the active kickoff-decision queue`
   - `#241` `Phase 34: add execution kickoff board from readiness board, routing pack, and blocker posture`
   - `#242` `Phase 34: add escalation decision guide from readiness board, handoff packet, and fallback thresholds`


### PR DESCRIPTION
## Summary
- sync repo truth from Phase 34 closeout to the active Phase 35 queue
- add the Phase 35 milestone, label, and issue metadata to the bootstrap spec
- align README and current-state docs with the live GitHub queue and closeout status

## Testing
- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
- ./make.ps1 test
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim

Closes #247
