### PR TITLE
[codex] Resolve remaining codex branch exceptions

### DIFF
--- a/docs/plans/codex-branch-classification-baseline.md
+++ b/docs/plans/codex-branch-classification-baseline.md
@@ -1,12 +1,12 @@
 # Codex Branch Classification Baseline
 
-This note records the Phase 42 protected-core classification baseline and the reviewed apply result for historical `codex/*` branches.
+This note records the merged Phase 42 branch-hygiene baseline and the Phase 43 `#308` closeout result for the remaining historical `codex/*` exceptions.
 
 ## Purpose
 
-- Use the current branch inventory and active milestone state to drive branch hygiene decisions.
+- Use the live branch inventory, issue state, and merged PR history to drive branch hygiene decisions.
 - Treat `main` / `origin/main` as the only long-lived coordination line.
-- Separate classification in `#302` from destructive cleanup in `#303`.
+- Keep old execution branches only when an open issue, PR, or explicit forensic need still depends on them.
 - Do not treat old docs snapshots or `git branch --merged origin/main` as sufficient deletion evidence on their own.
 
 ## Decision Rules
@@ -24,96 +24,58 @@ This note records the Phase 42 protected-core classification baseline and the re
 
 ## Evidence Notes
 
-- Current local inventory on `codex/phase42-branch-cleanup-apply` after the reviewed delete set:
-  - local `codex/*` branches: `4`
-  - remote `origin/codex/*` branches in the current remote-tracking snapshot: `1`
+- Current local inventory on `codex/phase43-branch-exceptions` before applying the final delete set:
+  - local `codex/*` branches: `5`
+  - local remote-tracking `origin/codex/*` refs: `3`
   - local branches with gone upstreams: `2`
-  - local branches equal to upstream: `0`
   - local branches diverged from upstream: `1`
   - local branches with no upstream: `1`
-  - local `codex/*` branches that track `origin/main`: `0`
 - The current authenticated REST pull snapshot shows no open pull requests.
-- The current authenticated REST issue snapshot shows only two open issues:
-  - `#295` `Phase 42 exit gate`
-  - `#303` `Phase 42: apply reviewed codex branch cleanup and sync branch-hygiene docs`
-- Phases 30-41 are already recorded as closed in [current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md:1).
-- Phase 42 product issues `#296-#298` are no longer open, `#302` has merged through PR `#304`, and the remaining open Phase 42 work is exit-gate closeout plus reviewed branch-hygiene apply.
-- The reviewed remote delete set has already been applied; the only remaining historical remote exception is `origin/codex/phase23-session-summary`.
+- The current authenticated REST issue snapshot shows only two open Phase 43 issues:
+  - `#306` `Phase 43 exit gate`
+  - `#308` `Phase 43: resolve remaining codex branch TODO exceptions`
+- Authenticated REST branch lookup shows only one live historical remote branch:
+  - `origin/codex/phase23-session-summary`
+- Authenticated REST lookup returns `404` for:
+  - `origin/codex/phase42-branch-cleanup-apply`
+  - `origin/codex/phase43-queue-bootstrap`
+- Patch-id evidence closes the two frontend exceptions:
+  - local `4d4c150` and main commit `9bc3b73` share patch-id `458686e21e0d387d2a885d04e34e07a0ecff1654`
+  - local `cef67d1`, remote `7e00df6`, and main commit `56335a5` share patch-id `a322431a5cd51cbb0a1242c526aec25d410ff5a5`
+- `7e00df6` is tied to merged PR `#163` (`[codex] Add preset session summary strip`).
+- `e33989a` has no associated PR and only touched queue-truth docs that have since been superseded repeatedly on `main`.
 - The repo uses squash merges heavily, so ancestry alone is not enough to prove whether an old execution branch has already been absorbed by `main`.
 
 ## Apply Result
 
-- Remote historical `origin/codex/*` branches have been reduced to a single explicit `TODO[verify]` exception:
-  - `origin/codex/phase23-session-summary`
-- Local `codex/*` branches now retain only:
-  - `codex/phase42-branch-cleanup-apply`
-  - `codex/phase1-queue-sync`
-  - `codex/phase22-apply-copy`
-  - `codex/phase23-session-summary`
-- `#302` is complete and closed through PR `#304`.
-- `#303` is now the active apply/closeout issue for any remaining doc sync and exception handling.
+- No live historical `origin/codex/*` exception remains after deleting `origin/codex/phase23-session-summary`.
+- Stale local remote-tracking refs for `origin/codex/phase42-branch-cleanup-apply` and `origin/codex/phase43-queue-bootstrap` should be pruned locally because they no longer exist on GitHub.
+- Local historical residue is reduced to the current active writer branch only:
+  - `codex/phase43-branch-exceptions`
+- `#302`, `#303`, and `#307` are already closed.
+- `#308` is the Phase 43 closeout vehicle for applying the final exception deletes and syncing the docs to the resolved branch inventory.
 
 ## Remote Branch Classification
 
 ### `delete-remote-and-local`
 
-These remote branches were reviewed in `#302` and have now been deleted in `#303`.
-
-- `origin/codex/phase30-checkpoint-board`
-- `origin/codex/phase30-queue-sync`
-- `origin/codex/phase30-response-packet`
-- `origin/codex/phase31-outcome-tracker`
-- `origin/codex/phase31-queue-sync`
-- `origin/codex/phase31-resolution-handoff`
-- `origin/codex/phase32-next-step-routing`
-- `origin/codex/phase32-queue-sync`
-- `origin/codex/phase32-status-board`
-- `origin/codex/phase33-action-readiness`
-- `origin/codex/phase33-escalation-packet`
-- `origin/codex/phase33-queue-sync`
-- `origin/codex/phase34-escalation-decision`
-- `origin/codex/phase34-execution-kickoff`
-- `origin/codex/phase34-queue-sync`
-- `origin/codex/phase35-escalation-trigger`
-- `origin/codex/phase35-execution-progress`
-- `origin/codex/phase35-queue-sync`
-- `origin/codex/phase36-escalation-dispatch`
-- `origin/codex/phase36-execution-outcome`
-- `origin/codex/phase36-queue-sync`
-- `origin/codex/phase37-escalation-delivery`
-- `origin/codex/phase37-execution-correction`
-- `origin/codex/phase37-queue-sync`
-- `origin/codex/phase38-escalation-confirmation`
-- `origin/codex/phase38-execution-recovery`
-- `origin/codex/phase39-escalation-receipt`
-- `origin/codex/phase39-recovery-checkpoint`
-- `origin/codex/phase40-escalation-acknowledgment`
-- `origin/codex/phase40-recovery-clearance`
-- `origin/codex/phase41-escalation-closure`
-- `origin/codex/phase41-recovery-release`
-- `origin/codex/phase42-escalation-finalization`
-- `origin/codex/phase42-recovery-completion`
-
-Evidence:
-
-- No open PR head was holding these refs alive in the current authenticated REST pull snapshot.
-- The phases that created these branches were already closed or their feature issues were no longer open.
-- The delete set has now been applied.
-
-### `TODO[verify]`
-
 - `origin/codex/phase23-session-summary`
 
 Evidence:
 
-- The older baseline already flagged this branch as non-ancestor and risky to clean blindly.
-- The local twin still diverges from the remote-tracking ref, so it remains the one remote exception that still needs explicit forensic review before deletion.
+- The live remote branch still points to `7e00df6`, which is the PR head for merged PR `#163`.
+- The local diverged twin `cef67d1` has the same patch-id as both the remote head `7e00df6` and merged main commit `56335a5`.
+- No open issue, PR, or runbook step still depends on this branch.
 
 ### `keep`
 
 - none
 
 ### `revive`
+
+- none
+
+### `TODO[verify]`
 
 - none
 
@@ -121,85 +83,93 @@ Evidence:
 
 ### `keep`
 
-- `codex/phase42-branch-cleanup-apply`
+- `codex/phase43-branch-exceptions`
 
 Evidence:
 
-- This is the current dedicated writer branch for `#303`.
-- It is the only active local execution branch still needed for the apply/closeout slice.
+- This is the current dedicated writer branch for `#308`.
+- It is the only local execution branch still needed for active Phase 43 work.
 
 ### `delete-remote-and-local`
 
-- applied
-
-Evidence:
-
-- The same-name historical execution branches in this set were deleted locally after the reviewed remote delete set was applied.
-
-### `delete-local-now`
-
-- applied
-
-Evidence:
-
-- The reviewed local-only and upstream-gone residues in this set have now been deleted.
-
-### `TODO[verify]`
-
-- `codex/phase1-queue-sync`
-- `codex/phase22-apply-copy`
 - `codex/phase23-session-summary`
 
 Evidence:
 
-- `codex/phase1-queue-sync` still carries a unique closed-but-unmerged historical commit.
-- `codex/phase22-apply-copy` still carries a unique local head even though the current repo already contains apply-and-copy behavior.
-- `codex/phase23-session-summary` remains the one explicit local/remote divergence pair and should not be deleted without a dedicated replay check.
+- Its unique local head `cef67d1` is patch-equivalent to the merged main change and the remaining remote head.
+- The same-name remote branch is a merged historical residue with no open dependency.
+
+### `delete-local-now`
+
+- `codex/phase1-queue-sync`
+- `codex/phase22-apply-copy`
+- `codex/phase43-queue-bootstrap`
+
+Evidence:
+
+- `codex/phase1-queue-sync` has no upstream, no associated PR, and only carries an outdated queue-doc snapshot that has been superseded many times on `main`.
+- `codex/phase22-apply-copy` has no upstream, and its unique local commit `4d4c150` is patch-equivalent to main commit `9bc3b73`; main history already records the feature through merge PR `#156`.
+- `codex/phase43-queue-bootstrap` merged through PR `#309`; its upstream branch has already been removed and the local branch is now only merged residue.
 
 ### `revive`
 
 - none
 
-## Reviewed Apply Set For #303
+### `TODO[verify]`
 
-- Applied remote plus same-name local historical execution delete set
-- Applied local-only historical residue delete set
-- Preserved explicit exceptions for dedicated follow-up:
+- none
+
+## Reviewed Apply Set For #308
+
+- Delete the final live historical remote exception:
   - `origin/codex/phase23-session-summary`
+- Delete the corresponding local same-name residue:
+  - `codex/phase23-session-summary`
+- Delete local-only or upstream-gone historical residue:
   - `codex/phase1-queue-sync`
   - `codex/phase22-apply-copy`
-  - `codex/phase23-session-summary`
-- Preserved the current active writer branch:
-  - `codex/phase42-branch-cleanup-apply`
+  - `codex/phase43-queue-bootstrap`
+- Prune stale local remote-tracking refs:
+  - `origin/codex/phase42-branch-cleanup-apply`
+  - `origin/codex/phase43-queue-bootstrap`
+- Preserve the current active writer branch:
+  - `codex/phase43-branch-exceptions`
 
 ## Commands Used
 
 ```powershell
 git status -sb
 git branch -vv
-git branch -r --list origin/codex/*
-git branch -r --merged origin/main --list origin/codex/*
-git branch -r --no-merged origin/main --list origin/codex/*
 git for-each-ref --format="%(refname:short)|%(upstream:short)|%(upstream:trackshort)|%(objectname:short)|%(subject)" refs/heads
-git log --oneline origin/main..codex/phase1-queue-sync
-git log --oneline origin/main..codex/phase22-apply-copy
-git log --oneline origin/main..codex/phase23-session-summary
-git log --oneline origin/main..codex/phase28-branch-cleanup
-git log --oneline origin/main..codex/phase28-delivery-script
-git log --oneline origin/main..codex/phase28-delivery-script-clean
-git log --oneline origin/main..codex/phase28-send-checklist
-git log --oneline origin/main..codex/phase29-queue-sync
-git show --stat --oneline --summary c62f86d
-git show --stat --oneline --summary 66ed805
-rg -n "destination-specific delivery script|final send checklist|apply reviewed codex branch cleanup|preset apply-and-copy actions|session summary strip" README.md docs frontend backend .github
-gh auth status
+git branch -r --list origin/codex/*
+git log --oneline main..codex/phase1-queue-sync
+git log --oneline main..codex/phase22-apply-copy
+git log --oneline main..codex/phase23-session-summary
+git log --oneline codex/phase23-session-summary..main
+git log --oneline origin/codex/phase23-session-summary..codex/phase23-session-summary
+git log --oneline codex/phase23-session-summary..origin/codex/phase23-session-summary
+git show --stat --oneline --summary e33989a
+git show --stat --oneline --summary 4d4c150
+git show --stat --oneline --summary cef67d1
+git show --stat --oneline --summary 7e00df6
+git show 4d4c150 --format= --patch | git patch-id --stable
+git show 9bc3b73 --format= --patch | git patch-id --stable
+git show cef67d1 --format= --patch | git patch-id --stable
+git show 7e00df6 --format= --patch | git patch-id --stable
+git show 56335a5 --format= --patch | git patch-id --stable
+git log --oneline --grep="apply-and-copy" main
+git log --oneline --grep="session summary strip" main
 gh api "repos/YSCJRH/mirror-sim/pulls?state=open&per_page=100"
 gh api "repos/YSCJRH/mirror-sim/issues?state=open&per_page=100"
-git push origin --delete codex/phase33-action-readiness codex/phase33-escalation-packet codex/phase34-escalation-decision codex/phase34-execution-kickoff codex/phase35-escalation-trigger codex/phase35-execution-progress codex/phase36-escalation-dispatch codex/phase36-execution-outcome codex/phase37-escalation-delivery codex/phase37-execution-correction codex/phase38-escalation-confirmation codex/phase38-execution-recovery codex/phase39-escalation-receipt codex/phase39-recovery-checkpoint codex/phase40-escalation-acknowledgment codex/phase40-recovery-clearance codex/phase41-escalation-closure codex/phase41-recovery-release codex/phase42-escalation-finalization codex/phase42-recovery-completion
-git branch -D codex/phase28-branch-cleanup codex/phase28-delivery-script codex/phase28-delivery-script-clean codex/phase28-send-checklist codex/phase29-queue-sync codex/phase33-action-readiness codex/phase33-escalation-packet codex/phase34-escalation-decision codex/phase34-execution-kickoff codex/phase35-escalation-trigger codex/phase35-execution-progress codex/phase36-escalation-dispatch codex/phase36-execution-outcome codex/phase37-escalation-delivery codex/phase37-execution-correction codex/phase38-escalation-confirmation codex/phase38-execution-recovery codex/phase39-escalation-receipt codex/phase39-queue-sync codex/phase39-recovery-checkpoint codex/phase40-escalation-acknowledgment codex/phase40-queue-sync codex/phase40-recovery-clearance codex/phase41-escalation-closure codex/phase41-queue-sync codex/phase41-recovery-release codex/phase42-escalation-finalization codex/phase42-queue-sync codex/phase42-recovery-completion
-git branch -r -d origin/codex/phase42-branch-classification
+gh api repos/YSCJRH/mirror-sim/branches/codex/phase23-session-summary
+gh api repos/YSCJRH/mirror-sim/branches/codex/phase42-branch-cleanup-apply
+gh api repos/YSCJRH/mirror-sim/branches/codex/phase43-queue-bootstrap
+gh api -H "Accept: application/vnd.github+json" repos/YSCJRH/mirror-sim/commits/e33989a/pulls
+gh api -H "Accept: application/vnd.github+json" repos/YSCJRH/mirror-sim/commits/4d4c150/pulls
+gh api -H "Accept: application/vnd.github+json" repos/YSCJRH/mirror-sim/commits/7e00df6/pulls
+gh api -H "Accept: application/vnd.github+json" repos/YSCJRH/mirror-sim/commits/cef67d1/pulls
 ```
 
 ## TODO[verify]
 
-- Re-run authenticated REST pull and issue audits immediately before closing `#303`, in case a new PR or issue dependency appears while the apply branch is still open.
+- none

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -178,7 +178,7 @@ This note is the current Phase 43 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/milestones/43`
     - milestone `Phase 43 - Successor Bootstrap and Branch Exception Resolution` is `open`
   - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=43"`
-    - Phase 43 now remains open through exit gate `#306` plus successor-bootstrap follow-through issues `#307-#308`
+    - Phase 43 now remains open through exit gate `#306` plus branch-exception closeout issue `#308`
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
     - successor queue now reports `ready` because Phase 43 has exactly one blocked protected-core exit gate and ready work items available for pickup
 
@@ -188,9 +188,9 @@ This note is the current Phase 43 active-queue baseline.
 - Local phase audits remain the contract-aligned source of truth for whether the current repo state is runnable and reviewable.
 - `audit-github-queue` is the executable local rule for whether builder automation should remain `paused` or can resume against the successor queue.
 - `backlog/sprint-01.md` is historical seed material only and should not be used as the live queue.
-- Historical remote `origin/codex/*` branches have now been reduced to a single explicit exception and should not be treated as a standing backlog.
-- The current reviewed branch-hygiene baseline lives in `docs/plans/codex-branch-classification-baseline.md` and reflects the merged Phase 42 classification/apply result; remaining exception handling now continues under `#308`.
-- The current remote-tracking inventory retains only `origin/codex/phase23-session-summary` as the explicit `TODO[verify]` remote exception.
+- Historical remote `origin/codex/*` branches have now been reduced to zero live legacy exceptions and should not be treated as a standing backlog.
+- The current reviewed branch-hygiene baseline lives in `docs/plans/codex-branch-classification-baseline.md` and now records the evidence needed to close the final exception set through `#308`.
+- Any remaining local `origin/codex/*` tracking ref after `#308` should be treated as stale fetch residue and pruned against live GitHub truth.
 - Delete a historical remote branch once it is tied only to merged or closed work and no open issue, PR, or runbook step still references it.
 - Keep a historical remote branch only when an open issue or unresolved forensic comparison explicitly names it.
 - Revive a historical remote branch only by opening a new issue that states why `main` is insufficient.
@@ -204,8 +204,8 @@ This note is the current Phase 43 active-queue baseline.
 
 ## Next Entry Point
 
-- Phase 43 is the active milestone and the current implementation slice is tracked by exit-gate issue `#306` plus protected-core follow-through issues `#307-#308`.
-- New implementation work should consume the current Phase 43 queue and should not open another successor milestone while `#306-#308` remain unresolved.
+- Phase 43 is the active milestone and the current implementation slice is tracked by exit-gate issue `#306` plus protected-core follow-through issue `#308`.
+- New implementation work should consume the current Phase 43 queue and should not open another successor milestone while `#306` and `#308` remain unresolved.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
 - The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the ready/paused state of the live Phase 43 queue.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -335,8 +335,10 @@ Local phase audits currently report:
   - open
 - blocked until the Phase 43 successor-bootstrap and branch-exception-resolution slice is complete
 - The current Phase 43 execution slice is tracked through:
-  - `#307` `Phase 43: sync repo truth to Phase 43 queue`
   - `#308` `Phase 43: resolve remaining codex branch TODO exceptions`
+- The completed Phase 43 queue-sync slice was tracked through:
+  - `#307` `Phase 43: sync repo truth to Phase 43 queue`
+  - merged via PR `#309`
 - The completed Phase 42 slice was tracked through:
   - `#295` `Phase 42 exit gate`
   - `#296` `Phase 42: sync repo truth to Phase 42 queue`
@@ -510,9 +512,9 @@ Local phase audits currently report:
 
 ## Historical Branch Status
 
-- Historical remote `origin/codex/*` branches have now been reduced to the explicit `TODO[verify]` exception set.
-- The current reviewed baseline is recorded in `docs/plans/codex-branch-classification-baseline.md`; `#302` and `#303` are merged, and remaining exception handling now continues through `#308`.
-- Current remote-tracking inventory retains only `origin/codex/phase23-session-summary` as the explicit `TODO[verify]` exception.
+- Historical remote `origin/codex/*` branches no longer retain any live legacy exception branch.
+- The current reviewed baseline is recorded in `docs/plans/codex-branch-classification-baseline.md`; `#302` and `#303` are merged, and `#308` now carries the final exception closeout.
+- Current local `origin/codex/*` tracking refs should be empty after pruning stale fetch residue and deleting the final historical remote exception.
 - Treat any future recreated or still-live `codex/*` remote branch as temporary execution state, not as a standing backlog.
 - Delete a historical branch when it is tied only to closed or merged work and no open issue, PR, or runbook step references it.
 - Keep a historical branch only when an open issue or unresolved forensic comparison explicitly depends on it.


### PR DESCRIPTION
## Summary
- resolve the last historical `codex/*` branch exceptions that were left as `TODO[verify]`
- update the branch-hygiene baseline and active-state docs to reflect the verified end state
- remove the final live historical remote branch and clean the corresponding local residue

## What changed
- classified `codex/phase1-queue-sync` as delete-local-now because it is an unmerged local docs snapshot with no PR dependency and long-superseded queue truth
- classified `codex/phase22-apply-copy` as delete-local-now because its local patch is identical to the already-landed mainline change
- classified local and remote `codex/phase23-session-summary` as delete-remote-and-local because both heads are patch-equivalent to the merged Phase 23 mainline change
- pruned stale local tracking refs for already-removed execution branches
- synced branch-hygiene docs so they no longer claim any live historical remote exception remains

## Evidence
- `4d4c150` and main commit `9bc3b73` share the same stable patch-id
- `cef67d1`, remote `7e00df6`, and main commit `56335a5` share the same stable patch-id
- `7e00df6` is tied to merged PR `#163`
- REST branch lookup returns `404` for `codex/phase42-branch-cleanup-apply` and `codex/phase43-queue-bootstrap`, proving those were only stale local tracking refs
- `git branch -r --list origin/codex/*` is now empty after deleting the final live remote historical branch

## Validation
- `python -m backend.app.cli classify-lane --files docs/plans/codex-branch-classification-baseline.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`
- `./make.ps1 test`
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`

Closes #308.
