### PR TITLE
[codex] Sync Phase 45 docs after queue handoff

### DIFF
--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -142,8 +142,9 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 45 is now open in GitHub.
 - Phase 45 milestone `Phase 45 - Branch Generalization and Compare Contracts` is open.
 - `#322` `Phase 45 exit gate` is open and remains `status:blocked`.
-- `#323` `Phase 45: sync repo truth to Phase 45 queue` is open and is the current `status:ready` work item.
-- `#324-#326` are open behind the queue-sync and ADR path.
+- `#323` `Phase 45: sync repo truth to Phase 45 queue` is merged and closed via PR `#327`.
+- `#324` `Phase 45: ratify multi-branch compare ADR and contracts` is open and is now the current `status:ready` work item.
+- `#325-#326` remain open and `status:blocked` behind the ADR/contracts issue.
 - `audit-github-queue` now reports `ready` against the active Phase 45 milestone.
 - Phase 46 remains a documented successor direction only and is not an open milestone.
 - The first formal repository release is published as `v0.1.0`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -194,9 +194,9 @@ This note is the active Phase 45 queue baseline after the formal `v0.1.0` releas
   - `gh api repos/YSCJRH/mirror-sim/issues/322`
     - Phase 45 exit issue is `open` and remains `status:blocked`
   - `gh api repos/YSCJRH/mirror-sim/issues/323`
-    - Phase 45 queue-sync issue is `open` and is the current `status:ready` work item
+    - Phase 45 queue-sync issue is `closed` after merging PR `#327`
   - `gh api repos/YSCJRH/mirror-sim/issues/324`
-    - Phase 45 ADR/contracts issue is `open` and remains `status:needs-adr`
+    - Phase 45 ADR/contracts issue is `open` and is now the current `status:ready` work item
   - `gh api repos/YSCJRH/mirror-sim/issues/325`
     - Phase 45 runner/artifact issue is `open` and remains `status:blocked`
   - `gh api repos/YSCJRH/mirror-sim/issues/326`
@@ -230,8 +230,8 @@ This note is the active Phase 45 queue baseline after the formal `v0.1.0` releas
 
 ## Next Entry Point
 
-- Phase 45 is now the sole active milestone, and `#323` `Phase 45: sync repo truth to Phase 45 queue` is the current ready work item.
-- The next unlock order is fixed: `#322` remains blocked as the Phase 45 exit gate, `#323` is ready, `#324` is waiting on ADR ratification, and `#325-#326` remain blocked behind that contract work.
+- Phase 45 is now the sole active milestone, and `#324` `Phase 45: ratify multi-branch compare ADR and contracts` is the current ready work item.
+- The next unlock order is fixed: `#322` remains blocked as the Phase 45 exit gate, `#323` is closed after queue bootstrap, `#324` is ready to ratify the ADR and contracts, and `#325-#326` remain blocked behind that contract work.
 - Phase 46 remains the documented successor direction, but it must not be opened while Phase 45 remains active.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -64,11 +64,11 @@ Local phase audits currently report:
   - open
   - `status:blocked`
 - `#323` `Phase 45: sync repo truth to Phase 45 queue`
-  - open
-  - `status:ready`
+  - closed
+  - merged via PR `#327`
 - `#324` `Phase 45: ratify multi-branch compare ADR and contracts`
   - open
-  - `status:needs-adr`
+  - `status:ready`
 - `#325` `Phase 45: implement branch_count runner and compare artifacts`
   - open
   - `status:blocked`
@@ -77,7 +77,7 @@ Local phase audits currently report:
   - `status:blocked`
 - `audit-github-queue`
   - reports `ready` against the Phase 45 milestone because exactly one open milestone exists with a protected blocked exit gate and ready work items
-  - the current ready work item is `#323`
+  - the current ready work item is `#324`
 - recent closeout
   - milestone `Phase 44 - Counterfactual Depth and Eval Hardening`
     - closed


### PR DESCRIPTION
## Summary
- update the active queue docs after the Phase 45 queue-sync PR merged
- record `#323` as closed via PR `#327` and `#324` as the current ready work item
- keep the written queue baseline aligned with the live GitHub queue state

## Testing
- python -m backend.app.cli classify-lane --files docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim