### PR TITLE
[codex] Add workbench counterfactual comparison overview

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -161,6 +161,18 @@ code {
   gap: 16px;
 }
 
+.comparisonOverviewGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 18px;
+}
+
+.scenarioGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 18px;
+}
+
 .reportGrid {
   display: grid;
   grid-template-columns: 1.3fr 1fr;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,31 +1,33 @@
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { ReviewScorecard } from "./review-scorecard";
+
+const repoRoot = path.resolve(process.cwd(), "..");
 
 const sections = [
   {
     title: "Corpus",
-    copy: "Source documents and chunks remain the base truth layer behind every later review step.",
+    copy: "Source documents and chunks remain the bounded truth layer behind every later comparison, claim, and review step.",
     path: "artifacts/demo/ingest"
   },
   {
     title: "World Model",
-    copy: "Graph entities, relations, events, and personas keep evidence-bearing context queryable.",
+    copy: "Graph entities, relations, events, and personas keep evidence-bearing context queryable after the matrix branches diverge.",
     path: "artifacts/demo/graph and artifacts/demo/personas"
   },
   {
-    title: "Scenario",
-    copy: "Baseline and intervention scenarios stay explicit, normalized, and branch-comparable.",
+    title: "Scenario Matrix",
+    copy: "Canonical baseline and intervention scenarios stay normalized, explicit, and discoverable from the same artifact directory.",
     path: "artifacts/demo/scenario"
   },
   {
-    title: "Run",
-    copy: "Deterministic traces and snapshots now surface as a reviewer-readable branch timeline.",
+    title: "Run Matrix",
+    copy: "Deterministic traces and snapshots now load as a four-branch comparison surface instead of a single intervention lane.",
     path: "artifacts/demo/run"
   },
   {
-    title: "Review Workflow",
-    copy: "Claims, evidence excerpts, graph context, and branch turns can be traversed without leaving the workbench.",
+    title: "Compare To Review",
+    copy: "The default operator path now starts from outcome deltas, then drops into trace, claim and evidence, and eval summary.",
     path: "artifacts/demo/report, run, and eval"
   }
 ];
@@ -124,7 +126,22 @@ type SnapshotPayload = {
   state: Record<string, unknown>;
 };
 
-type ScenarioKey = "baseline" | "reporter_detained";
+type RunSummary = {
+  run_id: string;
+  scenario_id: string;
+  seed: number;
+  turn_budget: number;
+  executed_turns: number;
+  ledger_public_turn?: number;
+  budget_exposed_turn?: number;
+  evacuation_turn?: number;
+  final_state: Record<string, unknown>;
+  action_count: number;
+  action_types: string[];
+  notes: string[];
+};
+
+type ScenarioKey = string;
 
 type RubricRow = {
   dimension: string;
@@ -135,8 +152,9 @@ type RubricRow = {
 
 type RunPayload = {
   key: ScenarioKey;
-  title: string;
+  label: string;
   scenario: ScenarioPayload;
+  summary: RunSummary;
   actions: TurnAction[];
   snapshots: SnapshotPayload[];
 };
@@ -150,7 +168,6 @@ type TurnEntry = {
 };
 
 async function readText(relativePath: string) {
-  const repoRoot = path.resolve(process.cwd(), "..");
   return readFile(path.join(repoRoot, relativePath), "utf-8");
 }
 
@@ -165,6 +182,23 @@ async function readJsonl<T>(relativePath: string) {
     .map((line) => JSON.parse(line) as T);
 }
 
+async function listJsonBaseNames(relativeDir: string) {
+  const entries = await readdir(path.join(repoRoot, relativeDir), { withFileTypes: true });
+
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .map((entry) => entry.name.replace(/\.json$/u, ""))
+    .sort((left, right) => {
+      if (left === "baseline") {
+        return -1;
+      }
+      if (right === "baseline") {
+        return 1;
+      }
+      return left.localeCompare(right);
+    });
+}
+
 async function loadSnapshots(runDir: string, turnBudget: number) {
   return Promise.all(
     Array.from({ length: turnBudget }, (_, index) =>
@@ -175,21 +209,18 @@ async function loadSnapshots(runDir: string, turnBudget: number) {
   );
 }
 
-async function loadRunPayload(
-  key: ScenarioKey,
-  runDir: string,
-  title: string,
-  scenario: ScenarioPayload
-): Promise<RunPayload> {
-  const [actions, snapshots] = await Promise.all([
-    readJsonl<TurnAction>(`artifacts/demo/run/${runDir}/run_trace.jsonl`),
-    loadSnapshots(runDir, scenario.turn_budget)
+async function loadRunPayload(key: ScenarioKey, scenario: ScenarioPayload): Promise<RunPayload> {
+  const [summary, actions, snapshots] = await Promise.all([
+    readJson<RunSummary>(`artifacts/demo/run/${key}/summary.json`),
+    readJsonl<TurnAction>(`artifacts/demo/run/${key}/run_trace.jsonl`),
+    loadSnapshots(key, scenario.turn_budget)
   ]);
 
   return {
     key,
-    title,
+    label: key === "baseline" ? "Baseline" : "Intervention",
     scenario,
+    summary,
     actions,
     snapshots
   };
@@ -204,8 +235,7 @@ async function loadWorkbenchData() {
     documents,
     chunks,
     graph,
-    baselineScenario,
-    interventionScenario
+    scenarioKeys
   ] = await Promise.all([
     readText("artifacts/demo/report/report.md"),
     readJson<Claim[]>("artifacts/demo/report/claims.json"),
@@ -214,14 +244,25 @@ async function loadWorkbenchData() {
     readJsonl<DocumentRow>("artifacts/demo/ingest/documents.jsonl"),
     readJsonl<ChunkRow>("artifacts/demo/ingest/chunks.jsonl"),
     readJson<GraphPayload>("artifacts/demo/graph/graph.json"),
-    readJson<ScenarioPayload>("artifacts/demo/scenario/baseline.json"),
-    readJson<ScenarioPayload>("artifacts/demo/scenario/reporter_detained.json")
+    listJsonBaseNames("artifacts/demo/scenario")
   ]);
 
-  const [baselineRun, interventionRun] = await Promise.all([
-    loadRunPayload("baseline", "baseline", "Baseline", baselineScenario),
-    loadRunPayload("reporter_detained", "reporter_detained", "Intervention", interventionScenario)
-  ]);
+  const runs = await Promise.all(
+    scenarioKeys.map(async (key) => {
+      const scenario = await readJson<ScenarioPayload>(`artifacts/demo/scenario/${key}.json`);
+      return loadRunPayload(key, scenario);
+    })
+  );
+
+  const runsByKey = new Map(runs.map((run) => [run.key, run]));
+  const baselineRun = runsByKey.get("baseline") ?? runs[0];
+
+  if (!baselineRun) {
+    throw new Error("Expected at least one canonical demo run.");
+  }
+
+  const comparisonRuns = runs.filter((run) => run.key !== baselineRun.key);
+  const reportComparisonRun = runsByKey.get("reporter_detained") ?? comparisonRuns[0] ?? baselineRun;
 
   return {
     report,
@@ -231,8 +272,11 @@ async function loadWorkbenchData() {
     documents,
     chunks,
     graph,
+    runs,
+    runsByKey,
     baselineRun,
-    interventionRun
+    comparisonRuns,
+    reportComparisonRun
   };
 }
 
@@ -241,6 +285,21 @@ function formatValue(value: unknown) {
     return value;
   }
   return JSON.stringify(value) ?? "undefined";
+}
+
+function formatTurnLabel(turn: number | null | undefined) {
+  return typeof turn === "number" ? `T${turn}` : "not reached";
+}
+
+function formatDeltaLabel(delta: number | null) {
+  if (delta === null) {
+    return "n/a";
+  }
+  if (delta === 0) {
+    return "0 turns";
+  }
+  const prefix = delta > 0 ? "+" : "-";
+  return `${prefix}${Math.abs(delta)} turn${Math.abs(delta) === 1 ? "" : "s"}`;
 }
 
 function buildTurnEntries(run: RunPayload): TurnEntry[] {
@@ -269,7 +328,8 @@ function stateHighlights(state: Record<string, unknown> | undefined) {
     "evacuation_turn",
     "public_pressure",
     "command_post",
-    "mayor_alerted"
+    "mayor_alerted",
+    "communications_status"
   ];
 
   return keys.flatMap((key) => {
@@ -322,6 +382,162 @@ function parseRubricRows(rubric: string): RubricRow[] {
   ];
 }
 
+type ComparisonRow = {
+  turnIndex: number;
+  baseline: TurnEntry | null;
+  candidate: TurnEntry | null;
+  divergent: boolean;
+};
+
+type ComparisonOverview = {
+  run: RunPayload;
+  rows: ComparisonRow[];
+  divergentTurnCount: number;
+  ledgerDelta: number | null;
+  evacuationDelta: number | null;
+  directWarningPath: boolean;
+  summaryLines: string[];
+};
+
+function turnsDiffer(baseline: TurnEntry | null, candidate: TurnEntry | null) {
+  if (!baseline || !candidate) {
+    return baseline !== candidate;
+  }
+
+  return (
+    baseline.turn.action_type !== candidate.turn.action_type ||
+    baseline.turn.target_id !== candidate.turn.target_id ||
+    baseline.turn.actor_id !== candidate.turn.actor_id
+  );
+}
+
+function buildComparisonRows(baselineRun: RunPayload, candidateRun: RunPayload): ComparisonRow[] {
+  const baselineTurns = buildTurnEntries(baselineRun);
+  const candidateTurns = buildTurnEntries(candidateRun);
+
+  return Array.from(
+    { length: Math.max(baselineTurns.length, candidateTurns.length) },
+    (_, index) => {
+      const baseline = baselineTurns[index] ?? null;
+      const candidate = candidateTurns[index] ?? null;
+
+      return {
+        turnIndex: index + 1,
+        baseline,
+        candidate,
+        divergent: turnsDiffer(baseline, candidate)
+      };
+    }
+  );
+}
+
+function firstDirectWarningTurn(run: RunPayload) {
+  const directWarningTurn = run.actions.find(
+    (action) => action.action_type === "inform" && action.target_id === "persona_zhao_ke"
+  );
+
+  return directWarningTurn?.turn_index ?? null;
+}
+
+function hasDirectWarningPath(run: RunPayload) {
+  return firstDirectWarningTurn(run) !== null;
+}
+
+function describeMetricDelta(
+  label: string,
+  baselineTurn: number | undefined,
+  candidateTurn: number | undefined
+) {
+  if (typeof baselineTurn !== "number" && typeof candidateTurn !== "number") {
+    return `${label} never lands in either branch.`;
+  }
+
+  if (typeof baselineTurn === "number" && typeof candidateTurn !== "number") {
+    return `${label} never lands in this intervention branch.`;
+  }
+
+  if (typeof baselineTurn !== "number" && typeof candidateTurn === "number") {
+    return `${label} appears only in this intervention branch at ${formatTurnLabel(candidateTurn)}.`;
+  }
+
+  const resolvedBaselineTurn = baselineTurn as number;
+  const resolvedCandidateTurn = candidateTurn as number;
+  const delta = resolvedCandidateTurn - resolvedBaselineTurn;
+
+  if (delta > 0) {
+    return `${label} slips by ${delta} turn${delta === 1 ? "" : "s"} to ${formatTurnLabel(resolvedCandidateTurn)}.`;
+  }
+
+  if (delta < 0) {
+    return `${label} lands ${Math.abs(delta)} turn${Math.abs(delta) === 1 ? "" : "s"} earlier at ${formatTurnLabel(resolvedCandidateTurn)}.`;
+  }
+
+  return `${label} stays on the baseline timing at ${formatTurnLabel(resolvedCandidateTurn)}.`;
+}
+
+function describeWarningPath(baselineRun: RunPayload, candidateRun: RunPayload) {
+  const baselineWarningTurn = firstDirectWarningTurn(baselineRun);
+  const candidateWarningTurn = firstDirectWarningTurn(candidateRun);
+
+  if (baselineWarningTurn === null && candidateWarningTurn === null) {
+    return "No direct warning path to Zhao Ke appears in either branch.";
+  }
+
+  if (baselineWarningTurn !== null && candidateWarningTurn === null) {
+    return "The direct warning path to Zhao Ke drops out of this branch.";
+  }
+
+  if (baselineWarningTurn === null && candidateWarningTurn !== null) {
+    return `A direct warning path to Zhao Ke appears only in this branch at ${formatTurnLabel(candidateWarningTurn)}.`;
+  }
+
+  if (baselineWarningTurn === candidateWarningTurn) {
+    return `The direct warning path to Zhao Ke still lands at ${formatTurnLabel(candidateWarningTurn)}.`;
+  }
+
+  return `The direct warning path to Zhao Ke shifts from ${formatTurnLabel(baselineWarningTurn)} to ${formatTurnLabel(candidateWarningTurn)}.`;
+}
+
+function buildComparisonOverview(
+  baselineRun: RunPayload,
+  candidateRun: RunPayload
+): ComparisonOverview {
+  const rows = buildComparisonRows(baselineRun, candidateRun);
+  const divergentTurnCount = rows.filter((row) => row.divergent).length;
+  const ledgerDelta =
+    typeof candidateRun.summary.ledger_public_turn === "number" &&
+    typeof baselineRun.summary.ledger_public_turn === "number"
+      ? candidateRun.summary.ledger_public_turn - baselineRun.summary.ledger_public_turn
+      : null;
+  const evacuationDelta =
+    typeof candidateRun.summary.evacuation_turn === "number" &&
+    typeof baselineRun.summary.evacuation_turn === "number"
+      ? candidateRun.summary.evacuation_turn - baselineRun.summary.evacuation_turn
+      : null;
+
+  return {
+    run: candidateRun,
+    rows,
+    divergentTurnCount,
+    ledgerDelta,
+    evacuationDelta,
+    directWarningPath: hasDirectWarningPath(candidateRun),
+    summaryLines: [
+      describeMetricDelta(
+        "Ledger publication",
+        baselineRun.summary.ledger_public_turn,
+        candidateRun.summary.ledger_public_turn
+      ),
+      describeMetricDelta(
+        "Evacuation",
+        baselineRun.summary.evacuation_turn,
+        candidateRun.summary.evacuation_turn
+      ),
+      describeWarningPath(baselineRun, candidateRun)
+    ]
+  };
+}
+
 export default async function Page() {
   const {
     report,
@@ -331,16 +547,17 @@ export default async function Page() {
     documents,
     chunks,
     graph,
+    runs,
+    runsByKey,
     baselineRun,
-    interventionRun
+    comparisonRuns,
+    reportComparisonRun
   } = await loadWorkbenchData();
 
   const rubricRows = parseRubricRows(rubric);
   const documentsById = new Map(documents.map((document) => [document.document_id, document]));
   const chunksById = new Map(chunks.map((chunk) => [chunk.chunk_id, chunk]));
-  const baselineTurns = buildTurnEntries(baselineRun);
-  const interventionTurns = buildTurnEntries(interventionRun);
-  const allTurns = [...baselineTurns, ...interventionTurns];
+  const allTurns = runs.flatMap(buildTurnEntries);
   const turnsById = new Map(allTurns.map((entry) => [entry.turn.turn_id, entry]));
   const claimIdsByTurnId = new Map<string, string[]>();
 
@@ -373,9 +590,9 @@ export default async function Page() {
       .map((turnId) => turnsById.get(turnId))
       .filter((entry): entry is TurnEntry => Boolean(entry));
 
-    const scenarioContext = Array.from(new Set(relatedTurns.map((entry) => entry.scenarioKey))).map((scenarioKey) =>
-      scenarioKey === "baseline" ? baselineRun : interventionRun
-    );
+    const scenarioContext = Array.from(new Set(relatedTurns.map((entry) => entry.scenarioKey)))
+      .map((scenarioKey) => runsByKey.get(scenarioKey))
+      .filter((run): run is RunPayload => Boolean(run));
 
     return {
       claim,
@@ -386,35 +603,46 @@ export default async function Page() {
     };
   });
 
-  const timelineRows = Array.from(
-    { length: Math.max(baselineTurns.length, interventionTurns.length) },
-    (_, index) => ({
-      turnIndex: index + 1,
-      baseline: baselineTurns[index] ?? null,
-      intervention: interventionTurns[index] ?? null
-    })
-  );
+  const comparisonOverviews = comparisonRuns.map((run) => buildComparisonOverview(baselineRun, run));
+  const reportComparison =
+    comparisonOverviews.find((overview) => overview.run.key === reportComparisonRun.key) ?? null;
+  const delayedEvacuationCount = comparisonOverviews.filter(
+    (overview) => (overview.evacuationDelta ?? 0) > 0
+  ).length;
+  const delayedLedgerCount = comparisonOverviews.filter(
+    (overview) => (overview.ledgerDelta ?? 0) > 0
+  ).length;
+  const lostDirectWarningCount = comparisonOverviews.filter(
+    (overview) => !overview.directWarningPath
+  ).length;
 
   return (
     <main className="shell">
       <section className="hero">
-        <p className="eyebrow">Mirror Engine / Phase 5 Review Sign-Off</p>
-        <h1>Review the Fog Harbor sandbox with evidence, trace, and branch context in one place.</h1>
+        <p className="eyebrow">Mirror Engine / Phase 44 Counterfactual Workbench</p>
+        <h1>Start with the scenario matrix, then drop into trace, evidence, and eval.</h1>
         <p className="lede">
-          The workbench now stays artifact-first while extending the reviewer path:
-          from claim, to evidence, to branch timeline, to a live sign-off worksheet inside the bounded demo world.
+          The workbench now leads with artifact-backed counterfactual deltas across the canonical
+          Fog Harbor matrix, so reviewers can answer which intervention changed what before they
+          drill into turn-by-turn trace, claims, evidence, or the eval summary.
         </p>
         <div className="heroMeta">
           <span>Current demo: Fog Harbor East Gate</span>
-          <span>Current phase: review sign-off and evidence packaging</span>
-          <span>No backend API expansion required</span>
+          <span>{runs.length} canonical scenario branches loaded</span>
+          <span>{comparisonRuns.length} intervention comparisons against baseline</span>
+          <span>
+            Current report pair: baseline vs {reportComparisonRun.scenario.title}
+          </span>
+          <span>
+            {evalSummary.eval_name}: {evalSummary.status}
+          </span>
         </div>
       </section>
 
       <section className="panel">
         <div className="panelHeader">
           <p className="eyebrow">Workbench Spine</p>
-          <h2>Each review step still maps directly to the durable artifact tree.</h2>
+          <h2>Each step in the matrix-to-review path still maps directly to durable artifacts.</h2>
         </div>
         <div className="grid">
           {sections.map((section) => (
@@ -429,20 +657,161 @@ export default async function Page() {
 
       <section className="panel panelAccent">
         <div className="panelHeader">
-          <p className="eyebrow">Phase 5 Slice</p>
-          <h2>The current successor slice turns review context into sign-off context.</h2>
+          <p className="eyebrow">Phase 44 Slice</p>
+          <h2>The default operator path is now compare, then trace, then claim and evidence, then eval.</h2>
         </div>
         <ul className="checklist">
-          <li>Claim cards now link into their supporting evidence, graph context, and branch turns.</li>
-          <li>Baseline and intervention runs now surface as a reviewer-readable turn-by-turn timeline.</li>
-          <li>Reviewer scorecards and sign-off worksheets now live on top of the same artifacts, still without backend API expansion.</li>
+          <li>The workbench opens with a four-branch scenario matrix instead of a single intervention lane.</li>
+          <li>Each intervention card now links straight into pairwise trace diff, claim and evidence review, and the eval summary.</li>
+          <li>
+            The current report artifacts still come from the canonical baseline vs reporter-detained
+            pair, so that narrower report contract stays explicit rather than being implied across
+            all branches.
+          </li>
         </ul>
       </section>
 
-      <section className="panel">
+      <section className="panel panelAccent" id="compare-overview">
         <div className="panelHeader">
-          <p className="eyebrow">Report</p>
-          <h2>Current branch report and evidence-labeled claims.</h2>
+          <p className="eyebrow">Counterfactual Overview</p>
+          <h2>See which intervention changes the outcome, which only changes the route, and where to inspect next.</h2>
+        </div>
+        <div className="metricGrid">
+          <div className="metricCard">
+            <span>scenario branches</span>
+            <strong>{runs.length}</strong>
+          </div>
+          <div className="metricCard">
+            <span>intervention branches</span>
+            <strong>{comparisonRuns.length}</strong>
+          </div>
+          <div className="metricCard">
+            <span>delayed ledger branches</span>
+            <strong>{delayedLedgerCount}</strong>
+          </div>
+          <div className="metricCard">
+            <span>delayed evacuation branches</span>
+            <strong>{delayedEvacuationCount}</strong>
+          </div>
+          <div className="metricCard">
+            <span>lost direct warning path</span>
+            <strong>{lostDirectWarningCount}</strong>
+          </div>
+        </div>
+        <div className="comparisonOverviewGrid">
+          <article className="artifactCard">
+            <div className="artifactMeta">
+              <span>baseline</span>
+              <code>artifacts/demo/run/{baselineRun.key}/summary.json</code>
+            </div>
+            <div className="claimHeader">
+              <strong>{baselineRun.scenario.title}</strong>
+              <span className="pill">reference branch</span>
+            </div>
+            <p>{baselineRun.scenario.description}</p>
+            <div className="claimEvidence">
+              <code>{baselineRun.scenario.scenario_id}</code>
+              <code>turn_budget={baselineRun.scenario.turn_budget}</code>
+              <code>injections={baselineRun.scenario.injections.length}</code>
+            </div>
+            <div className="metricGrid">
+              <div className="metricCard">
+                <span>ledger public</span>
+                <strong>{formatTurnLabel(baselineRun.summary.ledger_public_turn)}</strong>
+              </div>
+              <div className="metricCard">
+                <span>evacuation</span>
+                <strong>{formatTurnLabel(baselineRun.summary.evacuation_turn)}</strong>
+              </div>
+              <div className="metricCard">
+                <span>direct warning</span>
+                <strong>{formatTurnLabel(firstDirectWarningTurn(baselineRun) ?? undefined)}</strong>
+              </div>
+            </div>
+            <ul className="checklist compact">
+              <li>Baseline keeps the direct warning path to Zhao Ke intact.</li>
+              <li>Ledger publication becomes public at {formatTurnLabel(baselineRun.summary.ledger_public_turn)}.</li>
+              <li>Evacuation triggers at {formatTurnLabel(baselineRun.summary.evacuation_turn)}.</li>
+            </ul>
+            <div className="claimEvidence">
+              <a className="linkPill" href="#scenario-matrix">
+                Scenario JSON
+              </a>
+              <a className="linkPill" href="#trace-diff">
+                Trace compare
+              </a>
+              <a className="linkPill" href="#eval-summary">
+                Eval summary
+              </a>
+            </div>
+          </article>
+
+          {comparisonOverviews.map((overview) => (
+            <article key={overview.run.key} className="artifactCard">
+              <div className="artifactMeta">
+                <span>{overview.run.label}</span>
+                <code>artifacts/demo/run/{overview.run.key}/summary.json</code>
+              </div>
+              <div className="claimHeader">
+                <strong>{overview.run.scenario.title}</strong>
+                <span className="pill">{overview.divergentTurnCount} divergent turns</span>
+              </div>
+              <p>{overview.run.scenario.description}</p>
+              <div className="claimEvidence">
+                <code>{overview.run.scenario.scenario_id}</code>
+                <code>ledger delta {formatDeltaLabel(overview.ledgerDelta)}</code>
+                <code>evacuation delta {formatDeltaLabel(overview.evacuationDelta)}</code>
+              </div>
+              <div className="claimEvidence">
+                {overview.run.scenario.injections.map((injection) => (
+                  <code key={injection.injection_id}>{injection.kind}</code>
+                ))}
+                <span className="pill">
+                  {overview.directWarningPath ? "direct warning preserved" : "direct warning lost"}
+                </span>
+              </div>
+              <div className="metricGrid">
+                <div className="metricCard">
+                  <span>ledger public</span>
+                  <strong>{formatTurnLabel(overview.run.summary.ledger_public_turn)}</strong>
+                </div>
+                <div className="metricCard">
+                  <span>evacuation</span>
+                  <strong>{formatTurnLabel(overview.run.summary.evacuation_turn)}</strong>
+                </div>
+                <div className="metricCard">
+                  <span>direct warning</span>
+                  <strong>{formatTurnLabel(firstDirectWarningTurn(overview.run) ?? undefined)}</strong>
+                </div>
+              </div>
+              <ul className="checklist compact">
+                {overview.summaryLines.map((line) => (
+                  <li key={line}>{line}</li>
+                ))}
+              </ul>
+              {overview.run.summary.notes.length > 1 ? (
+                <p className="subtle">{overview.run.summary.notes.slice(1).join(" ")}</p>
+              ) : null}
+              <div className="claimEvidence">
+                <a className="linkPill" href={`#compare-${overview.run.key}`}>
+                  Trace diff
+                </a>
+                <a className="linkPill" href="#report-claims">
+                  Claim and evidence
+                </a>
+                <a className="linkPill" href="#eval-summary">
+                  Eval summary
+                </a>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="panel" id="report-claims">
+        <div className="panelHeader">
+          <p className="eyebrow">Report Pair</p>
+          <h2>Current report artifacts remain explicit about the canonical baseline vs reporter-detained comparison.</h2>
         </div>
         <div className="reportGrid">
           <article className="artifactCard artifactCardWide">
@@ -450,6 +819,18 @@ export default async function Page() {
               <span>artifact</span>
               <code>artifacts/demo/report/report.md</code>
             </div>
+            <div className="claimEvidence">
+              <code>baseline</code>
+              <code>{reportComparisonRun.key}</code>
+              <a className="linkPill" href={`#compare-${reportComparisonRun.key}`}>
+                Open canonical trace diff
+              </a>
+            </div>
+            <p>
+              The report layer is still generated from the baseline vs reporter-detained pair, which
+              keeps the current claim and evidence contract honest while the new matrix overview
+              broadens the top-level comparison surface.
+            </p>
             <pre className="artifactPre">{report}</pre>
           </article>
           <article className="artifactCard">
@@ -490,10 +871,10 @@ export default async function Page() {
         </div>
       </section>
 
-      <section className="panel">
+      <section className="panel" id="claim-drilldowns">
         <div className="panelHeader">
           <p className="eyebrow">Claim Drill-Down</p>
-          <h2>Move from each claim into supporting evidence, graph context, and trace context.</h2>
+          <h2>Move from each claim into supporting evidence, graph context, and the specific branch turns behind it.</h2>
         </div>
         <div className="drilldownGrid">
           {claimDrilldowns.map(({ claim, evidenceChunks, graphContext, relatedTurns, scenarioContext }) => (
@@ -531,7 +912,7 @@ export default async function Page() {
                       <article key={run.scenario.scenario_id} className="docCard">
                         <div className="claimHeader">
                           <strong>{run.scenario.title}</strong>
-                          <span className="pill">{run.title}</span>
+                          <span className="pill">{run.label}</span>
                         </div>
                         <p>{run.scenario.description}</p>
                         <div className="claimEvidence">
@@ -734,136 +1115,145 @@ export default async function Page() {
 
       <section className="panel">
         <div className="panelHeader">
-          <p className="eyebrow">Scenario</p>
-          <h2>Normalized baseline and intervention scenarios stay visible in the browser.</h2>
+          <p className="eyebrow">Scenario Matrix</p>
+          <h2>All canonical scenario artifacts stay visible, normalized, and branch-comparable.</h2>
         </div>
-        <div className="reportGrid">
-          <article className="artifactCard">
-            <div className="artifactMeta">
-              <span>artifact</span>
-              <code>artifacts/demo/scenario/baseline.json</code>
-            </div>
-            <div className="claimHeader">
-              <strong>{baselineRun.scenario.title}</strong>
-              <span className="pill">{baselineRun.scenario.scenario_id}</span>
-            </div>
-            <div className="claimEvidence">
-              <code>turn_budget={baselineRun.scenario.turn_budget}</code>
-              <code>branch_count={baselineRun.scenario.branch_count}</code>
-            </div>
-            <pre className="artifactPre artifactPreCompact">
-              {JSON.stringify(baselineRun.scenario, null, 2)}
-            </pre>
-          </article>
-
-          <article className="artifactCard">
-            <div className="artifactMeta">
-              <span>artifact</span>
-              <code>artifacts/demo/scenario/reporter_detained.json</code>
-            </div>
-            <div className="claimHeader">
-              <strong>{interventionRun.scenario.title}</strong>
-              <span className="pill">{interventionRun.scenario.scenario_id}</span>
-            </div>
-            <div className="claimEvidence">
-              <code>turn_budget={interventionRun.scenario.turn_budget}</code>
-              <code>branch_count={interventionRun.scenario.branch_count}</code>
-              <code>injections={interventionRun.scenario.injections.length}</code>
-            </div>
-            <pre className="artifactPre artifactPreCompact">
-              {JSON.stringify(interventionRun.scenario, null, 2)}
-            </pre>
-          </article>
+        <div className="scenarioGrid" id="scenario-matrix">
+          {runs.map((run) => (
+            <article key={run.key} className="artifactCard">
+              <div className="artifactMeta">
+                <span>{run.label}</span>
+                <code>artifacts/demo/scenario/{run.key}.json</code>
+              </div>
+              <div className="claimHeader">
+                <strong>{run.scenario.title}</strong>
+                <span className="pill">{run.scenario.scenario_id}</span>
+              </div>
+              <p>{run.scenario.description}</p>
+              <div className="claimEvidence">
+                <code>turn_budget={run.scenario.turn_budget}</code>
+                <code>branch_count={run.scenario.branch_count}</code>
+                <code>injections={run.scenario.injections.length}</code>
+              </div>
+              <pre className="artifactPre artifactPreCompact">
+                {JSON.stringify(run.scenario, null, 2)}
+              </pre>
+            </article>
+          ))}
         </div>
       </section>
 
-      <section className="panel">
+      <section className="panel" id="trace-diff">
         <div className="panelHeader">
-          <p className="eyebrow">Run Timeline</p>
-          <h2>Compare baseline and intervention turns with trace, state patch, and snapshot state.</h2>
+          <p className="eyebrow">Pairwise Trace Diff</p>
+          <h2>Compare the baseline against each intervention with trace, state patch, and highlighted snapshot state.</h2>
         </div>
-        <div className="timelineRows">
-          {timelineRows.map(({ turnIndex, baseline, intervention }) => {
-            const divergent =
-              baseline?.turn.action_type !== intervention?.turn.action_type ||
-              baseline?.turn.target_id !== intervention?.turn.target_id;
-
-            return (
-              <article key={turnIndex} className={`timelineRow${divergent ? " timelineRowDivergent" : ""}`}>
-                <div className="claimHeader">
-                  <strong>Turn {turnIndex}</strong>
-                  <span className="pill">{divergent ? "branch divergence" : "same step"}</span>
-                </div>
-                <div className="timelineCards">
-                  {[baseline, intervention].map((entry, index) => (
-                    <section
-                      key={index === 0 ? "baseline" : "intervention"}
-                      id={entry ? `turn-${entry.turn.turn_id}` : undefined}
-                      className={`timelineCard${entry ? "" : " timelineCardEmpty"}`}
-                    >
-                      {entry ? (
-                        <>
-                          <div className="artifactMeta">
-                            <span>{entry.scenarioKey === "baseline" ? "baseline" : "intervention"}</span>
-                            <code>{entry.turn.turn_id}</code>
-                          </div>
-                          <div className="claimHeader">
-                            <strong>{entry.turn.action_type}</strong>
-                            <span className="pill">{entry.turn.actor_id}</span>
-                          </div>
-                          <p>{entry.turn.rationale}</p>
-                          <div className="claimEvidence">
-                            {entry.turn.target_id ? <code>{entry.turn.target_id}</code> : null}
-                            {claimIdsByTurnId.get(entry.turn.turn_id)?.map((claimId) => (
-                              <a key={claimId} className="linkPill" href={`#drill-${claimId}`}>
-                                {claimId}
-                              </a>
-                            ))}
-                          </div>
-                          <div className="claimEvidence">
-                            {entry.turn.evidence_ids.map((evidenceId) => (
-                              <a key={evidenceId} className="linkPill" href={`#chunk-${evidenceId}`}>
-                                {evidenceId}
-                              </a>
-                            ))}
-                          </div>
-                          <div className="timelineState">
-                            {Object.keys(entry.turn.state_patch).length > 0 ? (
-                              Object.entries(entry.turn.state_patch).map(([key, value]) => (
-                                <code key={key}>
-                                  {key}={formatValue(value)}
-                                </code>
-                              ))
-                            ) : (
-                              <span className="subtle">no state patch</span>
-                            )}
-                          </div>
-                          <div className="timelineState">
-                            {stateHighlights(entry.snapshot?.state).length > 0 ? (
-                              stateHighlights(entry.snapshot?.state).map((highlight) => (
-                                <code key={highlight}>{highlight}</code>
-                              ))
-                            ) : (
-                              <span className="subtle">no highlighted snapshot state</span>
-                            )}
-                          </div>
-                        </>
-                      ) : (
-                        <span className="subtle">No turn recorded for this branch.</span>
-                      )}
-                    </section>
-                  ))}
-                </div>
-              </article>
-            );
-          })}
+        <div className="detailList">
+          {comparisonOverviews.map((overview) => (
+            <article key={overview.run.key} id={`compare-${overview.run.key}`} className="artifactCard">
+              <div className="artifactMeta">
+                <span>compare</span>
+                <code>baseline -&gt; {overview.run.key}</code>
+              </div>
+              <div className="claimHeader">
+                <strong>{baselineRun.scenario.title} vs {overview.run.scenario.title}</strong>
+                <span className="pill">{overview.divergentTurnCount} divergent turns</span>
+              </div>
+              <p>{overview.summaryLines.join(" ")}</p>
+              <div className="claimEvidence">
+                <a className="linkPill" href="#report-claims">
+                  Jump to claims
+                </a>
+                <a className="linkPill" href="#claim-drilldowns">
+                  Jump to drill-down
+                </a>
+                <a className="linkPill" href="#eval-summary">
+                  Jump to eval
+                </a>
+              </div>
+              <div className="timelineRows">
+                {overview.rows.map(({ turnIndex, baseline, candidate, divergent }) => (
+                  <article
+                    key={`${overview.run.key}-turn-${turnIndex}`}
+                    className={`timelineRow${divergent ? " timelineRowDivergent" : ""}`}
+                  >
+                    <div className="claimHeader">
+                      <strong>Turn {turnIndex}</strong>
+                      <span className="pill">{divergent ? "branch divergence" : "same step"}</span>
+                    </div>
+                    <div className="timelineCards">
+                      {[baseline, candidate].map((entry, index) => (
+                        <section
+                          key={index === 0 ? `${overview.run.key}-baseline` : `${overview.run.key}-candidate`}
+                          id={entry ? `turn-${entry.turn.turn_id}` : undefined}
+                          className={`timelineCard${entry ? "" : " timelineCardEmpty"}`}
+                        >
+                          {entry ? (
+                            <>
+                              <div className="artifactMeta">
+                                <span>{index === 0 ? "baseline" : "candidate"}</span>
+                                <code>{entry.turn.turn_id}</code>
+                              </div>
+                              <div className="claimHeader">
+                                <strong>{entry.turn.action_type}</strong>
+                                <span className="pill">{entry.turn.actor_id}</span>
+                              </div>
+                              <p>{entry.turn.rationale}</p>
+                              <div className="claimEvidence">
+                                <code>{entry.scenarioTitle}</code>
+                                {entry.turn.target_id ? <code>{entry.turn.target_id}</code> : null}
+                                {claimIdsByTurnId.get(entry.turn.turn_id)?.map((claimId) => (
+                                  <a key={claimId} className="linkPill" href={`#drill-${claimId}`}>
+                                    {claimId}
+                                  </a>
+                                ))}
+                              </div>
+                              <div className="claimEvidence">
+                                {entry.turn.evidence_ids.map((evidenceId) => (
+                                  <a key={evidenceId} className="linkPill" href={`#chunk-${evidenceId}`}>
+                                    {evidenceId}
+                                  </a>
+                                ))}
+                              </div>
+                              <div className="timelineState">
+                                {Object.keys(entry.turn.state_patch).length > 0 ? (
+                                  Object.entries(entry.turn.state_patch).map(([key, value]) => (
+                                    <code key={key}>
+                                      {key}={formatValue(value)}
+                                    </code>
+                                  ))
+                                ) : (
+                                  <span className="subtle">no state patch</span>
+                                )}
+                              </div>
+                              <div className="timelineState">
+                                {stateHighlights(entry.snapshot?.state).length > 0 ? (
+                                  stateHighlights(entry.snapshot?.state).map((highlight) => (
+                                    <code key={highlight}>{highlight}</code>
+                                  ))
+                                ) : (
+                                  <span className="subtle">no highlighted snapshot state</span>
+                                )}
+                              </div>
+                            </>
+                          ) : (
+                            <span className="subtle">No turn recorded for this branch.</span>
+                          )}
+                        </section>
+                      ))}
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </article>
+          ))}
         </div>
       </section>
 
-      <section className="panel">
+      <section className="panel" id="eval-summary">
         <div className="panelHeader">
           <p className="eyebrow">Eval And Review</p>
-          <h2>Machine summary and human rubric stay visible side-by-side.</h2>
+          <h2>The matrix-level machine summary stays visible beside the human review rubric.</h2>
         </div>
         <div className="reportGrid">
           <article className="artifactCard">
@@ -905,10 +1295,7 @@ export default async function Page() {
       <ReviewScorecard
         rubricRows={rubricRows}
         claimCount={claims.length}
-        divergentTurnCount={timelineRows.filter(({ baseline, intervention }) => (
-          baseline?.turn.action_type !== intervention?.turn.action_type ||
-          baseline?.turn.target_id !== intervention?.turn.target_id
-        )).length}
+        divergentTurnCount={reportComparison?.divergentTurnCount ?? 0}
         evalName={evalSummary.eval_name}
         evalStatus={evalSummary.status}
         claimPackets={claims.map((claim) => ({
@@ -916,17 +1303,14 @@ export default async function Page() {
           text: claim.text,
           relatedTurnIds: claim.related_turn_ids.filter(Boolean)
         }))}
-        divergentTurns={timelineRows
-          .filter(({ baseline, intervention }) => (
-            baseline?.turn.action_type !== intervention?.turn.action_type ||
-            baseline?.turn.target_id !== intervention?.turn.target_id
-          ))
-          .map(({ turnIndex, baseline, intervention }) => ({
+        divergentTurns={(reportComparison?.rows ?? [])
+          .filter((row) => row.divergent)
+          .map(({ turnIndex, baseline, candidate }) => ({
             turnIndex,
             baselineTurnId: baseline?.turn.turn_id ?? null,
             baselineAction: baseline?.turn.action_type ?? null,
-            interventionTurnId: intervention?.turn.turn_id ?? null,
-            interventionAction: intervention?.turn.action_type ?? null
+            interventionTurnId: candidate?.turn.turn_id ?? null,
+            interventionAction: candidate?.turn.action_type ?? null
           }))}
       />
     </main>


### PR DESCRIPTION
## Summary
- replace the single-intervention homepage flow with a comparison-first Phase 44 workbench overview
- discover canonical scenario artifacts dynamically and render matrix cards for all current branches
- add pairwise baseline-to-intervention trace sections and keep the existing report/claim contract explicit

## Testing
- python -m backend.app.cli classify-lane --files frontend/src/app/page.tsx frontend/src/app/globals.css
- npm run build --prefix frontend
- ./make.ps1 smoke
- ./make.ps1 eval-demo

Closes #316