### PR TITLE
[codex] Expand canonical scenario matrix coverage

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -11,6 +11,7 @@ class Settings:
     artifacts_root: Path
     manifest_path: Path
     world_model_path: Path
+    scenario_dir: Path
     baseline_scenario_path: Path
     intervention_scenario_path: Path
     expectations_path: Path
@@ -27,6 +28,7 @@ def get_settings() -> Settings:
         artifacts_root=artifacts_root,
         manifest_path=data_root / "corpus" / "manifest.yaml",
         world_model_path=data_root / "config" / "world_model.yaml",
+        scenario_dir=data_root / "scenarios",
         baseline_scenario_path=data_root / "scenarios" / "baseline.yaml",
         intervention_scenario_path=data_root / "scenarios" / "reporter_detained.yaml",
         expectations_path=data_root / "expectations" / "demo_eval.yaml",

--- a/backend/app/evals/service.py
+++ b/backend/app/evals/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -44,14 +45,9 @@ def _graph_collection_id_field(collection: str) -> str:
 def _redline_texts(artifacts_root: Path) -> dict[str, str]:
     graph_path = artifacts_root / "graph" / "graph.json"
     personas_path = artifacts_root / "personas" / "personas.json"
-    return {
+    texts = {
         "report": (artifacts_root / "report" / "report.md").read_text(encoding="utf-8"),
         "claims": json.dumps(read_json(artifacts_root / "report" / "claims.json"), ensure_ascii=False),
-        "baseline_scenario": json.dumps(read_json(artifacts_root / "scenario" / "baseline.json"), ensure_ascii=False),
-        "intervention_scenario": json.dumps(
-            read_json(artifacts_root / "scenario" / "reporter_detained.json"),
-            ensure_ascii=False,
-        ),
         "query_entity_east_gate": json.dumps(
             inspect_world("entity", "entity_east_gate", graph_path, personas_path),
             ensure_ascii=False,
@@ -65,6 +61,18 @@ def _redline_texts(artifacts_root: Path) -> dict[str, str]:
             ensure_ascii=False,
         ),
     }
+    for scenario_path in sorted((artifacts_root / "scenario").glob("*.json")):
+        texts[f"scenario_{scenario_path.stem}"] = json.dumps(read_json(scenario_path), ensure_ascii=False)
+    return texts
+
+
+def _load_run_payloads(artifacts_root: Path) -> dict[str, dict[str, Any]]:
+    run_payloads: dict[str, dict[str, Any]] = {}
+    for run_dir in sorted((artifacts_root / "run").iterdir()):
+        summary_path = run_dir / "summary.json"
+        if run_dir.is_dir() and summary_path.exists():
+            run_payloads[run_dir.name] = read_json(summary_path)
+    return run_payloads
 
 
 def _evaluate_redlines(redlines_path: Path, artifacts_root: Path) -> list[str]:
@@ -83,15 +91,12 @@ def _evaluate_redlines(redlines_path: Path, artifacts_root: Path) -> list[str]:
 
 def evaluate_runs(expectations_path: Path, artifacts_root: Path, out_dir: Path, redlines_path: Path) -> EvalResult:
     expectations = load_yaml(expectations_path)
-    baseline_summary = read_json(artifacts_root / "run" / "baseline" / "summary.json")
-    intervention_summary = read_json(artifacts_root / "run" / "reporter_detained" / "summary.json")
+    summary_payloads = _load_run_payloads(artifacts_root)
+    baseline_summary = summary_payloads["baseline"]
     graph_payload = read_json(artifacts_root / "graph" / "graph.json")
     persona_payload = read_json(artifacts_root / "personas" / "personas.json")
     claims = read_json(artifacts_root / "report" / "claims.json")
-    runs = {
-        "baseline": {**baseline_summary, **baseline_summary["final_state"]},
-        "reporter_detained": {**intervention_summary, **intervention_summary["final_state"]},
-    }
+    runs = {name: {**summary, **summary["final_state"]} for name, summary in summary_payloads.items()}
 
     failures: list[str] = []
     passed = 0
@@ -181,9 +186,16 @@ def evaluate_runs(expectations_path: Path, artifacts_root: Path, out_dir: Path, 
         metrics={
             "checks_total": len(expectations["checks"]) + 1,
             "checks_passed": passed,
-            "baseline_evacuation_turn": baseline_summary["evacuation_turn"],
-            "intervention_evacuation_turn": intervention_summary["evacuation_turn"],
+            "scenario_count": len(runs),
             "event_count": graph_payload["stats"]["event_count"],
+            **{
+                f"{name}_evacuation_turn": summary["evacuation_turn"]
+                for name, summary in summary_payloads.items()
+            },
+            **{
+                f"{name}_ledger_public_turn": summary["ledger_public_turn"]
+                for name, summary in summary_payloads.items()
+            },
         },
         failures=failures,
         notes=["Phase 1 eval covers deterministic demo behavior, world-model provenance, and redline checks."],
@@ -195,27 +207,35 @@ def evaluate_runs(expectations_path: Path, artifacts_root: Path, out_dir: Path, 
 def run_phase0_demo(settings: Settings | None = None, artifacts_root: Path | None = None) -> EvalResult:
     settings = settings or get_settings()
     artifacts_root = artifacts_root or settings.artifacts_root
+    scenario_paths = [settings.baseline_scenario_path] + sorted(
+        path for path in settings.scenario_dir.glob("*.yaml") if path != settings.baseline_scenario_path
+    )
 
     ingest_manifest(settings.manifest_path, artifacts_root / "ingest")
     build_graph(artifacts_root / "ingest" / "chunks.jsonl", artifacts_root / "graph", settings.world_model_path)
     build_personas(artifacts_root / "graph" / "graph.json", artifacts_root / "personas", settings.world_model_path)
-    validate_scenario(settings.baseline_scenario_path, artifacts_root / "scenario" / "baseline.json")
-    validate_scenario(settings.intervention_scenario_path, artifacts_root / "scenario" / "reporter_detained.json")
-    simulate_scenario(
-        settings.baseline_scenario_path,
-        artifacts_root / "graph" / "graph.json",
-        artifacts_root / "personas" / "personas.json",
-        artifacts_root / "run" / "baseline",
-    )
-    simulate_scenario(
-        settings.intervention_scenario_path,
-        artifacts_root / "graph" / "graph.json",
-        artifacts_root / "personas" / "personas.json",
-        artifacts_root / "run" / "reporter_detained",
-    )
+    scenario_out_dir = artifacts_root / "scenario"
+    run_root = artifacts_root / "run"
+    scenario_out_dir.mkdir(parents=True, exist_ok=True)
+    run_root.mkdir(parents=True, exist_ok=True)
+    for scenario_json in scenario_out_dir.glob("*.json"):
+        scenario_json.unlink()
+    for run_dir in run_root.iterdir():
+        if run_dir.is_dir():
+            shutil.rmtree(run_dir)
+
+    for scenario_path in scenario_paths:
+        stem = scenario_path.stem
+        validate_scenario(scenario_path, scenario_out_dir / f"{stem}.json")
+        simulate_scenario(
+            scenario_path,
+            artifacts_root / "graph" / "graph.json",
+            artifacts_root / "personas" / "personas.json",
+            run_root / stem,
+        )
     generate_report(
-        artifacts_root / "run" / "reporter_detained",
+        run_root / settings.intervention_scenario_path.stem,
         artifacts_root / "report",
-        baseline_dir=artifacts_root / "run" / "baseline",
+        baseline_dir=run_root / "baseline",
     )
     return evaluate_runs(settings.expectations_path, artifacts_root, artifacts_root / "eval", settings.redlines_path)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -26,6 +26,7 @@ def test_demo_report_endpoint_reflects_artifact_state(tmp_path: Path, monkeypatc
         artifacts_root=tmp_path / "demo",
         manifest_path=settings.manifest_path,
         world_model_path=settings.world_model_path,
+        scenario_dir=settings.scenario_dir,
         baseline_scenario_path=settings.baseline_scenario_path,
         intervention_scenario_path=settings.intervention_scenario_path,
         expectations_path=settings.expectations_path,

--- a/backend/tests/test_pipeline.py
+++ b/backend/tests/test_pipeline.py
@@ -131,7 +131,22 @@ def test_eval_demo_passes(tmp_path: Path) -> None:
     settings = get_settings()
     result = run_phase0_demo(settings=settings, artifacts_root=tmp_path / "demo")
     assert result.status == "pass"
+    assert result.metrics["scenario_count"] == 4
     assert result.metrics["event_count"] >= 4
+    assert result.metrics["reporter_detained_evacuation_turn"] > result.metrics["baseline_evacuation_turn"]
+    assert result.metrics["harbor_comms_failure_evacuation_turn"] > result.metrics["baseline_evacuation_turn"]
+    assert result.metrics["mayor_signal_blocked_evacuation_turn"] == result.metrics["baseline_evacuation_turn"]
+
+
+def test_eval_demo_writes_canonical_scenario_matrix(tmp_path: Path) -> None:
+    settings = get_settings()
+    artifacts_root = tmp_path / "demo"
+    run_phase0_demo(settings=settings, artifacts_root=artifacts_root)
+
+    for stem in ("baseline", "reporter_detained", "harbor_comms_failure", "mayor_signal_blocked"):
+        assert (artifacts_root / "scenario" / f"{stem}.json").exists()
+        assert (artifacts_root / "run" / stem / "summary.json").exists()
+        assert (artifacts_root / "run" / stem / "run_trace.jsonl").exists()
 
 
 def test_eval_redlines_cover_query_outputs(tmp_path: Path, monkeypatch) -> None:

--- a/data/demo/expectations/demo_eval.yaml
+++ b/data/demo/expectations/demo_eval.yaml
@@ -1,4 +1,4 @@
-eval_name: fog_harbor_phase0_demo
+eval_name: fog_harbor_phase44_matrix
 checks:
   - name: graph_has_events
     kind: graph_events_nonempty
@@ -63,20 +63,63 @@ checks:
     run: baseline
     field: evacuation_triggered
     equals: true
-  - name: intervention_delays_ledger
+  - name: reporter_detained_delays_ledger
     kind: compare_runs
     left_run: reporter_detained
     left_field: ledger_public_turn
     op: gt
     right_run: baseline
     right_field: ledger_public_turn
-  - name: intervention_delays_evacuation
+  - name: reporter_detained_delays_evacuation
     kind: compare_runs
     left_run: reporter_detained
     left_field: evacuation_turn
     op: gt
     right_run: baseline
     right_field: evacuation_turn
+  - name: reporter_detained_preserves_direct_warning_path
+    kind: run_field
+    run: reporter_detained
+    field: risk_known_by
+    equals:
+      - entity_chen_yu
+      - entity_su_he
+  - name: harbor_comms_failure_delays_ledger
+    kind: compare_runs
+    left_run: harbor_comms_failure
+    left_field: ledger_public_turn
+    op: gt
+    right_run: baseline
+    right_field: ledger_public_turn
+  - name: harbor_comms_failure_delays_evacuation
+    kind: compare_runs
+    left_run: harbor_comms_failure
+    left_field: evacuation_turn
+    op: gt
+    right_run: baseline
+    right_field: evacuation_turn
+  - name: harbor_comms_failure_loses_direct_warning_path
+    kind: run_field
+    run: harbor_comms_failure
+    field: risk_known_by
+    equals:
+      - entity_su_he
+  - name: mayor_signal_blocked_keeps_publish_on_baseline_turn
+    kind: run_field
+    run: mayor_signal_blocked
+    field: ledger_public_turn
+    equals: 3
+  - name: mayor_signal_blocked_keeps_evacuation_on_baseline_turn
+    kind: run_field
+    run: mayor_signal_blocked
+    field: evacuation_turn
+    equals: 5
+  - name: mayor_signal_blocked_loses_direct_warning_path
+    kind: run_field
+    run: mayor_signal_blocked
+    field: risk_known_by
+    equals:
+      - entity_su_he
   - name: claims_are_labeled
     kind: claim_labels_complete
   - name: claims_have_evidence

--- a/data/demo/scenarios/harbor_comms_failure.yaml
+++ b/data/demo/scenarios/harbor_comms_failure.yaml
@@ -1,0 +1,26 @@
+scenario_id: scenario_harbor_comms_failure
+world_id: fog-harbor-east-gate
+title: Harbor Communications Failure Delays Warning Relay
+description: >
+  Saltwater interference takes the harbor radios offline during the early warning
+  window, delaying both the tide alert and the first opportunity to surface the
+  copied maintenance ledger.
+seed: 7
+turn_budget: 8
+branch_count: 1
+evaluation_questions:
+  - How much later does the maintenance ledger surface when communications stay down through turn three?
+  - Does the outage postpone evacuation even if the engineering risk is already visible?
+  - Which actor loses situational awareness first when the warning relay breaks?
+injections:
+  - injection_id: inj_harbor_comms_failure
+    kind: resource_failure
+    actor_id: persona_chen_yu
+    target_id: entity_east_wharf
+    params:
+      duration_turns: 3
+      cause: saltwater_radio_interference
+    rationale: >
+      The eastern harbor radios fail during the first three turns, so Chen Yu's
+      warning relay and Lin Lan's first publication attempt both slip behind the
+      baseline branch.

--- a/data/demo/scenarios/mayor_signal_blocked.yaml
+++ b/data/demo/scenarios/mayor_signal_blocked.yaml
@@ -1,0 +1,24 @@
+scenario_id: scenario_mayor_signal_blocked
+world_id: fog-harbor-east-gate
+title: Mayor Signal Blocked During Tide Warning
+description: >
+  Chen Yu cannot reach Zhao Ke during the first warning attempt, so the deputy
+  mayor misses the direct tide escalation even though the ledger still surfaces
+  on schedule.
+seed: 7
+turn_budget: 8
+branch_count: 1
+evaluation_questions:
+  - What changes when the deputy mayor misses Chen Yu's first alert but Lin Lan still publishes on time?
+  - Does evacuation still happen on the baseline turn once the ledger becomes public?
+  - Which branch facts remain stable even when the early warning path is blocked?
+injections:
+  - injection_id: inj_mayor_signal_blocked
+    kind: block_contact
+    actor_id: persona_chen_yu
+    target_id: persona_zhao_ke
+    params:
+      cause: courier_interception
+    rationale: >
+      The harbor warning never reaches Zhao Ke on turn two, forcing the branch
+      to rely on documentary exposure rather than the direct tide report.


### PR DESCRIPTION
## Summary
- expand the canonical demo from baseline + one intervention to a four-run scenario matrix
- add `harbor_comms_failure` and `mayor_signal_blocked` alongside the existing `reporter_detained` branch
- update `eval-demo` to validate the whole matrix while keeping the report contract centered on `reporter_detained` vs baseline
- extend tests so the scenario matrix is part of the stable Phase 44 baseline

## Validation
- `python -m backend.app.cli classify-lane --files backend/app/config.py backend/app/evals/service.py backend/tests/test_api.py backend/tests/test_pipeline.py data/demo/expectations/demo_eval.yaml data/demo/scenarios/harbor_comms_failure.yaml data/demo/scenarios/mayor_signal_blocked.yaml`
- `./make.ps1 test`
- `./make.ps1 eval-demo`
- `./make.ps1 smoke`

Closes #315