### PR TITLE
[codex] Sync repo truth to Phase 42 queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -163,6 +163,10 @@
     {
       "title": "Phase 41 - Recovery Release and Escalation Closure",
       "description": "Turn the current recovery-clearance and escalation-acknowledgment surfaces into a clearer recovery-release and escalation-closure workflow without changing simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 42 - Recovery Completion and Escalation Finalization",
+      "description": "Turn the current recovery-release and escalation-closure surfaces into a clearer recovery-completion and escalation-finalization workflow without changing simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -370,6 +374,11 @@
       "name": "phase:41",
       "color": "F1F5F8",
       "description": "Phase 41 recovery release and escalation closure work."
+    },
+    {
+      "name": "phase:42",
+      "color": "F7FAFC",
+      "description": "Phase 42 recovery completion and escalation finalization work."
     },
     {
       "name": "area:backend",
@@ -2220,6 +2229,51 @@
         "lane:auto-safe"
       ],
       "body": "## Summary\nAdd an escalation closure packet that turns the current acknowledgment surface into a clearer closure-ready handoff.\n\n## Scope\n- combine the existing escalation acknowledgment context into a closure-oriented packet for downstream completion and closeout\n- keep the packet frontend-only and derived from current artifacts\n- preserve the current in-workbench copy/export flow\n\n## Constraints\n- no backend API additions\n- no artifact schema changes\n- no simulation or report contract expansion"
+    },
+    {
+      "title": "Phase 42 exit gate",
+      "milestone": "Phase 42 - Recovery Completion and Escalation Finalization",
+      "labels": [
+        "phase:42",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "Close this issue only after the full Phase 42 queue is complete.\n\nExit criteria:\n- the Phase 42 queue-sync issue is merged\n- the execution recovery completion board is merged\n- the escalation finalization packet is merged\n- `./make.ps1 smoke` passes\n- `./make.ps1 test` passes\n- `./make.ps1 eval-demo` passes\n- `python -m backend.app.cli audit-phase phase1` passes\n- `python -m backend.app.cli audit-phase phase2` passes\n- `python -m backend.app.cli audit-phase phase3` passes\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` returns `ready` after successor bootstrap\n- only one execution milestone remains open after closeout"
+    },
+    {
+      "title": "Phase 42: sync repo truth to Phase 42 queue",
+      "milestone": "Phase 42 - Recovery Completion and Escalation Finalization",
+      "labels": [
+        "phase:42",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## Summary\nSync the repo truth to the Phase 42 queue and record the Phase 41 closeout baseline.\n\n## Scope\n- update the bootstrap spec and current-state docs to reflect Phase 42 as the active queue\n- record the Phase 41 closeout and successor bootstrap in the repo-facing documentation\n- keep Phase 42 as the sole active execution queue after closeout\n\n## Constraints\n- no simulation, report, claim, evidence, or schema contract changes\n- no new backend/runtime behavior beyond queue/governance sync"
+    },
+    {
+      "title": "Phase 42: add execution recovery completion board",
+      "milestone": "Phase 42 - Recovery Completion and Escalation Finalization",
+      "labels": [
+        "phase:42",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## Summary\nAdd an execution recovery completion board that turns the current release surface into a clearer completion-ready review board.\n\n## Scope\n- summarize current recovery completion posture, completion cues, and immediate post-completion checks in the workbench\n- keep the board frontend-only and driven by existing artifacts\n- stay inside the current review workflow without adding new backend APIs\n\n## Constraints\n- no artifact schema changes\n- no simulation or report contract expansion"
+    },
+    {
+      "title": "Phase 42: add escalation finalization packet",
+      "milestone": "Phase 42 - Recovery Completion and Escalation Finalization",
+      "labels": [
+        "phase:42",
+        "area:frontend",
+        "status:ready",
+        "lane:auto-safe"
+      ],
+      "body": "## Summary\nAdd an escalation finalization packet that turns the current closure surface into a clearer finalization-ready handoff.\n\n## Scope\n- combine the existing escalation closure context into a finalization-oriented packet for downstream completion and archive-ready follow-through\n- keep the packet frontend-only and derived from current artifacts\n- preserve the current in-workbench copy/export flow\n\n## Constraints\n- no backend API additions\n- no artifact schema changes\n- no simulation or report contract expansion"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-40 gates, and resumed the successor queue as `Phase 41 - Recovery Release and Escalation Closure`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-41 gates, and resumed the successor queue as `Phase 42 - Recovery Completion and Escalation Finalization`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -19,7 +19,7 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-40 gates, and r
   - CI upgraded to a long-running quality gate
   - local lane-classification, phase-audit, and GitHub queue-audit commands
   - protected `main` with required status checks and auto-merge for safe-lane PRs
-  - a browser workbench that now supports claim -> evidence drill-down, trace review, reviewer scorecards, issue-comment packets, operator handoff briefs, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, and escalation acknowledgment packets
+  - a browser workbench that now supports claim -> evidence drill-down, trace review, reviewer scorecards, issue-comment packets, operator handoff briefs, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, execution recovery release boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, escalation acknowledgment packets, and escalation closure packets
   - a documented worktree-based pickup and handoff path for long-running queue execution
 - GitHub queue state is aligned with the local baseline:
   - Phase 3 exit issue `#4` is closed
@@ -80,8 +80,10 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-40 gates, and r
   - Phase 39 queue was completed through issues `#274-#277`
   - milestone `Phase 40 - Recovery Clearance and Escalation Acknowledgment` is closed
   - Phase 40 queue was completed through issues `#281-#284`
-  - milestone `Phase 41 - Recovery Release and Escalation Closure` is open
-  - Phase 41 queue is initialized through issues `#288-#291`
+  - milestone `Phase 41 - Recovery Release and Escalation Closure` is closed
+  - Phase 41 queue was completed through issues `#288-#291`
+  - milestone `Phase 42 - Recovery Completion and Escalation Finalization` is open
+  - Phase 42 queue is initialized through issues `#295-#298`
 
 Local phase audits currently show:
 
@@ -136,7 +138,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): review workbench with Phase 40 recovery-clearance and escalation-acknowledgment surfaces landed while the current Phase 41 release-and-closure queue continues to consume the same artifact surface
+- [frontend](/D:/mirror/frontend): review workbench with Phase 41 recovery-release and escalation-closure surfaces landed while the current Phase 42 completion-and-finalization queue continues to consume the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -181,10 +183,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 40 closeout are complete. Phase 41 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 41 closeout are complete. Phase 42 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may resume pickup guidance only against the Phase 41 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation may resume pickup guidance only against the Phase 42 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, and Phase 41 is now the active recovery-release track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, and Phase 42 is now the active recovery-completion track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -124,9 +124,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 40 is closed locally and in GitHub.
 - Phase 40 exit issue `#281` is closed and milestone `Phase 40 - Recovery Clearance and Escalation Acknowledgment` is closed.
 - The Phase 40 queue was completed through issues `#281-#284`.
-- Phase 41 is the active successor queue.
-- milestone `Phase 41 - Recovery Release and Escalation Closure` is open.
-- The Phase 41 queue is initialized through issues `#288-#291`.
+- Phase 41 is closed locally and in GitHub.
+- Phase 41 exit issue `#288` is closed and milestone `Phase 41 - Recovery Release and Escalation Closure` is closed.
+- The Phase 41 queue was completed through issues `#288-#291`.
+- Phase 42 is the active successor queue.
+- milestone `Phase 42 - Recovery Completion and Escalation Finalization` is open.
+- The Phase 42 queue is initialized through issues `#295-#298`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 41 active-queue baseline.
+This note is the current Phase 42 active-queue baseline.
 
 ## Snapshot
 
@@ -168,11 +168,15 @@ This note is the current Phase 41 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/issues/281`
     - Phase 40 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/41`
-    - milestone `Phase 41 - Recovery Release and Escalation Closure` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=41"`
-    - Phase 41 queue is initialized through issues `#288-#291`
+    - milestone `Phase 41 - Recovery Release and Escalation Closure` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/288`
+    - Phase 41 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/42`
+    - milestone `Phase 42 - Recovery Completion and Escalation Finalization` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=42"`
+    - Phase 42 queue is initialized through issues `#295-#298`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` because Phase 41 has one blocked protected-core exit gate and multiple ready work items
+    - successor queue currently reports `ready` because Phase 42 has one blocked protected-core exit gate and multiple ready work items
 
 ## Trusted Source Of Truth
 
@@ -191,13 +195,13 @@ This note is the current Phase 41 active-queue baseline.
 
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
-- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, and escalation acknowledgment packets without introducing backend API expansion.
-- The current repository state is in an active Phase 41 successor queue, not a closed Phase 40 baseline.
+- The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, execution recovery release boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, escalation acknowledgment packets, and escalation closure packets without introducing backend API expansion.
+- The current repository state is in an active Phase 42 successor queue, not a closed Phase 41 baseline.
 
 ## Next Entry Point
 
-- Phase 41 is the active milestone and the current recovery-release slice is tracked by issues `#288-#291`.
-- New implementation work should attach to the existing Phase 41 queue until its exit gate is closed, instead of opening a parallel successor milestone.
+- Phase 42 is the active milestone and the current recovery-completion slice is tracked by issues `#295-#298`.
+- New implementation work should attach to the existing Phase 42 queue until its exit gate is closed, instead of opening a parallel successor milestone.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
 - The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 41 queue resumption.
+This note records the current post-Day-0 execution status for Mirror after the Phase 42 queue resumption.
 
 ## Current Gate State
 
@@ -44,7 +44,8 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 38 exit gate: closed
 - Phase 39 exit gate: closed
 - Phase 40 exit gate: closed
-- Phase 41 exit gate: open
+- Phase 41 exit gate: closed
+- Phase 42 exit gate: open
 
 Local phase audits currently report:
 
@@ -313,16 +314,30 @@ Local phase audits currently report:
   - closed
 - milestone `Phase 40 - Recovery Clearance and Escalation Acknowledgment`
   - closed
+- Phase 41 queue sync
+  - merged via PR `#292`
+- Phase 41 execution recovery release board
+  - merged via PR `#293`
+- Phase 41 escalation closure packet
+  - merged via PR `#294`
+- Phase 41 exit issue `#288`
+  - closed
+- milestone `Phase 41 - Recovery Release and Escalation Closure`
+  - closed
 - GitHub remote state
-  - no open pull requests remain after the Phase 40 closeout
+  - no open pull requests remain after the Phase 41 closeout
 
 ## Current Queue
 
-- milestone `Phase 41 - Recovery Release and Escalation Closure` is open.
-- `#288` `Phase 41 exit gate`
+- milestone `Phase 42 - Recovery Completion and Escalation Finalization` is open.
+- `#295` `Phase 42 exit gate`
   - open
-- blocked until the Phase 41 recovery-release and escalation-closure slice is complete
-- The current Phase 41 execution slice is tracked through:
+- blocked until the Phase 42 recovery-completion and escalation-finalization slice is complete
+- The current Phase 42 execution slice is tracked through:
+  - `#296` `Phase 42: sync repo truth to Phase 42 queue`
+  - `#297` `Phase 42: add execution recovery completion board`
+  - `#298` `Phase 42: add escalation finalization packet`
+- The completed Phase 41 slice was tracked through:
   - `#289` `Phase 41: sync repo truth to Phase 41 queue`
   - `#290` `Phase 41: add execution recovery release board`
   - `#291` `Phase 41: add escalation closure packet`


### PR DESCRIPTION
## Summary
- sync repo truth from the closed Phase 41 queue to the active Phase 42 queue
- record the Phase 41 closeout in README and current execution docs
- extend bootstrap metadata so the repo bootstrap spec recognizes the Phase 42 milestone, label, and issues

## Validation
- python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
- ./make.ps1 test
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim

Closes #296
