### PR TITLE
[codex] Bootstrap Phase 43 successor queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -167,6 +167,10 @@
     {
       "title": "Phase 42 - Recovery Completion and Escalation Finalization",
       "description": "Turn the current recovery-release and escalation-closure surfaces into a clearer recovery-completion and escalation-finalization workflow without changing simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 43 - Successor Bootstrap and Branch Exception Resolution",
+      "description": "Turn the post-Phase-42 closeout into a clear successor-bootstrap and branch-exception-resolution queue without changing simulation or artifact contracts."
     }
   ],
   "labels": [
@@ -379,6 +383,11 @@
       "name": "phase:42",
       "color": "F7FAFC",
       "description": "Phase 42 recovery completion and escalation finalization work."
+    },
+    {
+      "name": "phase:43",
+      "color": "FBFCFD",
+      "description": "Phase 43 successor bootstrap and branch exception resolution work."
     },
     {
       "name": "area:backend",
@@ -2274,6 +2283,40 @@
         "lane:auto-safe"
       ],
       "body": "## Summary\nAdd an escalation finalization packet that turns the current closure surface into a clearer finalization-ready handoff.\n\n## Scope\n- combine the existing escalation closure context into a finalization-oriented packet for downstream completion and archive-ready follow-through\n- keep the packet frontend-only and derived from current artifacts\n- preserve the current in-workbench copy/export flow\n\n## Constraints\n- no backend API additions\n- no artifact schema changes\n- no simulation or report contract expansion"
+    },
+    {
+      "title": "Phase 43 exit gate",
+      "milestone": "Phase 43 - Successor Bootstrap and Branch Exception Resolution",
+      "labels": [
+        "phase:43",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "Close this issue only after the full Phase 43 queue is complete.\n\nExit criteria:\n- the Phase 43 queue-sync issue is merged\n- the remaining codex branch TODO exception issue is merged\n- `./make.ps1 smoke` passes\n- `./make.ps1 test` passes\n- `./make.ps1 eval-demo` passes\n- `python -m backend.app.cli audit-phase phase1` passes\n- `python -m backend.app.cli audit-phase phase2` passes\n- `python -m backend.app.cli audit-phase phase3` passes\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` returns `ready`\n- only one execution milestone remains open after closeout"
+    },
+    {
+      "title": "Phase 43: sync repo truth to Phase 43 queue",
+      "milestone": "Phase 43 - Successor Bootstrap and Branch Exception Resolution",
+      "labels": [
+        "phase:43",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## Summary\nSync the repo truth to the Phase 43 queue and record the Phase 42 closeout baseline.\n\n## Scope\n- update the bootstrap spec and current-state docs to reflect Phase 43 as the active queue\n- record the Phase 42 closeout and successor bootstrap in the repo-facing documentation\n- keep Phase 43 as the sole active execution queue after closeout\n\n## Constraints\n- no simulation, report, claim, evidence, or schema contract changes\n- no new backend/runtime behavior beyond queue/governance sync"
+    },
+    {
+      "title": "Phase 43: resolve remaining codex branch TODO exceptions",
+      "milestone": "Phase 43 - Successor Bootstrap and Branch Exception Resolution",
+      "labels": [
+        "phase:43",
+        "area:docs-evals",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## Summary\nResolve the explicit remaining codex branch TODO exceptions against live GitHub state and current `main` so branch hygiene no longer depends on stale carry-forward assumptions.\n\n## Scope\n- inspect the remaining `TODO[verify]` local and remote branch exceptions documented in the branch baseline\n- decide keep, revive, or delete from live evidence instead of historical assumptions\n- update the branch-hygiene docs so the exception set matches live GitHub truth after review\n\n## Constraints\n- do not reopen historical work without a new issue that explains why `main` is insufficient\n- do not delete any branch that is still referenced by open work, unresolved forensic comparison, or active runbook guidance\n- no simulation, report, claim, evidence, scenario, or schema contract changes"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-41 gates, and resumed the successor queue as `Phase 42 - Recovery Completion and Escalation Finalization`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-42 gates, and resumed the successor queue as `Phase 43 - Successor Bootstrap and Branch Exception Resolution`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -82,8 +82,10 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-41 gates, and r
   - Phase 40 queue was completed through issues `#281-#284`
   - milestone `Phase 41 - Recovery Release and Escalation Closure` is closed
   - Phase 41 queue was completed through issues `#288-#291`
-  - milestone `Phase 42 - Recovery Completion and Escalation Finalization` is open
-  - Phase 42 queue is initialized through issues `#295-#298`
+  - milestone `Phase 42 - Recovery Completion and Escalation Finalization` is closed
+  - Phase 42 queue was completed through issues `#295-#298` plus branch-hygiene governance issues `#302-#303`
+  - milestone `Phase 43 - Successor Bootstrap and Branch Exception Resolution` is open
+  - Phase 43 queue is initialized through issues `#306-#308`
 
 Local phase audits currently show:
 
@@ -138,7 +140,7 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): review workbench with Phase 41 recovery-release and escalation-closure surfaces landed while the current Phase 42 completion-and-finalization queue continues to consume the same artifact surface
+- [frontend](/D:/mirror/frontend): review workbench with the Phase 42 recovery-completion and escalation-finalization surfaces landed while the current Phase 43 successor-bootstrap queue continues to consume the same artifact surface
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -183,10 +185,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 41 closeout are complete. Phase 42 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 42 closeout are complete. Phase 43 is now the active successor queue and should remain the only open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may resume pickup guidance only against the Phase 42 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation may resume pickup guidance only against the Phase 43 queue and must stop again if `audit-github-queue` leaves `ready`.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, and Phase 42 is now the active recovery-completion track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, and Phase 43 is now the active successor-bootstrap and branch-exception-resolution track.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -127,9 +127,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 41 is closed locally and in GitHub.
 - Phase 41 exit issue `#288` is closed and milestone `Phase 41 - Recovery Release and Escalation Closure` is closed.
 - The Phase 41 queue was completed through issues `#288-#291`.
-- Phase 42 is the active successor queue.
-- milestone `Phase 42 - Recovery Completion and Escalation Finalization` is open.
-- The Phase 42 queue is initialized through issues `#295-#298`.
+- Phase 42 is closed locally and in GitHub.
+- Phase 42 exit issue `#295` is closed and milestone `Phase 42 - Recovery Completion and Escalation Finalization` is closed.
+- The Phase 42 queue was completed through issues `#295-#298` plus branch-hygiene governance issues `#302-#303`.
+- Phase 43 is the active successor queue.
+- milestone `Phase 43 - Successor Bootstrap and Branch Exception Resolution` is open.
+- The Phase 43 queue is initialized through issues `#306-#308`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
 - The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 42 active-queue baseline.
+This note is the current Phase 43 active-queue baseline.
 
 ## Snapshot
 
@@ -172,11 +172,15 @@ This note is the current Phase 42 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/issues/288`
     - Phase 41 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/42`
-    - milestone `Phase 42 - Recovery Completion and Escalation Finalization` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=42"`
-    - Phase 42 now remains open through exit-gate closeout `#295` and branch-hygiene apply issue `#303`; product issues `#296-#298` are no longer open and classification issue `#302` is merged
+    - milestone `Phase 42 - Recovery Completion and Escalation Finalization` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/295`
+    - Phase 42 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/43`
+    - milestone `Phase 43 - Successor Bootstrap and Branch Exception Resolution` is `open`
+  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=43"`
+    - Phase 43 now remains open through exit gate `#306` plus successor-bootstrap follow-through issues `#307-#308`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue currently reports `ready` because Phase 42 still has one blocked protected-core exit gate and at least one ready work item, with branch hygiene now occupying the open implementation slot
+    - successor queue now reports `ready` because Phase 43 has exactly one blocked protected-core exit gate and ready work items available for pickup
 
 ## Trusted Source Of Truth
 
@@ -185,7 +189,7 @@ This note is the current Phase 42 active-queue baseline.
 - `audit-github-queue` is the executable local rule for whether builder automation should remain `paused` or can resume against the successor queue.
 - `backlog/sprint-01.md` is historical seed material only and should not be used as the live queue.
 - Historical remote `origin/codex/*` branches have now been reduced to a single explicit exception and should not be treated as a standing backlog.
-- The current reviewed branch-hygiene baseline lives in `docs/plans/codex-branch-classification-baseline.md` and now reflects both the Phase 42 classification and reviewed apply result.
+- The current reviewed branch-hygiene baseline lives in `docs/plans/codex-branch-classification-baseline.md` and reflects the merged Phase 42 classification/apply result; remaining exception handling now continues under `#308`.
 - The current remote-tracking inventory retains only `origin/codex/phase23-session-summary` as the explicit `TODO[verify]` remote exception.
 - Delete a historical remote branch once it is tied only to merged or closed work and no open issue, PR, or runbook step still references it.
 - Keep a historical remote branch only when an open issue or unresolved forensic comparison explicitly names it.
@@ -196,12 +200,12 @@ This note is the current Phase 42 active-queue baseline.
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
 - The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, execution recovery release boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, escalation acknowledgment packets, and escalation closure packets without introducing backend API expansion.
-- The current repository state is in an active Phase 42 successor queue, not a closed Phase 41 baseline.
+- The current repository state is in an active Phase 43 successor queue, not a closed Phase 42 baseline.
 
 ## Next Entry Point
 
-- Phase 42 is the active milestone and the current closeout slice is tracked by exit-gate issue `#295` plus the branch-hygiene apply issue `#303`.
-- New implementation work should not open a parallel successor milestone before the remaining `TODO[verify]` exception handling and Phase 42 closeout are resolved.
+- Phase 43 is the active milestone and the current implementation slice is tracked by exit-gate issue `#306` plus protected-core follow-through issues `#307-#308`.
+- New implementation work should consume the current Phase 43 queue and should not open another successor milestone while `#306-#308` remain unresolved.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
-- The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the paused/ready state of the live queue.
+- The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the ready/paused state of the live Phase 43 queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 42 queue resumption.
+This note records the current post-Day-0 execution status for Mirror after the Phase 43 successor bootstrap.
 
 ## Current Gate State
 
@@ -45,7 +45,8 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 39 exit gate: closed
 - Phase 40 exit gate: closed
 - Phase 41 exit gate: closed
-- Phase 42 exit gate: open
+- Phase 42 exit gate: closed
+- Phase 43 exit gate: open
 
 Local phase audits currently report:
 
@@ -329,14 +330,19 @@ Local phase audits currently report:
 
 ## Current Queue
 
-- milestone `Phase 42 - Recovery Completion and Escalation Finalization` is open.
-- `#295` `Phase 42 exit gate`
+- milestone `Phase 43 - Successor Bootstrap and Branch Exception Resolution` is open.
+- `#306` `Phase 43 exit gate`
   - open
-- blocked until the Phase 42 recovery-completion and escalation-finalization slice is complete
-- The current Phase 42 execution slice is tracked through:
+- blocked until the Phase 43 successor-bootstrap and branch-exception-resolution slice is complete
+- The current Phase 43 execution slice is tracked through:
+  - `#307` `Phase 43: sync repo truth to Phase 43 queue`
+  - `#308` `Phase 43: resolve remaining codex branch TODO exceptions`
+- The completed Phase 42 slice was tracked through:
+  - `#295` `Phase 42 exit gate`
   - `#296` `Phase 42: sync repo truth to Phase 42 queue`
   - `#297` `Phase 42: add execution recovery completion board`
   - `#298` `Phase 42: add escalation finalization packet`
+  - branch-hygiene governance issues `#302-#303`
 - The completed Phase 41 slice was tracked through:
   - `#289` `Phase 41: sync repo truth to Phase 41 queue`
   - `#290` `Phase 41: add execution recovery release board`
@@ -505,7 +511,7 @@ Local phase audits currently report:
 ## Historical Branch Status
 
 - Historical remote `origin/codex/*` branches have now been reduced to the explicit `TODO[verify]` exception set.
-- The current reviewed baseline is recorded in `docs/plans/codex-branch-classification-baseline.md`; `#302` is merged and `#303` now carries the remaining apply/closeout work.
+- The current reviewed baseline is recorded in `docs/plans/codex-branch-classification-baseline.md`; `#302` and `#303` are merged, and remaining exception handling now continues through `#308`.
 - Current remote-tracking inventory retains only `origin/codex/phase23-session-summary` as the explicit `TODO[verify]` exception.
 - Treat any future recreated or still-live `codex/*` remote branch as temporary execution state, not as a standing backlog.
 - Delete a historical branch when it is tied only to closed or merged work and no open issue, PR, or runbook step references it.


### PR DESCRIPTION
## Summary
- add Phase 43 milestone, label, and successor bootstrap issues to `.github/automation/bootstrap-spec.json`
- bootstrap the live GitHub queue so Phase 43 exists as the sole open milestone through `#306-#308`
- sync `README.md` and the active queue docs to the post-closeout Phase 43 truth surface

## Why
Phase 42 branch-hygiene closeout left the queue without any ready work items. We needed to open the successor queue, retire the closed Phase 42 milestone, and restore a single ready execution path before the long-running loop could continue cleanly.

## Impact
- `#295` is now closed after successor bootstrap and queue audit verification
- `#307` is the current repo-truth sync issue for the active Phase 43 queue
- `#308` now carries the remaining codex branch TODO exception follow-through
- `audit-github-queue` returns `ready` against Phase 43 with one blocked exit gate and ready work items

## Validation
- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`
- `python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`
- `./make.ps1 test`
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`

Closes #307.
