### PR TITLE
[codex] Sync Phase 44 docs after scenario matrix handoff

### DIFF
--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -137,8 +137,8 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 44 milestone `Phase 44 - Counterfactual Depth and Eval Hardening` is open.
 - `#313` `Phase 44 exit gate` is open and remains `status:blocked`.
 - `#314` `Phase 44: sync repo truth to Phase 44 queue` is merged and closed via PR `#317`.
-- `#315` `Phase 44: add canonical scenario matrix and eval coverage` is open and is now the current `status:ready` work item.
-- `#316` `Phase 44: add workbench counterfactual comparison overview` is open and remains `status:blocked`.
+- `#315` `Phase 44: add canonical scenario matrix and eval coverage` is merged and closed via PR `#319`.
+- `#316` `Phase 44: add workbench counterfactual comparison overview` is open and is now the current `status:ready` work item.
 - `audit-github-queue` now reports `ready` against the active Phase 44 milestone.
 - Phase 45 and Phase 46 are documented successor directions only; neither milestone is open yet.
 - The first formal repository release is published as `v0.1.0`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -186,9 +186,9 @@ This note is the active Phase 44 queue baseline after the formal `v0.1.0` releas
   - `gh api repos/YSCJRH/mirror-sim/issues/314`
     - Phase 44 queue-sync issue is `closed` after merging PR `#317`
   - `gh api repos/YSCJRH/mirror-sim/issues/315`
-    - Phase 44 scenario-matrix issue is `open` and is now the current `status:ready` work item
+    - Phase 44 scenario-matrix issue is `closed` after merging PR `#319`
   - `gh api repos/YSCJRH/mirror-sim/issues/316`
-    - Phase 44 comparison-overview issue is `open` and remains `status:blocked`
+    - Phase 44 comparison-overview issue is `open` and is now the current `status:ready` work item
   - `gh api "repos/YSCJRH/mirror-sim/milestones?state=open"`
     - exactly one open milestone exists: `Phase 44 - Counterfactual Depth and Eval Hardening`
   - `gh api repos/YSCJRH/mirror-sim/releases`
@@ -218,8 +218,8 @@ This note is the active Phase 44 queue baseline after the formal `v0.1.0` releas
 
 ## Next Entry Point
 
-- Phase 44 is now the sole active milestone, and `#315` `Phase 44: add canonical scenario matrix and eval coverage` is the current ready work item.
-- The next unlock order is fixed: `#314` is now closed, `#315` is ready, and `#316` should remain blocked until the scenario matrix artifacts are stable.
+- Phase 44 is now the sole active milestone, and `#316` `Phase 44: add workbench counterfactual comparison overview` is the current ready work item.
+- The next unlock order is fixed: `#314` and `#315` are now closed, and `#316` is ready to carry the Phase 44 workbench slice.
 - Phase 45 and Phase 46 are documented successor directions only; they must not be opened while Phase 44 remains active.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -66,14 +66,14 @@ Local phase audits currently report:
   - closed
   - merged via PR `#317`
 - `#315` `Phase 44: add canonical scenario matrix and eval coverage`
-  - open
-  - `status:ready`
+  - closed
+  - merged via PR `#319`
 - `#316` `Phase 44: add workbench counterfactual comparison overview`
   - open
-  - `status:blocked`
+  - `status:ready`
 - `audit-github-queue`
   - reports `ready` against the Phase 44 milestone because exactly one open milestone exists with a protected blocked exit gate and ready work items
-  - the current ready work item is now `#315` rather than the already-merged queue-sync issue
+  - the current ready work item is now `#316` rather than the already-merged scenario-matrix issue
 - planned successor directions
   - Phase 45: branch generalization and compare contracts
   - Phase 46: workbench focus and modularity


### PR DESCRIPTION
## Summary
- update the Phase 44 docs after the scenario-matrix PR merged
- record that `#315` is now closed via PR `#319`
- record that `#316` is now the active `status:ready` work item

## Validation
- `python -m backend.app.cli classify-lane --files docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`