### PR TITLE
[codex] Sync repo truth to Phase 40 queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -155,6 +155,10 @@
     {
       "title": "Phase 39 - Recovery Checkpoint and Escalation Receipt",
       "description": "Turn the current execution-recovery and escalation-confirmation surfaces into a clearer recovery-checkpoint and escalation-receipt workflow without changing simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 40 - Recovery Clearance and Escalation Acknowledgment",
+      "description": "Turn the current recovery-checkpoint and escalation-receipt surfaces into a clearer recovery-clearance and escalation-acknowledgment workflow without changing simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -352,6 +356,11 @@
       "name": "phase:39",
       "color": "DDE5EA",
       "description": "Phase 39 recovery checkpoint and escalation receipt work."
+    },
+    {
+      "name": "phase:40",
+      "color": "E6EDF1",
+      "description": "Phase 40 recovery clearance and escalation acknowledgment work."
     },
     {
       "name": "area:backend",
@@ -2112,6 +2121,51 @@
         "lane:auto-safe"
       ],
       "body": "## Summary\nAdd an escalation receipt packet that turns the current confirmation surface into a clearer receipt-ready handoff.\n\n## Scope\n- combine the existing escalation confirmation context into a receipt-oriented packet for downstream acknowledgment\n- keep the packet frontend-only and derived from current artifacts\n- preserve the current in-workbench copy/export flow\n\n## Constraints\n- no backend API additions\n- no artifact schema changes\n- no simulation or report contract expansion"
+    },
+    {
+      "title": "Phase 40 exit gate",
+      "milestone": "Phase 40 - Recovery Clearance and Escalation Acknowledgment",
+      "labels": [
+        "phase:40",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "Close this issue only after the full Phase 40 queue is complete.\n\nExit criteria:\n- the Phase 40 queue-sync issue is merged\n- the execution recovery clearance board is merged\n- the escalation acknowledgment packet is merged\n- `./make.ps1 smoke` passes\n- `./make.ps1 test` passes\n- `./make.ps1 eval-demo` passes\n- `python -m backend.app.cli audit-phase phase1` passes\n- `python -m backend.app.cli audit-phase phase2` passes\n- `python -m backend.app.cli audit-phase phase3` passes\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` returns `ready` after successor bootstrap\n- only one execution milestone remains open after closeout"
+    },
+    {
+      "title": "Phase 40: sync repo truth to Phase 40 queue",
+      "milestone": "Phase 40 - Recovery Clearance and Escalation Acknowledgment",
+      "labels": [
+        "phase:40",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## Summary\nSync the repo truth to the Phase 40 queue and record the Phase 39 closeout baseline.\n\n## Scope\n- update the bootstrap spec and current-state docs to reflect Phase 40 as the active queue\n- record the Phase 39 closeout and successor bootstrap in the repo-facing documentation\n- keep Phase 40 as the sole active execution queue after closeout\n\n## Constraints\n- no simulation, report, claim, evidence, or schema contract changes\n- no new backend/runtime behavior beyond queue/governance sync"
+    },
+    {
+      "title": "Phase 40: add execution recovery clearance board",
+      "milestone": "Phase 40 - Recovery Clearance and Escalation Acknowledgment",
+      "labels": [
+        "phase:40",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## Summary\nAdd an execution recovery clearance board that turns the current checkpoint surface into a clearer clearance-ready review board.\n\n## Scope\n- summarize current recovery clearance posture, remaining blockers, and final release cues in the workbench\n- keep the board frontend-only and driven by existing artifacts\n- stay inside the current review workflow without adding new backend APIs\n\n## Constraints\n- no artifact schema changes\n- no simulation or report contract expansion"
+    },
+    {
+      "title": "Phase 40: add escalation acknowledgment packet",
+      "milestone": "Phase 40 - Recovery Clearance and Escalation Acknowledgment",
+      "labels": [
+        "phase:40",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## Summary\nAdd an escalation acknowledgment packet that turns the current receipt surface into a clearer acknowledgment-ready handoff.\n\n## Scope\n- combine the existing escalation receipt context into an acknowledgment-oriented packet for downstream follow-through\n- keep the packet frontend-only and derived from current artifacts\n- preserve the current in-workbench copy/export flow\n\n## Constraints\n- no backend API additions\n- no artifact schema changes\n- no simulation or report contract expansion"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-38 gates, and resumed the successor queue as `Phase 39 - Recovery Checkpoint and Escalation Receipt`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-39 gates, and resumed the successor queue as `Phase 40 - Recovery Clearance and Escalation Acknowledgment`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -19,7 +19,7 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-38 gates, and r
   - CI upgraded to a long-running quality gate
   - local lane-classification, phase-audit, and GitHub queue-audit commands
   - protected `main` with required status checks and auto-merge for safe-lane PRs
-  - a browser workbench that now supports claim -> evidence drill-down, trace review, reviewer scorecards, issue-comment packets, operator handoff briefs, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, and escalation confirmation packets
+  - a browser workbench that now supports claim -> evidence drill-down, trace review, reviewer scorecards, issue-comment packets, operator handoff briefs, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, and escalation receipt packets
   - a documented worktree-based pickup and handoff path for long-running queue execution
 - GitHub queue state is aligned with the local baseline:
   - Phase 3 exit issue `#4` is closed
@@ -76,8 +76,10 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-38 gates, and r
   - Phase 37 queue was completed through issues `#260-#263`
   - milestone `Phase 38 - Execution Recovery and Escalation Confirmation` is closed
   - Phase 38 queue was completed through issues `#267-#270`
-  - milestone `Phase 39 - Recovery Checkpoint and Escalation Receipt` is open
-  - Phase 39 queue is initialized through issues `#274-#277`
+  - milestone `Phase 39 - Recovery Checkpoint and Escalation Receipt` is closed
+  - Phase 39 queue was completed through issues `#274-#277`
+  - milestone `Phase 40 - Recovery Clearance and Escalation Acknowledgment` is open
+  - Phase 40 queue is initialized through issues `#281-#284`
 
 Local phase audits currently show:
 
@@ -132,7 +134,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): review workbench with Phase 38 recovery and escalation-confirmation surfaces landed while the current Phase 39 checkpoint-and-receipt queue continues to consume the same artifact surface
+- [frontend](/D:/mirror/frontend): review workbench with Phase 39 recovery-checkpoint and escalation-receipt surfaces landed while the current Phase 40 clearance-and-acknowledgment queue continues to consume the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -177,10 +179,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 38 closeout are complete. Phase 39 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 39 closeout are complete. Phase 40 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may resume pickup guidance only against the Phase 39 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation may resume pickup guidance only against the Phase 40 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, and Phase 39 is now the active recovery-checkpoint track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, and Phase 40 is now the active recovery-clearance track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -118,9 +118,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 38 is closed locally and in GitHub.
 - Phase 38 exit issue `#267` is closed and milestone `Phase 38 - Execution Recovery and Escalation Confirmation` is closed.
 - The Phase 38 queue was completed through issues `#267-#270`.
-- Phase 39 is the active successor queue.
-- milestone `Phase 39 - Recovery Checkpoint and Escalation Receipt` is open.
-- The Phase 39 queue is initialized through issues `#274-#277`.
+- Phase 39 is closed locally and in GitHub.
+- Phase 39 exit issue `#274` is closed and milestone `Phase 39 - Recovery Checkpoint and Escalation Receipt` is closed.
+- The Phase 39 queue was completed through issues `#274-#277`.
+- Phase 40 is the active successor queue.
+- milestone `Phase 40 - Recovery Clearance and Escalation Acknowledgment` is open.
+- The Phase 40 queue is initialized through issues `#281-#284`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 39 active-queue baseline.
+This note is the current Phase 40 active-queue baseline.
 
 ## Snapshot
 
@@ -160,11 +160,15 @@ This note is the current Phase 39 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/issues/267`
     - Phase 38 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/39`
-    - milestone `Phase 39 - Recovery Checkpoint and Escalation Receipt` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=39"`
-    - Phase 39 queue is initialized through issues `#274-#277`
+    - milestone `Phase 39 - Recovery Checkpoint and Escalation Receipt` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/274`
+    - Phase 39 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/40`
+    - milestone `Phase 40 - Recovery Clearance and Escalation Acknowledgment` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=40"`
+    - Phase 40 queue is initialized through issues `#281-#284`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` because Phase 39 has one blocked protected-core exit gate and multiple ready work items
+    - successor queue currently reports `ready` because Phase 40 has one blocked protected-core exit gate and multiple ready work items
 
 ## Trusted Source Of Truth
 
@@ -183,13 +187,13 @@ This note is the current Phase 39 active-queue baseline.
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
-- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, and escalation confirmation packets without introducing backend API expansion.
-- The current repository state is in an active Phase 39 successor queue, not a closed Phase 38 baseline.
+- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, and escalation receipt packets without introducing backend API expansion.
+- The current repository state is in an active Phase 40 successor queue, not a closed Phase 39 baseline.
 
 ## Next Entry Point
 
-- Phase 39 is the active milestone and the current recovery-checkpoint slice is tracked by issues `#274-#277`.
-- New implementation work should attach to the existing Phase 39 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- Phase 40 is the active milestone and the current recovery-clearance slice is tracked by issues `#281-#284`.
+- New implementation work should attach to the existing Phase 40 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
 - The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 39 queue resumption.
+This note records the current post-Day-0 execution status for Mirror after the Phase 40 queue resumption.
 
 ## Current Gate State
 
@@ -42,7 +42,8 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 36 exit gate: closed
 - Phase 37 exit gate: closed
 - Phase 38 exit gate: closed
-- Phase 39 exit gate: open
+- Phase 39 exit gate: closed
+- Phase 40 exit gate: open
 
 Local phase audits currently report:
 
@@ -291,16 +292,30 @@ Local phase audits currently report:
   - closed
 - milestone `Phase 38 - Execution Recovery and Escalation Confirmation`
   - closed
+- Phase 39 queue sync
+  - merged via PR `#278`
+- Phase 39 execution recovery checkpoint board
+  - merged via PR `#279`
+- Phase 39 escalation receipt packet
+  - merged via PR `#280`
+- Phase 39 exit issue `#274`
+  - closed
+- milestone `Phase 39 - Recovery Checkpoint and Escalation Receipt`
+  - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 38 closeout
+  - no open pull requests remain after the Phase 39 closeout
 
 ## Current Queue
 
-- milestone `Phase 39 - Recovery Checkpoint and Escalation Receipt` is open.
-- `#274` `Phase 39 exit gate`
+- milestone `Phase 40 - Recovery Clearance and Escalation Acknowledgment` is open.
+- `#281` `Phase 40 exit gate`
   - open
-- blocked until the Phase 39 recovery-checkpoint and escalation-receipt slice is complete
-- The current Phase 39 execution slice is tracked through:
+- blocked until the Phase 40 recovery-clearance and escalation-acknowledgment slice is complete
+- The current Phase 40 execution slice is tracked through:
+  - `#282` `Phase 40: sync repo truth to Phase 40 queue`
+  - `#283` `Phase 40: add execution recovery clearance board`
+  - `#284` `Phase 40: add escalation acknowledgment packet`
+- The completed Phase 39 slice was tracked through:
   - `#275` `Phase 39: sync repo truth to Phase 39 queue`
   - `#276` `Phase 39: add execution recovery checkpoint board`
   - `#277` `Phase 39: add escalation receipt packet`


### PR DESCRIPTION
## Summary
- sync repo truth from the closed Phase 39 queue to the active Phase 40 queue
- record the Phase 39 closeout in README and current execution docs
- extend bootstrap metadata so the repo bootstrap spec recognizes the Phase 40 milestone, label, and issues

## Validation
- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
- ./make.ps1 test
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim

Closes #282
