### PR TITLE
[codex] Formalize Phase 43 release closeout

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -2293,7 +2293,7 @@
         "status:blocked",
         "lane:protected-core"
       ],
-      "body": "Close this issue only after the full Phase 43 queue is complete.\n\nExit criteria:\n- the Phase 43 queue-sync issue is merged\n- the remaining codex branch TODO exception issue is merged\n- `./make.ps1 smoke` passes\n- `./make.ps1 test` passes\n- `./make.ps1 eval-demo` passes\n- `python -m backend.app.cli audit-phase phase1` passes\n- `python -m backend.app.cli audit-phase phase2` passes\n- `python -m backend.app.cli audit-phase phase3` passes\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` returns `ready`\n- only one execution milestone remains open after closeout"
+      "body": "Close this issue only after the full Phase 43 formal-release closeout is complete.\n\nExit criteria:\n- the Phase 43 queue-sync issue is merged\n- the remaining codex branch TODO exception issue is merged\n- `./make.ps1 smoke` passes\n- `./make.ps1 test` passes\n- `./make.ps1 eval-demo` passes\n- `python -m backend.app.cli audit-phase phase1` passes\n- `python -m backend.app.cli audit-phase phase2` passes\n- `python -m backend.app.cli audit-phase phase3` passes\n- no live historical `origin/codex/*` execution branches remain\n- the Phase 43 milestone is closed without opening an approved successor phase\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` returns `paused` with no active milestone"
     },
     {
       "title": "Phase 43: sync repo truth to Phase 43 queue",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mirror Engine is a constrained, evidence-backed conditional simulation sandbox f
 
 ## Current Status
 
-The repository has completed Day 0 bootstrap, closed the Phase 1-42 gates, and resumed the successor queue as `Phase 43 - Successor Bootstrap and Branch Exception Resolution`.
+The repository has completed Day 0 bootstrap, closed the Phase 1-43 gates, and is now in the formal release stop-state as `v0.1.0`.
 
 - Governance documents and Codex execution rules are in place.
 - The canonical demo world is `Fog Harbor East Gate`.
@@ -84,8 +84,10 @@ The repository has completed Day 0 bootstrap, closed the Phase 1-42 gates, and r
   - Phase 41 queue was completed through issues `#288-#291`
   - milestone `Phase 42 - Recovery Completion and Escalation Finalization` is closed
   - Phase 42 queue was completed through issues `#295-#298` plus branch-hygiene governance issues `#302-#303`
-  - milestone `Phase 43 - Successor Bootstrap and Branch Exception Resolution` is open
-  - Phase 43 queue is initialized through issues `#306-#308`
+  - milestone `Phase 43 - Successor Bootstrap and Branch Exception Resolution` is closed
+  - Phase 43 queue was completed through issues `#306-#308`
+  - no open execution milestone remains after formal closeout
+  - GitHub tag and release `v0.1.0` mark the first formal repository release
 
 Local phase audits currently show:
 
@@ -140,7 +142,8 @@ python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 - [data/demo](/D:/mirror/data/demo): demo world, scenarios, expectations
 - [backend](/D:/mirror/backend): FastAPI app, CLI, automation helpers, domain models, pipeline
 - [evals/assertions](/D:/mirror/evals/assertions): automated assertions and redlines
-- [frontend](/D:/mirror/frontend): review workbench with the Phase 42 recovery-completion and escalation-finalization surfaces landed while the current Phase 43 successor-bootstrap queue continues to consume the same artifact surface
+- [frontend](/D:/mirror/frontend): review workbench with the Phase 42 recovery-completion and Phase 43 release-closeout surfaces landed in the formal `v0.1.0` baseline
+- [docs/releases/v0.1.0.md](/D:/mirror/docs/releases/v0.1.0.md): canonical notes for the first formal GitHub Release
 - [.github/automation/bootstrap-spec.json](/D:/mirror/.github/automation/bootstrap-spec.json): GitHub bootstrap source of truth
 - [.github/automation/lane-policy.json](/D:/mirror/.github/automation/lane-policy.json): safe-lane vs protected-core policy
 
@@ -185,10 +188,10 @@ Repository-side automation assets:
 
 Important constraint:
 
-- Day 0 bootstrap and Phase 42 closeout are complete. Phase 43 is now the active successor queue and should remain the only open execution milestone.
+- Day 0 bootstrap and Phase 43 closeout are complete. The repo now sits in the formal `v0.1.0` release stop-state with no open execution milestone.
 - The current handoff baseline is tracked in [docs/plans/current-state-baseline.md](/D:/mirror/docs/plans/current-state-baseline.md).
 - Long-running pickup, worktree usage, and branch hygiene are documented in [docs/plans/long-running-loop-runbook.md](/D:/mirror/docs/plans/long-running-loop-runbook.md).
-- The local heartbeat automation may resume pickup guidance only against the Phase 43 queue and must stop again if `audit-github-queue` leaves `ready`.
+- The local heartbeat automation should remain paused in the `v0.1.0` release stop-state and must not resume pickup until an approved successor milestone is opened.
 - Protected-core changes still must not auto-merge just because checks are green.
 
 ## Non-goals

--- a/backend/app/automation/service.py
+++ b/backend/app/automation/service.py
@@ -173,7 +173,9 @@ def audit_github_queue(repo: str, *, repo_root: Path | None = None) -> GitHubQue
             repo=repo,
             status="paused",
             checks=checks,
-            notes=["Queue is paused until a fresh milestone and exit-gate issue are opened."],
+            notes=[
+                "Queue is paused in the formal release stop-state until an approved successor milestone and exit-gate issue are opened."
+            ],
         )
 
     milestone_titles = [milestone["title"] for milestone in open_milestones]

--- a/backend/tests/test_automation.py
+++ b/backend/tests/test_automation.py
@@ -63,6 +63,9 @@ def test_audit_github_queue_pauses_without_open_milestone(monkeypatch) -> None:
     audit = audit_github_queue("YSCJRH/mirror-sim")
     assert audit.status == "paused"
     assert audit.active_milestone is None
+    assert audit.notes == [
+        "Queue is paused in the formal release stop-state until an approved successor milestone and exit-gate issue are opened."
+    ]
 
 
 def test_audit_github_queue_ready_with_single_milestone_and_ready_issue(monkeypatch) -> None:

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, and Phase 43 is now the active successor-bootstrap and branch-exception-resolution track.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, and the repo now rests in the formal `v0.1.0` release stop-state.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -130,12 +130,13 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 42 is closed locally and in GitHub.
 - Phase 42 exit issue `#295` is closed and milestone `Phase 42 - Recovery Completion and Escalation Finalization` is closed.
 - The Phase 42 queue was completed through issues `#295-#298` plus branch-hygiene governance issues `#302-#303`.
-- Phase 43 is the active successor queue.
-- milestone `Phase 43 - Successor Bootstrap and Branch Exception Resolution` is open.
-- The Phase 43 queue is initialized through issues `#306-#308`.
+- Phase 43 is closed locally and in GitHub.
+- Phase 43 exit issue `#306` is closed and milestone `Phase 43 - Successor Bootstrap and Branch Exception Resolution` is closed.
+- The Phase 43 queue was completed through issues `#306-#308`.
+- The first formal repository release is published as `v0.1.0`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
-- The local Codex queue heartbeat remains active as `mirror-queue-heartbeat`.
+- The local Codex queue heartbeat remains paused as `mirror-queue-heartbeat` until an approved successor milestone is opened.
 
 ## Day 0 Bootstrap
 
@@ -188,3 +189,4 @@ Before builder automation is allowed to write code or auto-merge:
 - Long-running execution must run from isolated worktrees rather than the current `main` checkout.
 - Queue pickup order, one-writer ownership, and branch hygiene should follow `docs/plans/long-running-loop-runbook.md`.
 - When the active milestone exists and the queue reports `ready`, the builder may resume against that milestone only.
+- When no open milestone exists and `audit-github-queue` reports `paused`, treat that state as an intentional released stop-state rather than a broken queue.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the current Phase 43 active-queue baseline.
+This note is the formal `v0.1.0` release baseline after the Phase 43 closeout.
 
 ## Snapshot
 
@@ -176,21 +176,25 @@ This note is the current Phase 43 active-queue baseline.
   - `gh api repos/YSCJRH/mirror-sim/issues/295`
     - Phase 42 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/43`
-    - milestone `Phase 43 - Successor Bootstrap and Branch Exception Resolution` is `open`
-  - `gh api "repos/YSCJRH/mirror-sim/issues?state=open&milestone=43"`
-    - Phase 43 now remains open through exit gate `#306` plus branch-exception closeout issue `#308`
+    - milestone `Phase 43 - Successor Bootstrap and Branch Exception Resolution` is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/issues/306`
+    - Phase 43 exit issue is `closed`
+  - `gh api "repos/YSCJRH/mirror-sim/milestones?state=open"`
+    - no open milestone remains after the formal release closeout
+  - `gh api repos/YSCJRH/mirror-sim/releases`
+    - release `v0.1.0` exists and matches the committed release notes baseline
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - successor queue now reports `ready` because Phase 43 has exactly one blocked protected-core exit gate and ready work items available for pickup
+    - queue now reports `paused` with no active milestone because the repo is in the intentional formal release stop-state
 
 ## Trusted Source Of Truth
 
 - GitHub issue and milestone state remain the operational source of truth for current and future work.
 - Local phase audits remain the contract-aligned source of truth for whether the current repo state is runnable and reviewable.
-- `audit-github-queue` is the executable local rule for whether builder automation should remain `paused` or can resume against the successor queue.
+- `audit-github-queue` is the executable local rule for whether builder automation should remain `paused`, has entered the released stop-state, or can resume against a successor queue.
 - `backlog/sprint-01.md` is historical seed material only and should not be used as the live queue.
 - Historical remote `origin/codex/*` branches have now been reduced to zero live legacy exceptions and should not be treated as a standing backlog.
-- The current reviewed branch-hygiene baseline lives in `docs/plans/codex-branch-classification-baseline.md` and now records the evidence needed to close the final exception set through `#308`.
-- Any remaining local `origin/codex/*` tracking ref after `#308` should be treated as stale fetch residue and pruned against live GitHub truth.
+- The current reviewed branch-hygiene baseline lives in `docs/plans/codex-branch-classification-baseline.md` and records the closed `#308` evidence that reduced live historical `origin/codex/*` branches to zero.
+- Any future local `origin/codex/*` tracking ref that survives after a verified remote deletion should be treated as stale fetch residue and pruned against live GitHub truth.
 - Delete a historical remote branch once it is tied only to merged or closed work and no open issue, PR, or runbook step still references it.
 - Keep a historical remote branch only when an open issue or unresolved forensic comparison explicitly names it.
 - Revive a historical remote branch only by opening a new issue that states why `main` is insufficient.
@@ -200,12 +204,12 @@ This note is the current Phase 43 active-queue baseline.
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
 - The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, execution recovery release boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, escalation acknowledgment packets, and escalation closure packets without introducing backend API expansion.
-- The current repository state is in an active Phase 43 successor queue, not a closed Phase 42 baseline.
+- The current repository state is in the formal `v0.1.0` release stop-state, not in an active successor queue.
 
 ## Next Entry Point
 
-- Phase 43 is the active milestone and the current implementation slice is tracked by exit-gate issue `#306` plus protected-core follow-through issue `#308`.
-- New implementation work should consume the current Phase 43 queue and should not open another successor milestone while `#306` and `#308` remain unresolved.
+- Phase 43 is formally closed; no active milestone is open and the release baseline is tagged and published as `v0.1.0`.
+- New implementation work should not resume until a real approved successor milestone is defined and opened.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
-- The local queue heartbeat remains active as `mirror-queue-heartbeat` and should continue reporting the ready/paused state of the live Phase 43 queue.
+- The local queue heartbeat remains active as `mirror-queue-heartbeat` and should report the released stop-state as `paused` until a successor queue is explicitly approved.

--- a/docs/plans/long-running-loop-runbook.md
+++ b/docs/plans/long-running-loop-runbook.md
@@ -19,6 +19,11 @@ This runbook defines the manual, worktree-based pickup and handoff flow for cons
 
 If `audit-github-queue` reports `paused`, stop and do not invent new work outside the active milestone.
 
+Interpret `paused` in one of two ways:
+
+- If one active milestone still exists but has no `status:ready` issue, treat the queue as waiting for explicit preparation or closeout inside that same milestone.
+- If no open milestone exists, treat the repo as being in the intentional released stop-state; do not reopen work until an approved successor milestone is defined.
+
 ## Worktree Rules
 
 - Create one dedicated worktree per issue.
@@ -54,6 +59,8 @@ Immediately after each merge:
 8. Confirm the merged issue is closed or otherwise updated in GitHub.
 
 If the queue becomes `fail`, stop pickup and repair the milestone, exit gate, or label structure before continuing.
+
+If the queue becomes `paused` because no open milestone remains after a formal closeout, treat that as a successful stop-state rather than a queue defect.
 
 ## Branch Hygiene
 

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the Phase 43 successor bootstrap.
+This note records the current post-Day-0 execution status for Mirror after the formal Phase 43 closeout and `v0.1.0` release cut.
 
 ## Current Gate State
 
@@ -46,7 +46,7 @@ This note records the current post-Day-0 execution status for Mirror after the P
 - Phase 40 exit gate: closed
 - Phase 41 exit gate: closed
 - Phase 42 exit gate: closed
-- Phase 43 exit gate: open
+- Phase 43 exit gate: closed
 
 Local phase audits currently report:
 
@@ -328,17 +328,19 @@ Local phase audits currently report:
 - GitHub remote state
   - no open pull requests remain after the Phase 41 closeout
 
-## Current Queue
+## Formal Release Stop-State
 
-- milestone `Phase 43 - Successor Bootstrap and Branch Exception Resolution` is open.
+- milestone `Phase 43 - Successor Bootstrap and Branch Exception Resolution` is closed.
 - `#306` `Phase 43 exit gate`
-  - open
-- blocked until the Phase 43 successor-bootstrap and branch-exception-resolution slice is complete
-- The current Phase 43 execution slice is tracked through:
-  - `#308` `Phase 43: resolve remaining codex branch TODO exceptions`
-- The completed Phase 43 queue-sync slice was tracked through:
+  - closed
+- no open execution milestone remains after the formal release closeout
+- `audit-github-queue` should now report `paused` with no active milestone until a real successor phase is approved
+- the first formal GitHub release is published as `v0.1.0`
+- The completed Phase 43 slice was tracked through:
   - `#307` `Phase 43: sync repo truth to Phase 43 queue`
   - merged via PR `#309`
+  - `#308` `Phase 43: resolve remaining codex branch TODO exceptions`
+  - merged via PR `#310`
 - The completed Phase 42 slice was tracked through:
   - `#295` `Phase 42 exit gate`
   - `#296` `Phase 42: sync repo truth to Phase 42 queue`
@@ -513,7 +515,7 @@ Local phase audits currently report:
 ## Historical Branch Status
 
 - Historical remote `origin/codex/*` branches no longer retain any live legacy exception branch.
-- The current reviewed baseline is recorded in `docs/plans/codex-branch-classification-baseline.md`; `#302` and `#303` are merged, and `#308` now carries the final exception closeout.
+- The current reviewed baseline is recorded in `docs/plans/codex-branch-classification-baseline.md`; `#302`, `#303`, and `#308` are all merged and closed.
 - Current local `origin/codex/*` tracking refs should be empty after pruning stale fetch residue and deleting the final historical remote exception.
 - Treat any future recreated or still-live `codex/*` remote branch as temporary execution state, not as a standing backlog.
 - Delete a historical branch when it is tied only to closed or merged work and no open issue, PR, or runbook step references it.

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,37 @@
+# Mirror Engine `v0.1.0`
+
+Mirror `v0.1.0` is the first formal repository release after the full Phase 43 closeout.
+
+## Highlights
+
+- deterministic corpus -> graph -> persona -> scenario -> simulation -> report -> eval backbone is landed on `main`
+- review workbench supports the full Phase 42 closeout surface, including recovery-completion and escalation-finalization delivery views
+- GitHub-native long-running governance is in place:
+  - issue and PR templates
+  - lane classification
+  - phase audits
+  - GitHub queue audit
+  - documented worktree pickup and handoff flow
+- historical `origin/codex/*` execution branches have been reconciled and cleared from the live remote inventory
+
+## Governance State
+
+- Phase 43 is formally closed
+- no successor phase is opened in this release
+- the repository is intentionally paused in the release stop-state until a real approved successor milestone exists
+
+## Validation
+
+- `./make.ps1 smoke`
+- `./make.ps1 test`
+- `./make.ps1 eval-demo`
+- `python -m backend.app.cli audit-phase phase1`
+- `python -m backend.app.cli audit-phase phase2`
+- `python -m backend.app.cli audit-phase phase3`
+- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
+
+## Notes
+
+- Backend package version remains `0.1.0`
+- Frontend package version remains `0.1.0`
+- This release tags the repo state; it does not introduce a new successor phase or reopen the execution queue


### PR DESCRIPTION
## Summary
- formalize Phase 43 as a terminal release closeout instead of an always-ready successor queue
- add explicit released stop-state semantics to repo truth, runbook guidance, and the queue audit note surface
- add canonical release notes for the first formal GitHub release `v0.1.0`

## What changed
- updated `.github/automation/bootstrap-spec.json` so the Phase 43 exit gate closes against terminal-release criteria instead of successor bootstrap
- updated README and queue/governance docs to describe the intended post-closeout state: no open milestone, paused queue, and formal release `v0.1.0`
- updated `backend/app/automation/service.py` so the no-open-milestone audit note explicitly names the formal release stop-state
- added `docs/releases/v0.1.0.md` as the canonical GitHub Release body source

## Why
The repo has finished the Phase 43 queue work. Keeping the governance docs in an "active successor queue" posture would make the repo look broken when the correct state is actually an intentional release stop-state. This PR makes the governance truth, runbook behavior, and release packaging line up.

## Validation
- `python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md backend/app/automation/service.py backend/tests/test_automation.py docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/long-running-loop-runbook.md docs/plans/phase-execution-queue.md docs/releases/v0.1.0.md`
- `./make.ps1 smoke`
- `./make.ps1 test`
- `./make.ps1 eval-demo`
- `python -m backend.app.cli audit-phase phase1`
- `python -m backend.app.cli audit-phase phase2`
- `python -m backend.app.cli audit-phase phase3`
- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`

## Post-merge release steps
- patch issue `#306` to the terminal-release criteria
- close milestone `Phase 43 - Successor Bootstrap and Branch Exception Resolution`
- confirm `audit-github-queue` returns paused with no active milestone
- close `#306`
- create annotated tag `v0.1.0`
- publish GitHub Release `v0.1.0` from `docs/releases/v0.1.0.md`