### PR TITLE
[codex] Sync repo truth to Phase 44 queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -171,6 +171,10 @@
     {
       "title": "Phase 43 - Successor Bootstrap and Branch Exception Resolution",
       "description": "Turn the post-Phase-42 closeout into a clear successor-bootstrap and branch-exception-resolution queue without changing simulation or artifact contracts."
+    },
+    {
+      "title": "Phase 44 - Counterfactual Depth and Eval Hardening",
+      "description": "Turn the formal v0.1.0 release stop-state into a counterfactual-depth queue that expands the canonical scenario matrix, hardens eval coverage, and adds a comparison-first workbench entrypoint without changing scenario DSL, claim labels, or artifact roots."
     }
   ],
   "labels": [
@@ -388,6 +392,11 @@
       "name": "phase:43",
       "color": "FBFCFD",
       "description": "Phase 43 successor bootstrap and branch exception resolution work."
+    },
+    {
+      "name": "phase:44",
+      "color": "FFF4D6",
+      "description": "Phase 44 counterfactual depth and eval hardening work."
     },
     {
       "name": "area:backend",
@@ -2317,6 +2326,51 @@
         "lane:protected-core"
       ],
       "body": "## Summary\nResolve the explicit remaining codex branch TODO exceptions against live GitHub state and current `main` so branch hygiene no longer depends on stale carry-forward assumptions.\n\n## Scope\n- inspect the remaining `TODO[verify]` local and remote branch exceptions documented in the branch baseline\n- decide keep, revive, or delete from live evidence instead of historical assumptions\n- update the branch-hygiene docs so the exception set matches live GitHub truth after review\n\n## Constraints\n- do not reopen historical work without a new issue that explains why `main` is insufficient\n- do not delete any branch that is still referenced by open work, unresolved forensic comparison, or active runbook guidance\n- no simulation, report, claim, evidence, scenario, or schema contract changes"
+    },
+    {
+      "title": "Phase 44 exit gate",
+      "milestone": "Phase 44 - Counterfactual Depth and Eval Hardening",
+      "labels": [
+        "phase:44",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "Close this issue only after the full Phase 44 counterfactual-depth queue is complete.\n\nExit criteria:\n- the Phase 44 queue-sync issue is merged\n- the canonical scenario matrix and eval coverage issue is merged\n- the workbench counterfactual comparison overview issue is merged\n- `./make.ps1 smoke` passes\n- `./make.ps1 test` passes\n- `./make.ps1 eval-demo` passes\n- `python -m backend.app.cli audit-phase phase1` passes\n- `python -m backend.app.cli audit-phase phase2` passes\n- `python -m backend.app.cli audit-phase phase3` passes\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` returns `ready`\n- the Phase 45 milestone is open and the Phase 45 queue-sync issue exists before closeout"
+    },
+    {
+      "title": "Phase 44: sync repo truth to Phase 44 queue",
+      "milestone": "Phase 44 - Counterfactual Depth and Eval Hardening",
+      "labels": [
+        "phase:44",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## Summary\nSync the repo truth from the formal `v0.1.0` release stop-state to the active Phase 44 queue.\n\n## Scope\n- add Phase 44 milestone, label, and issue definitions to the bootstrap spec\n- update README and active-state docs to show Phase 44 as the sole active queue\n- record Phase 45 and Phase 46 as planned successor directions without opening them yet\n- create the Phase 44 milestone and issues from the updated bootstrap spec\n\n## Constraints\n- no simulation, report, claim, evidence, scenario, or schema contract changes\n- do not open more than one active execution milestone\n- no backend/runtime behavior changes beyond queue-governance sync"
+    },
+    {
+      "title": "Phase 44: add canonical scenario matrix and eval coverage",
+      "milestone": "Phase 44 - Counterfactual Depth and Eval Hardening",
+      "labels": [
+        "phase:44",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## Summary\nExpand the canonical Fog Harbor East Gate demo from a single intervention comparison into a small scenario matrix with stronger eval coverage.\n\n## Scope\n- add at least three intervention scenarios on top of the existing baseline so the canonical matrix reaches four compared runs\n- keep the existing injection kinds: `delay_document`, `block_contact`, and `resource_failure`\n- update the expectation set so `eval-demo` covers the whole scenario matrix instead of only one intervention delta\n- keep the current scenario DSL, claim labels, and artifact root structure intact\n\n## Constraints\n- do not introduce new injection kinds, new scenario DSL fields, or new artifact root directories in this phase\n- no branch-count execution semantics yet\n- no workbench API expansion in this issue"
+    },
+    {
+      "title": "Phase 44: add workbench counterfactual comparison overview",
+      "milestone": "Phase 44 - Counterfactual Depth and Eval Hardening",
+      "labels": [
+        "phase:44",
+        "area:frontend",
+        "status:blocked",
+        "lane:auto-safe"
+      ],
+      "body": "## Summary\nAdd a comparison-first workbench overview that makes the scenario matrix, outcome deltas, and direct trace/evidence entrypoints visible at the top level.\n\n## Scope\n- add a scenario-matrix summary surface to the existing workbench using current artifact files only\n- highlight which intervention changes which key outcomes before the reviewer drops into detailed traces\n- link the overview directly into trace-diff and claim/evidence surfaces\n- avoid expanding the existing handoff/export packet family in this slice\n\n## Constraints\n- no backend API additions\n- no artifact schema changes\n- keep the default operator path focused on compare -> trace -> claim/evidence -> eval"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -119,9 +119,10 @@ mirror-sim
 
 ## Current Status | 当前状态
 
-- **Formal release `v0.1.0` | 正式版本 `v0.1.0`**: The repository has completed Phase 43 closeout and published its first formal GitHub Release.
-- **Release stop-state | 发布停机态**: No approved successor phase is open in this round, so the GitHub execution queue is intentionally `paused`.
-- **Repo truth lives in docs | 仓库真相以文档为准**: See [mirror.md](mirror.md) for the project blueprint and [docs/releases/v0.1.0.md](docs/releases/v0.1.0.md) for the canonical release notes.
+- **Formal release `v0.1.0` | 正式版本 `v0.1.0`**: The first formal GitHub Release remains published and anchors the current repository baseline.
+- **Active successor queue | 当前后继队列**: Phase 44, `Counterfactual Depth and Eval Hardening`, is now the sole open execution milestone and the GitHub queue reports `ready`.
+- **Planned next route | 已定后续主线**: Phase 45 and Phase 46 are now documented as the next contract and workbench-focus directions, but they are not open milestones yet.
+- **Repo truth lives in docs | 仓库真相以文档为准**: See [mirror.md](mirror.md) for the project blueprint, [docs/plans/current-state-baseline.md](docs/plans/current-state-baseline.md) for the active queue baseline, and [docs/releases/v0.1.0.md](docs/releases/v0.1.0.md) for the canonical release notes.
 
 ---
 

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, and the repo now rests in the formal `v0.1.0` release stop-state.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, the first formal release remains published as `v0.1.0`, and the repo has now reopened the queue through the active Phase 44 milestone.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -133,10 +133,18 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 43 is closed locally and in GitHub.
 - Phase 43 exit issue `#306` is closed and milestone `Phase 43 - Successor Bootstrap and Branch Exception Resolution` is closed.
 - The Phase 43 queue was completed through issues `#306-#308`.
+- Phase 44 is now open in GitHub.
+- Phase 44 milestone `Phase 44 - Counterfactual Depth and Eval Hardening` is open.
+- `#313` `Phase 44 exit gate` is open and remains `status:blocked`.
+- `#314` `Phase 44: sync repo truth to Phase 44 queue` is open and is the current `status:ready` work item.
+- `#315` `Phase 44: add canonical scenario matrix and eval coverage` is open and remains `status:blocked`.
+- `#316` `Phase 44: add workbench counterfactual comparison overview` is open and remains `status:blocked`.
+- `audit-github-queue` now reports `ready` against the active Phase 44 milestone.
+- Phase 45 and Phase 46 are documented successor directions only; neither milestone is open yet.
 - The first formal repository release is published as `v0.1.0`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
-- The local Codex queue heartbeat remains paused as `mirror-queue-heartbeat` until an approved successor milestone is opened.
+- The local Codex queue heartbeat should now follow the active Phase 44 queue instead of reporting the released stop-state as `paused`.
 
 ## Day 0 Bootstrap
 
@@ -189,4 +197,5 @@ Before builder automation is allowed to write code or auto-merge:
 - Long-running execution must run from isolated worktrees rather than the current `main` checkout.
 - Queue pickup order, one-writer ownership, and branch hygiene should follow `docs/plans/long-running-loop-runbook.md`.
 - When the active milestone exists and the queue reports `ready`, the builder may resume against that milestone only.
+- While Phase 44 is active, do not open the planned Phase 45 or Phase 46 milestones.
 - When no open milestone exists and `audit-github-queue` reports `paused`, treat that state as an intentional released stop-state rather than a broken queue.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the formal `v0.1.0` release baseline after the Phase 43 closeout.
+This note is the active Phase 44 queue baseline after the formal `v0.1.0` release closeout.
 
 ## Snapshot
 
@@ -179,18 +179,28 @@ This note is the formal `v0.1.0` release baseline after the Phase 43 closeout.
     - milestone `Phase 43 - Successor Bootstrap and Branch Exception Resolution` is `closed`
   - `gh api repos/YSCJRH/mirror-sim/issues/306`
     - Phase 43 exit issue is `closed`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/44`
+    - milestone `Phase 44 - Counterfactual Depth and Eval Hardening` is `open`
+  - `gh api repos/YSCJRH/mirror-sim/issues/313`
+    - Phase 44 exit issue is `open` and remains `status:blocked`
+  - `gh api repos/YSCJRH/mirror-sim/issues/314`
+    - Phase 44 queue-sync issue is `open` and is the current `status:ready` work item
+  - `gh api repos/YSCJRH/mirror-sim/issues/315`
+    - Phase 44 scenario-matrix issue is `open` and remains `status:blocked`
+  - `gh api repos/YSCJRH/mirror-sim/issues/316`
+    - Phase 44 comparison-overview issue is `open` and remains `status:blocked`
   - `gh api "repos/YSCJRH/mirror-sim/milestones?state=open"`
-    - no open milestone remains after the formal release closeout
+    - exactly one open milestone exists: `Phase 44 - Counterfactual Depth and Eval Hardening`
   - `gh api repos/YSCJRH/mirror-sim/releases`
     - release `v0.1.0` exists and matches the committed release notes baseline
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - queue now reports `paused` with no active milestone because the repo is in the intentional formal release stop-state
+    - queue now reports `ready` against the active `Phase 44 - Counterfactual Depth and Eval Hardening` milestone
 
 ## Trusted Source Of Truth
 
 - GitHub issue and milestone state remain the operational source of truth for current and future work.
 - Local phase audits remain the contract-aligned source of truth for whether the current repo state is runnable and reviewable.
-- `audit-github-queue` is the executable local rule for whether builder automation should remain `paused`, has entered the released stop-state, or can resume against a successor queue.
+- `audit-github-queue` is the executable local rule for whether builder automation should remain `paused`, has entered the released stop-state, or can resume against the active successor queue.
 - `backlog/sprint-01.md` is historical seed material only and should not be used as the live queue.
 - Historical remote `origin/codex/*` branches have now been reduced to zero live legacy exceptions and should not be treated as a standing backlog.
 - The current reviewed branch-hygiene baseline lives in `docs/plans/codex-branch-classification-baseline.md` and records the closed `#308` evidence that reduced live historical `origin/codex/*` branches to zero.
@@ -204,12 +214,13 @@ This note is the formal `v0.1.0` release baseline after the Phase 43 closeout.
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
 - The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, execution recovery release boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, escalation acknowledgment packets, and escalation closure packets without introducing backend API expansion.
-- The current repository state is in the formal `v0.1.0` release stop-state, not in an active successor queue.
+- The current repository state has reopened the queue through Phase 44 while preserving `v0.1.0` as the latest published release baseline.
 
 ## Next Entry Point
 
-- Phase 43 is formally closed; no active milestone is open and the release baseline is tagged and published as `v0.1.0`.
-- New implementation work should not resume until a real approved successor milestone is defined and opened.
+- Phase 44 is now the sole active milestone, and `#314` `Phase 44: sync repo truth to Phase 44 queue` is the current ready work item.
+- The next unlock order is fixed: close `#314`, then move `#315` to `status:ready`, then unlock `#316` only after the scenario matrix artifacts are stable.
+- Phase 45 and Phase 46 are documented successor directions only; they must not be opened while Phase 44 remains active.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
-- The local queue heartbeat remains active as `mirror-queue-heartbeat` and should report the released stop-state as `paused` until a successor queue is explicitly approved.
+- The local queue heartbeat remains active as `mirror-queue-heartbeat` and should now report the Phase 44 queue as `ready`; it must not open another milestone while Phase 44 is active.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the formal Phase 43 closeout and `v0.1.0` release cut.
+This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut and the Phase 44 queue restart.
 
 ## Current Gate State
 
@@ -47,12 +47,36 @@ This note records the current post-Day-0 execution status for Mirror after the f
 - Phase 41 exit gate: closed
 - Phase 42 exit gate: closed
 - Phase 43 exit gate: closed
+- Phase 44 exit gate: open
 
 Local phase audits currently report:
 
 - `phase1`: pass
 - `phase2`: pass
 - `phase3`: pass
+
+## Active Phase 44 Queue
+
+- milestone `Phase 44 - Counterfactual Depth and Eval Hardening`
+  - open
+- `#313` `Phase 44 exit gate`
+  - open
+  - `status:blocked`
+- `#314` `Phase 44: sync repo truth to Phase 44 queue`
+  - open
+  - `status:ready`
+- `#315` `Phase 44: add canonical scenario matrix and eval coverage`
+  - open
+  - `status:blocked`
+- `#316` `Phase 44: add workbench counterfactual comparison overview`
+  - open
+  - `status:blocked`
+- `audit-github-queue`
+  - reports `ready` against the Phase 44 milestone because exactly one open milestone exists with a protected blocked exit gate and ready work items
+- planned successor directions
+  - Phase 45: branch generalization and compare contracts
+  - Phase 46: workbench focus and modularity
+  - both remain documented successors only and are not open milestones yet
 
 ## Closeout Snapshot
 
@@ -328,14 +352,13 @@ Local phase audits currently report:
 - GitHub remote state
   - no open pull requests remain after the Phase 41 closeout
 
-## Formal Release Stop-State
+## Release-To-Queue Transition
 
-- milestone `Phase 43 - Successor Bootstrap and Branch Exception Resolution` is closed.
+- the first formal GitHub release remains published as `v0.1.0`
+- milestone `Phase 43 - Successor Bootstrap and Branch Exception Resolution` is closed
 - `#306` `Phase 43 exit gate`
   - closed
-- no open execution milestone remains after the formal release closeout
-- `audit-github-queue` should now report `paused` with no active milestone until a real successor phase is approved
-- the first formal GitHub release is published as `v0.1.0`
+- the repo has now moved out of the released stop-state by opening the Phase 44 milestone and queue issues
 - The completed Phase 43 slice was tracked through:
   - `#307` `Phase 43: sync repo truth to Phase 43 queue`
   - merged via PR `#309`
@@ -511,6 +534,7 @@ Local phase audits currently report:
 - Protected-core changes still require explicit review and must not auto-merge.
 - Long-running execution should assign exactly one writer worktree per issue.
 - When `audit-github-queue` reports `ready`, consume only the currently active milestone and do not parallel-open another execution queue.
+- While Phase 44 is active, do not open the planned Phase 45 or Phase 46 milestones.
 
 ## Historical Branch Status
 


### PR DESCRIPTION
## Summary
- add Phase 44 bootstrap metadata to the GitHub automation spec
- sync README and active-state docs from the `v0.1.0` stop-state to the active Phase 44 queue
- record Phase 45 and Phase 46 as planned successor directions without opening them yet
- bootstrap the live Phase 44 milestone, label, and issues on GitHub

## Validation
- `python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`
- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`
- `./make.ps1 test`
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`

Closes #314