### PR TITLE
[codex] Bootstrap Phase 45 successor queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -175,6 +175,10 @@
     {
       "title": "Phase 44 - Counterfactual Depth and Eval Hardening",
       "description": "Turn the formal v0.1.0 release stop-state into a counterfactual-depth queue that expands the canonical scenario matrix, hardens eval coverage, and adds a comparison-first workbench entrypoint without changing scenario DSL, claim labels, or artifact roots."
+    },
+    {
+      "title": "Phase 45 - Branch Generalization and Compare Contracts",
+      "description": "Turn the Phase 44 counterfactual matrix into a formal multi-branch compare contract by ratifying branch-count semantics, durable compare artifacts, and focused diff consumption without widening the product surface."
     }
   ],
   "labels": [
@@ -397,6 +401,11 @@
       "name": "phase:44",
       "color": "FFF4D6",
       "description": "Phase 44 counterfactual depth and eval hardening work."
+    },
+    {
+      "name": "phase:45",
+      "color": "FFE2B8",
+      "description": "Phase 45 branch generalization and compare contract work."
     },
     {
       "name": "area:backend",
@@ -2371,6 +2380,64 @@
         "lane:auto-safe"
       ],
       "body": "## Summary\nAdd a comparison-first workbench overview that makes the scenario matrix, outcome deltas, and direct trace/evidence entrypoints visible at the top level.\n\n## Scope\n- add a scenario-matrix summary surface to the existing workbench using current artifact files only\n- highlight which intervention changes which key outcomes before the reviewer drops into detailed traces\n- link the overview directly into trace-diff and claim/evidence surfaces\n- avoid expanding the existing handoff/export packet family in this slice\n\n## Constraints\n- no backend API additions\n- no artifact schema changes\n- keep the default operator path focused on compare -> trace -> claim/evidence -> eval"
+    },
+    {
+      "title": "Phase 45 exit gate",
+      "milestone": "Phase 45 - Branch Generalization and Compare Contracts",
+      "labels": [
+        "phase:45",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "Close this issue only after the full Phase 45 branch-generalization queue is complete.\n\nExit criteria:\n- the Phase 45 queue-sync issue is merged\n- the multi-branch compare ADR and contracts issue is merged\n- the branch-count runner and compare-artifact issue is merged\n- the focused diff-surface issue is merged\n- `./make.ps1 smoke` passes\n- `./make.ps1 test` passes\n- `./make.ps1 eval-demo` passes\n- `python -m backend.app.cli audit-phase phase1` passes\n- `python -m backend.app.cli audit-phase phase2` passes\n- `python -m backend.app.cli audit-phase phase3` passes\n- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` returns `ready`\n- the Phase 46 milestone is open and the Phase 46 queue-sync issue exists before closeout"
+    },
+    {
+      "title": "Phase 45: sync repo truth to Phase 45 queue",
+      "milestone": "Phase 45 - Branch Generalization and Compare Contracts",
+      "labels": [
+        "phase:45",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## Summary\nSync the repo truth from the closing Phase 44 queue to the active Phase 45 queue.\n\n## Scope\n- add the Phase 45 milestone, label, and issue definitions to the bootstrap spec\n- update README and active-state docs to show Phase 45 as the sole active queue after Phase 44 closeout\n- keep Phase 46 documented as the next successor direction without opening it yet\n- create the Phase 45 milestone and issues from the updated bootstrap spec\n- complete the GitHub closeout handoff from Phase 44 to Phase 45\n\n## Constraints\n- no simulation, report, claim, evidence, scenario, or schema contract changes\n- do not leave more than one active execution milestone open after closeout\n- no backend/runtime behavior changes beyond queue-governance sync"
+    },
+    {
+      "title": "Phase 45: ratify multi-branch compare ADR and contracts",
+      "milestone": "Phase 45 - Branch Generalization and Compare Contracts",
+      "labels": [
+        "phase:45",
+        "area:docs-evals",
+        "risk:core-contract",
+        "status:needs-adr",
+        "lane:protected-core"
+      ],
+      "body": "## Summary\nRatify the ADR and contract changes needed to turn the current scenario matrix habit into a formal multi-branch compare contract.\n\n## Scope\n- define how `branch_count` moves from a reserved field to an executable multi-branch contract\n- define the durable compare-artifact shape and the backend/frontend responsibilities around it\n- define how report, claim, and eval surfaces consume multi-branch compare results\n- record any backward-compatibility rules needed for the current demo artifacts\n\n## Constraints\n- do not implement the runner or artifact contract in this issue\n- do not widen the scenario DSL beyond what the ADR explicitly ratifies\n- keep the decision grounded in the existing Fog Harbor artifact flow"
+    },
+    {
+      "title": "Phase 45: implement branch_count runner and compare artifacts",
+      "milestone": "Phase 45 - Branch Generalization and Compare Contracts",
+      "labels": [
+        "phase:45",
+        "area:backend",
+        "risk:core-contract",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "## Summary\nImplement the runner and artifact work needed to make `branch_count` a real execution capability.\n\n## Scope\n- extend the simulation runner so one scenario can execute into multiple deterministic branches under the ratified contract\n- emit durable compare artifacts that can be consumed without frontend-only reconstruction\n- keep reruns stable for the canonical multi-branch demo path\n- preserve compatibility for existing single-branch or baseline-first artifact consumers where explicitly required by contract\n\n## Constraints\n- do not start until the Phase 45 ADR/contracts issue is merged\n- do not expand the scenario DSL beyond the ratified contract\n- do not add unrelated product surfaces in this issue"
+    },
+    {
+      "title": "Phase 45: consume compare artifacts in focused diff surfaces",
+      "milestone": "Phase 45 - Branch Generalization and Compare Contracts",
+      "labels": [
+        "phase:45",
+        "area:frontend",
+        "status:blocked",
+        "lane:auto-safe"
+      ],
+      "body": "## Summary\nConsume the new compare artifacts in focused workbench diff surfaces that stay centered on branch understanding.\n\n## Scope\n- update the workbench to consume the durable compare artifacts instead of reconstructing every contrast client-side\n- focus the UI on scenario compare, trace diff, claim and evidence context, and eval-facing deltas\n- keep the workbench compatible with the ratified multi-branch compare contract\n\n## Constraints\n- do not introduce new operator packet families in this phase\n- do not change backend APIs beyond the ratified compare-artifact contract\n- keep the default path focused on compare -> trace -> claim/evidence -> eval"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -120,8 +120,9 @@ mirror-sim
 ## Current Status | 当前状态
 
 - **Formal release `v0.1.0` | 正式版本 `v0.1.0`**: The first formal GitHub Release remains published and anchors the current repository baseline.
-- **Active successor queue | 当前后继队列**: Phase 44, `Counterfactual Depth and Eval Hardening`, is now the sole open execution milestone and the GitHub queue reports `ready`.
-- **Planned next route | 已定后续主线**: Phase 45 and Phase 46 are now documented as the next contract and workbench-focus directions, but they are not open milestones yet.
+- **Active successor queue | 当前后继队列**: Phase 45, `Branch Generalization and Compare Contracts`, is now the sole open execution milestone and the GitHub queue reports `ready`.
+- **Recent closeout | 最近收口**: Phase 44 is formally closed after landing queue sync, canonical scenario-matrix eval hardening, and the comparison-first workbench overview.
+- **Planned next route | 已定后续主线**: Phase 46 remains the documented next workbench-focus direction, but it is not an open milestone yet.
 - **Repo truth lives in docs | 仓库真相以文档为准**: See [mirror.md](mirror.md) for the project blueprint, [docs/plans/current-state-baseline.md](docs/plans/current-state-baseline.md) for the active queue baseline, and [docs/releases/v0.1.0.md](docs/releases/v0.1.0.md) for the canonical release notes.
 
 ---

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, the first formal release remains published as `v0.1.0`, and the repo has now reopened the queue through the active Phase 44 milestone.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, the first formal release remains published as `v0.1.0`, and the repo has now advanced the active queue to Phase 45.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -133,18 +133,23 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 43 is closed locally and in GitHub.
 - Phase 43 exit issue `#306` is closed and milestone `Phase 43 - Successor Bootstrap and Branch Exception Resolution` is closed.
 - The Phase 43 queue was completed through issues `#306-#308`.
-- Phase 44 is now open in GitHub.
-- Phase 44 milestone `Phase 44 - Counterfactual Depth and Eval Hardening` is open.
-- `#313` `Phase 44 exit gate` is open and remains `status:blocked`.
+- Phase 44 is now closed in GitHub.
+- Phase 44 milestone `Phase 44 - Counterfactual Depth and Eval Hardening` is closed.
+- `#313` `Phase 44 exit gate` is closed.
 - `#314` `Phase 44: sync repo truth to Phase 44 queue` is merged and closed via PR `#317`.
 - `#315` `Phase 44: add canonical scenario matrix and eval coverage` is merged and closed via PR `#319`.
-- `#316` `Phase 44: add workbench counterfactual comparison overview` is open and is now the current `status:ready` work item.
-- `audit-github-queue` now reports `ready` against the active Phase 44 milestone.
-- Phase 45 and Phase 46 are documented successor directions only; neither milestone is open yet.
+- `#316` `Phase 44: add workbench counterfactual comparison overview` is merged and closed via PR `#321`.
+- Phase 45 is now open in GitHub.
+- Phase 45 milestone `Phase 45 - Branch Generalization and Compare Contracts` is open.
+- `#322` `Phase 45 exit gate` is open and remains `status:blocked`.
+- `#323` `Phase 45: sync repo truth to Phase 45 queue` is open and is the current `status:ready` work item.
+- `#324-#326` are open behind the queue-sync and ADR path.
+- `audit-github-queue` now reports `ready` against the active Phase 45 milestone.
+- Phase 46 remains a documented successor direction only and is not an open milestone.
 - The first formal repository release is published as `v0.1.0`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
-- The local Codex queue heartbeat should now follow the active Phase 44 queue instead of reporting the released stop-state as `paused`.
+- The local Codex queue heartbeat should now follow the active Phase 45 queue instead of reporting the released stop-state as `paused`.
 
 ## Day 0 Bootstrap
 
@@ -197,5 +202,5 @@ Before builder automation is allowed to write code or auto-merge:
 - Long-running execution must run from isolated worktrees rather than the current `main` checkout.
 - Queue pickup order, one-writer ownership, and branch hygiene should follow `docs/plans/long-running-loop-runbook.md`.
 - When the active milestone exists and the queue reports `ready`, the builder may resume against that milestone only.
-- While Phase 44 is active, do not open the planned Phase 45 or Phase 46 milestones.
+- While Phase 45 is active, do not open the planned Phase 46 milestone.
 - When no open milestone exists and `audit-github-queue` reports `paused`, treat that state as an intentional released stop-state rather than a broken queue.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the active Phase 44 queue baseline after the formal `v0.1.0` release closeout.
+This note is the active Phase 45 queue baseline after the formal `v0.1.0` release closeout and the completed Phase 44 successor handoff.
 
 ## Snapshot
 
@@ -180,21 +180,33 @@ This note is the active Phase 44 queue baseline after the formal `v0.1.0` releas
   - `gh api repos/YSCJRH/mirror-sim/issues/306`
     - Phase 43 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/milestones/44`
-    - milestone `Phase 44 - Counterfactual Depth and Eval Hardening` is `open`
+    - milestone `Phase 44 - Counterfactual Depth and Eval Hardening` is `closed`
   - `gh api repos/YSCJRH/mirror-sim/issues/313`
-    - Phase 44 exit issue is `open` and remains `status:blocked`
+    - Phase 44 exit issue is `closed`
   - `gh api repos/YSCJRH/mirror-sim/issues/314`
     - Phase 44 queue-sync issue is `closed` after merging PR `#317`
   - `gh api repos/YSCJRH/mirror-sim/issues/315`
     - Phase 44 scenario-matrix issue is `closed` after merging PR `#319`
   - `gh api repos/YSCJRH/mirror-sim/issues/316`
-    - Phase 44 comparison-overview issue is `open` and is now the current `status:ready` work item
+    - Phase 44 comparison-overview issue is `closed` after merging PR `#321`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/45`
+    - milestone `Phase 45 - Branch Generalization and Compare Contracts` is `open`
+  - `gh api repos/YSCJRH/mirror-sim/issues/322`
+    - Phase 45 exit issue is `open` and remains `status:blocked`
+  - `gh api repos/YSCJRH/mirror-sim/issues/323`
+    - Phase 45 queue-sync issue is `open` and is the current `status:ready` work item
+  - `gh api repos/YSCJRH/mirror-sim/issues/324`
+    - Phase 45 ADR/contracts issue is `open` and remains `status:needs-adr`
+  - `gh api repos/YSCJRH/mirror-sim/issues/325`
+    - Phase 45 runner/artifact issue is `open` and remains `status:blocked`
+  - `gh api repos/YSCJRH/mirror-sim/issues/326`
+    - Phase 45 focused diff-surface issue is `open` and remains `status:blocked`
   - `gh api "repos/YSCJRH/mirror-sim/milestones?state=open"`
-    - exactly one open milestone exists: `Phase 44 - Counterfactual Depth and Eval Hardening`
+    - exactly one open milestone exists: `Phase 45 - Branch Generalization and Compare Contracts`
   - `gh api repos/YSCJRH/mirror-sim/releases`
     - release `v0.1.0` exists and matches the committed release notes baseline
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - queue now reports `ready` against the active `Phase 44 - Counterfactual Depth and Eval Hardening` milestone
+    - queue now reports `ready` against the active `Phase 45 - Branch Generalization and Compare Contracts` milestone
 
 ## Trusted Source Of Truth
 
@@ -214,13 +226,13 @@ This note is the active Phase 44 queue baseline after the formal `v0.1.0` releas
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
 - The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, execution recovery release boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, escalation acknowledgment packets, and escalation closure packets without introducing backend API expansion.
-- The current repository state has reopened the queue through Phase 44 while preserving `v0.1.0` as the latest published release baseline.
+- The current repository state has advanced from the Phase 44 counterfactual-depth queue into the Phase 45 branch-generalization queue while preserving `v0.1.0` as the latest published release baseline.
 
 ## Next Entry Point
 
-- Phase 44 is now the sole active milestone, and `#316` `Phase 44: add workbench counterfactual comparison overview` is the current ready work item.
-- The next unlock order is fixed: `#314` and `#315` are now closed, and `#316` is ready to carry the Phase 44 workbench slice.
-- Phase 45 and Phase 46 are documented successor directions only; they must not be opened while Phase 44 remains active.
+- Phase 45 is now the sole active milestone, and `#323` `Phase 45: sync repo truth to Phase 45 queue` is the current ready work item.
+- The next unlock order is fixed: `#322` remains blocked as the Phase 45 exit gate, `#323` is ready, `#324` is waiting on ADR ratification, and `#325-#326` remain blocked behind that contract work.
+- Phase 46 remains the documented successor direction, but it must not be opened while Phase 45 remains active.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
-- The local queue heartbeat remains active as `mirror-queue-heartbeat` and should now report the Phase 44 queue as `ready`; it must not open another milestone while Phase 44 is active.
+- The local queue heartbeat remains active as `mirror-queue-heartbeat` and should now report the Phase 45 queue as `ready`; it must not open another milestone while Phase 45 is active.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut and the Phase 44 queue restart.
+This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 44 counterfactual-depth queue, and the Phase 45 successor bootstrap.
 
 ## Current Gate State
 
@@ -47,7 +47,8 @@ This note records the current post-Day-0 execution status for Mirror after the f
 - Phase 41 exit gate: closed
 - Phase 42 exit gate: closed
 - Phase 43 exit gate: closed
-- Phase 44 exit gate: open
+- Phase 44 exit gate: closed
+- Phase 45 exit gate: open
 
 Local phase audits currently report:
 
@@ -55,29 +56,45 @@ Local phase audits currently report:
 - `phase2`: pass
 - `phase3`: pass
 
-## Active Phase 44 Queue
+## Active Phase 45 Queue
 
-- milestone `Phase 44 - Counterfactual Depth and Eval Hardening`
+- milestone `Phase 45 - Branch Generalization and Compare Contracts`
   - open
-- `#313` `Phase 44 exit gate`
+- `#322` `Phase 45 exit gate`
   - open
   - `status:blocked`
-- `#314` `Phase 44: sync repo truth to Phase 44 queue`
-  - closed
-  - merged via PR `#317`
-- `#315` `Phase 44: add canonical scenario matrix and eval coverage`
-  - closed
-  - merged via PR `#319`
-- `#316` `Phase 44: add workbench counterfactual comparison overview`
+- `#323` `Phase 45: sync repo truth to Phase 45 queue`
   - open
   - `status:ready`
+- `#324` `Phase 45: ratify multi-branch compare ADR and contracts`
+  - open
+  - `status:needs-adr`
+- `#325` `Phase 45: implement branch_count runner and compare artifacts`
+  - open
+  - `status:blocked`
+- `#326` `Phase 45: consume compare artifacts in focused diff surfaces`
+  - open
+  - `status:blocked`
 - `audit-github-queue`
-  - reports `ready` against the Phase 44 milestone because exactly one open milestone exists with a protected blocked exit gate and ready work items
-  - the current ready work item is now `#316` rather than the already-merged scenario-matrix issue
-- planned successor directions
-  - Phase 45: branch generalization and compare contracts
+  - reports `ready` against the Phase 45 milestone because exactly one open milestone exists with a protected blocked exit gate and ready work items
+  - the current ready work item is `#323`
+- recent closeout
+  - milestone `Phase 44 - Counterfactual Depth and Eval Hardening`
+    - closed
+  - `#313` `Phase 44 exit gate`
+    - closed
+  - `#314` `Phase 44: sync repo truth to Phase 44 queue`
+    - closed
+    - merged via PR `#317`
+  - `#315` `Phase 44: add canonical scenario matrix and eval coverage`
+    - closed
+    - merged via PR `#319`
+  - `#316` `Phase 44: add workbench counterfactual comparison overview`
+    - closed
+    - merged via PR `#321`
+- planned successor direction
   - Phase 46: workbench focus and modularity
-  - both remain documented successors only and are not open milestones yet
+  - it remains documented as the next route, but it is not an open milestone yet
 
 ## Closeout Snapshot
 
@@ -535,7 +552,7 @@ Local phase audits currently report:
 - Protected-core changes still require explicit review and must not auto-merge.
 - Long-running execution should assign exactly one writer worktree per issue.
 - When `audit-github-queue` reports `ready`, consume only the currently active milestone and do not parallel-open another execution queue.
-- While Phase 44 is active, do not open the planned Phase 45 or Phase 46 milestones.
+- While Phase 45 is active, do not open the planned Phase 46 milestone.
 
 ## Historical Branch Status
 


### PR DESCRIPTION
## Summary
- add Phase 45 milestone, label, and issue definitions to the bootstrap spec
- sync README and active-state docs from the completed Phase 44 queue to the active Phase 45 queue
- bootstrap the Phase 45 GitHub queue, close the Phase 44 exit gate, close milestone 44, and restore audit-github-queue to `ready`

## Testing
- python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
- ./make.ps1 smoke
- ./make.ps1 test
- ./make.ps1 eval-demo
- python -m backend.app.cli audit-phase phase1
- python -m backend.app.cli audit-phase phase2
- python -m backend.app.cli audit-phase phase3
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim

Closes #323