### PR TITLE
[codex] Sync Phase 44 docs after queue handoff

### DIFF
--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -136,8 +136,8 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 44 is now open in GitHub.
 - Phase 44 milestone `Phase 44 - Counterfactual Depth and Eval Hardening` is open.
 - `#313` `Phase 44 exit gate` is open and remains `status:blocked`.
-- `#314` `Phase 44: sync repo truth to Phase 44 queue` is open and is the current `status:ready` work item.
-- `#315` `Phase 44: add canonical scenario matrix and eval coverage` is open and remains `status:blocked`.
+- `#314` `Phase 44: sync repo truth to Phase 44 queue` is merged and closed via PR `#317`.
+- `#315` `Phase 44: add canonical scenario matrix and eval coverage` is open and is now the current `status:ready` work item.
 - `#316` `Phase 44: add workbench counterfactual comparison overview` is open and remains `status:blocked`.
 - `audit-github-queue` now reports `ready` against the active Phase 44 milestone.
 - Phase 45 and Phase 46 are documented successor directions only; neither milestone is open yet.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -184,9 +184,9 @@ This note is the active Phase 44 queue baseline after the formal `v0.1.0` releas
   - `gh api repos/YSCJRH/mirror-sim/issues/313`
     - Phase 44 exit issue is `open` and remains `status:blocked`
   - `gh api repos/YSCJRH/mirror-sim/issues/314`
-    - Phase 44 queue-sync issue is `open` and is the current `status:ready` work item
+    - Phase 44 queue-sync issue is `closed` after merging PR `#317`
   - `gh api repos/YSCJRH/mirror-sim/issues/315`
-    - Phase 44 scenario-matrix issue is `open` and remains `status:blocked`
+    - Phase 44 scenario-matrix issue is `open` and is now the current `status:ready` work item
   - `gh api repos/YSCJRH/mirror-sim/issues/316`
     - Phase 44 comparison-overview issue is `open` and remains `status:blocked`
   - `gh api "repos/YSCJRH/mirror-sim/milestones?state=open"`
@@ -218,8 +218,8 @@ This note is the active Phase 44 queue baseline after the formal `v0.1.0` releas
 
 ## Next Entry Point
 
-- Phase 44 is now the sole active milestone, and `#314` `Phase 44: sync repo truth to Phase 44 queue` is the current ready work item.
-- The next unlock order is fixed: close `#314`, then move `#315` to `status:ready`, then unlock `#316` only after the scenario matrix artifacts are stable.
+- Phase 44 is now the sole active milestone, and `#315` `Phase 44: add canonical scenario matrix and eval coverage` is the current ready work item.
+- The next unlock order is fixed: `#314` is now closed, `#315` is ready, and `#316` should remain blocked until the scenario matrix artifacts are stable.
 - Phase 45 and Phase 46 are documented successor directions only; they must not be opened while Phase 44 remains active.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -63,16 +63,17 @@ Local phase audits currently report:
   - open
   - `status:blocked`
 - `#314` `Phase 44: sync repo truth to Phase 44 queue`
-  - open
-  - `status:ready`
+  - closed
+  - merged via PR `#317`
 - `#315` `Phase 44: add canonical scenario matrix and eval coverage`
   - open
-  - `status:blocked`
+  - `status:ready`
 - `#316` `Phase 44: add workbench counterfactual comparison overview`
   - open
   - `status:blocked`
 - `audit-github-queue`
   - reports `ready` against the Phase 44 milestone because exactly one open milestone exists with a protected blocked exit gate and ready work items
+  - the current ready work item is now `#315` rather than the already-merged queue-sync issue
 - planned successor directions
   - Phase 45: branch generalization and compare contracts
   - Phase 46: workbench focus and modularity


### PR DESCRIPTION
## Summary
- update the Phase 44 docs after the queue-sync PR merged
- record that `#314` is now closed via PR `#317`
- record that `#315` is now the active `status:ready` work item

## Validation
- `python -m backend.app.cli classify-lane --files docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`