### PR TITLE
[codex] Implement branch_count runner and compare artifacts

### DIFF
--- a/backend/app/automation/service.py
+++ b/backend/app/automation/service.py
@@ -349,6 +349,7 @@ def _phase2_checks(artifacts_root: Path) -> list[AuditCheck]:
     intervention_dir = artifacts_root / "run" / "reporter_detained"
     report_dir = artifacts_root / "report"
     eval_path = artifacts_root / "eval" / "summary.json"
+    compare_path = artifacts_root / "compare" / "scenario_fog_harbor_phase44_matrix" / "compare.json"
     required_paths = (
         baseline_dir / "summary.json",
         intervention_dir / "summary.json",
@@ -357,6 +358,7 @@ def _phase2_checks(artifacts_root: Path) -> list[AuditCheck]:
         report_dir / "report.md",
         report_dir / "claims.json",
         eval_path,
+        compare_path,
     )
     checks: list[AuditCheck] = [
         _make_check(
@@ -372,6 +374,7 @@ def _phase2_checks(artifacts_root: Path) -> list[AuditCheck]:
     intervention_summary = read_json(intervention_dir / "summary.json")
     claims = read_json(report_dir / "claims.json")
     eval_summary = read_json(eval_path)
+    compare_payload = read_json(compare_path)
     checks.extend(
         [
             _make_check(
@@ -393,6 +396,12 @@ def _phase2_checks(artifacts_root: Path) -> list[AuditCheck]:
                 "snapshots_present",
                 all((run_dir / "snapshots").exists() for run_dir in (baseline_dir, intervention_dir)),
                 "Each run directory must contain snapshots/ for replayability.",
+            ),
+            _make_check(
+                "compare_artifact_present",
+                compare_payload.get("reference_branch_id") == "branch_baseline"
+                and len(compare_payload.get("branches", [])) >= 4,
+                "Phase 45 requires a durable compare artifact for the canonical demo matrix.",
             ),
         ]
     )

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -12,7 +12,7 @@ from backend.app.ingest.service import ingest_manifest
 from backend.app.personas.service import build_personas
 from backend.app.reports.service import generate_report
 from backend.app.scenarios.service import validate_scenario
-from backend.app.simulation.service import simulate_scenario
+from backend.app.simulation.service import simulate_branching_scenario, simulate_scenario
 from backend.app.world_query import inspect_world
 
 
@@ -97,8 +97,20 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.command == "simulate":
-        summary = simulate_scenario(Path(args.scenario), Path(args.graph), Path(args.personas), Path(args.out))
-        print(f"Simulated {summary.scenario_id}; evacuation_turn={summary.evacuation_turn}.")
+        scenario = validate_scenario(Path(args.scenario))
+        if scenario.branch_count > 1:
+            compare = simulate_branching_scenario(
+                Path(args.scenario),
+                Path(args.graph),
+                Path(args.personas),
+                Path(args.out),
+                Path(args.out),
+                compare_dir=Path(args.out) / "compare",
+            )
+            print(f"Simulated compare {compare.scenario_id}; branches={compare.branch_count}.")
+        else:
+            summary = simulate_scenario(Path(args.scenario), Path(args.graph), Path(args.personas), Path(args.out))
+            print(f"Simulated {summary.scenario_id}; evacuation_turn={summary.evacuation_turn}.")
         return 0
 
     if args.command == "report":

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -118,6 +118,45 @@ class RunTrace(MirrorBaseModel):
     notes: list[str] = Field(default_factory=list)
 
 
+class CompareBranch(MirrorBaseModel):
+    branch_id: str
+    label: str
+    run_id: str
+    is_reference: bool
+    summary_path: str
+    trace_path: str
+    snapshot_dir: str
+
+
+class CompareTurnDelta(MirrorBaseModel):
+    turn_index: int
+    reference_turn_id: str | None = None
+    candidate_turn_id: str | None = None
+
+
+class CompareOutcomeDelta(MirrorBaseModel):
+    reference: Any = None
+    candidate: Any = None
+    delta: Any = None
+
+
+class CompareBranchDelta(MirrorBaseModel):
+    branch_id: str
+    divergent_turn_count: int
+    divergent_turns: list[CompareTurnDelta] = Field(default_factory=list)
+    outcome_deltas: dict[str, CompareOutcomeDelta] = Field(default_factory=dict)
+
+
+class CompareArtifact(MirrorBaseModel):
+    compare_id: str
+    scenario_id: str
+    seed: int
+    branch_count: int
+    reference_branch_id: str
+    branches: list[CompareBranch] = Field(default_factory=list)
+    reference_deltas: list[CompareBranchDelta] = Field(default_factory=list)
+
+
 class Claim(MirrorBaseModel):
     claim_id: str
     text: str

--- a/backend/app/evals/service.py
+++ b/backend/app/evals/service.py
@@ -12,9 +12,17 @@ from backend.app.ingest.service import ingest_manifest
 from backend.app.personas.service import build_personas
 from backend.app.reports.service import generate_report
 from backend.app.scenarios.service import validate_scenario
-from backend.app.simulation.service import simulate_scenario
+from backend.app.simulation.service import (
+    BranchRunArtifacts,
+    load_run_artifacts,
+    simulate_branching_scenario,
+    simulate_scenario,
+    write_compare_artifact,
+)
 from backend.app.utils import load_yaml, read_json, write_json
 from backend.app.world_query import inspect_world
+
+DEMO_MATRIX_COMPARE_SCENARIO_ID = "scenario_fog_harbor_phase44_matrix"
 
 
 def _compare(op: str, left: Any, right: Any) -> bool:
@@ -216,22 +224,65 @@ def run_phase0_demo(settings: Settings | None = None, artifacts_root: Path | Non
     build_personas(artifacts_root / "graph" / "graph.json", artifacts_root / "personas", settings.world_model_path)
     scenario_out_dir = artifacts_root / "scenario"
     run_root = artifacts_root / "run"
+    compare_root = artifacts_root / "compare"
     scenario_out_dir.mkdir(parents=True, exist_ok=True)
     run_root.mkdir(parents=True, exist_ok=True)
+    compare_root.mkdir(parents=True, exist_ok=True)
     for scenario_json in scenario_out_dir.glob("*.json"):
         scenario_json.unlink()
     for run_dir in run_root.iterdir():
         if run_dir.is_dir():
             shutil.rmtree(run_dir)
+    for compare_dir in compare_root.iterdir():
+        if compare_dir.is_dir():
+            shutil.rmtree(compare_dir)
 
+    scenario_payloads: dict[str, Any] = {}
     for scenario_path in scenario_paths:
         stem = scenario_path.stem
-        validate_scenario(scenario_path, scenario_out_dir / f"{stem}.json")
-        simulate_scenario(
-            scenario_path,
-            artifacts_root / "graph" / "graph.json",
-            artifacts_root / "personas" / "personas.json",
-            run_root / stem,
+        scenario = validate_scenario(scenario_path, scenario_out_dir / f"{stem}.json")
+        scenario_payloads[stem] = scenario
+        if scenario.branch_count > 1:
+            simulate_branching_scenario(
+                scenario_path,
+                artifacts_root / "graph" / "graph.json",
+                artifacts_root / "personas" / "personas.json",
+                run_root / stem,
+                artifacts_root,
+                compare_dir=compare_root / scenario.scenario_id,
+            )
+        else:
+            simulate_scenario(
+                scenario_path,
+                artifacts_root / "graph" / "graph.json",
+                artifacts_root / "personas" / "personas.json",
+                run_root / stem,
+            )
+
+    matrix_branch_runs: list[BranchRunArtifacts] = []
+    for scenario_path in scenario_paths:
+        stem = scenario_path.stem
+        run_dir = run_root / stem
+        if not (run_dir / "summary.json").exists():
+            continue
+        summary, actions = load_run_artifacts(run_dir)
+        matrix_branch_runs.append(
+            BranchRunArtifacts(
+                branch_id="branch_baseline" if stem == "baseline" else f"branch_{stem}",
+                label="Baseline" if stem == "baseline" else scenario_payloads[stem].title,
+                summary=summary,
+                actions=actions,
+                run_dir=run_dir,
+            )
+        )
+    if matrix_branch_runs:
+        write_compare_artifact(
+            artifacts_root,
+            compare_root / DEMO_MATRIX_COMPARE_SCENARIO_ID,
+            scenario_id=DEMO_MATRIX_COMPARE_SCENARIO_ID,
+            seed=matrix_branch_runs[0].summary.seed,
+            branch_runs=matrix_branch_runs,
+            reference_branch_id="branch_baseline",
         )
     generate_report(
         run_root / settings.intervention_scenario_path.stem,

--- a/backend/app/simulation/service.py
+++ b/backend/app/simulation/service.py
@@ -1,11 +1,24 @@
 from __future__ import annotations
 
+import shutil
+from dataclasses import dataclass
+from itertools import combinations
 from pathlib import Path
 from typing import Any
 
-from backend.app.domain.models import Persona, RunTrace, Scenario, TurnAction
+from backend.app.domain.models import (
+    CompareArtifact,
+    CompareBranch,
+    CompareBranchDelta,
+    CompareOutcomeDelta,
+    CompareTurnDelta,
+    Persona,
+    RunTrace,
+    Scenario,
+    TurnAction,
+)
 from backend.app.scenarios.service import load_scenario
-from backend.app.utils import ensure_dir, read_json, write_json, write_jsonl
+from backend.app.utils import ensure_dir, read_json, read_jsonl, slugify, write_json, write_jsonl
 
 
 TURN_SEQUENCE = [
@@ -19,10 +32,44 @@ TURN_SEQUENCE = [
     "persona_zhao_ke",
 ]
 
+OUTCOME_DELTA_FIELDS = (
+    "ledger_public_turn",
+    "budget_exposed_turn",
+    "evacuation_turn",
+    "festival_status",
+    "budget_exposed",
+    "ledger_public",
+    "evacuation_triggered",
+    "risk_known_by",
+)
+
+
+@dataclass(frozen=True)
+class BranchExecutionPlan:
+    branch_id: str
+    label: str
+    scenario: Scenario
+    injection_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class BranchRunArtifacts:
+    branch_id: str
+    label: str
+    summary: RunTrace
+    actions: list[TurnAction]
+    run_dir: Path
+
 
 def _load_personas(path: Path) -> dict[str, Persona]:
     payload = read_json(path)
     return {item["persona_id"]: Persona.model_validate(item) for item in payload["personas"]}
+
+
+def load_run_artifacts(run_dir: Path) -> tuple[RunTrace, list[TurnAction]]:
+    summary = RunTrace.model_validate(read_json(run_dir / "summary.json"))
+    actions = [TurnAction.model_validate(row) for row in read_jsonl(run_dir / "run_trace.jsonl")]
+    return summary, actions
 
 
 def _apply_injections(scenario: Scenario, state: dict[str, Any], notes: list[str]) -> None:
@@ -245,12 +292,19 @@ def _action_for_turn(
     return action
 
 
-def simulate_scenario(scenario_path: Path, graph_path: Path, personas_path: Path, out_dir: Path) -> RunTrace:
+def _simulate_loaded_scenario(
+    scenario: Scenario,
+    graph_path: Path,
+    personas_path: Path,
+    out_dir: Path,
+    *,
+    run_id: str | None = None,
+    notes_prefix: list[str] | None = None,
+) -> tuple[RunTrace, list[TurnAction]]:
     _ = read_json(graph_path)
-    scenario = load_scenario(scenario_path)
     personas = _load_personas(personas_path)
-    run_id = f"run_{scenario.scenario_id}_{scenario.seed}"
-    notes = [f"Deterministic Phase 0 run for {scenario.scenario_id}."]
+    resolved_run_id = run_id or f"run_{scenario.scenario_id}_{scenario.seed}"
+    notes = [f"Deterministic Phase 0 run for {scenario.scenario_id}.", *(notes_prefix or [])]
     state: dict[str, Any] = {
         "east_gate_status": "fractured",
         "festival_status": "scheduled",
@@ -278,12 +332,12 @@ def simulate_scenario(scenario_path: Path, graph_path: Path, personas_path: Path
     actions: list[TurnAction] = []
     for turn_index in range(1, scenario.turn_budget + 1):
         persona_id = TURN_SEQUENCE[turn_index - 1]
-        action = _action_for_turn(turn_index, run_id, persona_id, personas, state)
+        action = _action_for_turn(turn_index, resolved_run_id, persona_id, personas, state)
         actions.append(action)
         write_json(snapshots_dir / f"turn-{turn_index:02d}.json", {"turn_index": turn_index, "state": state})
 
     summary = RunTrace(
-        run_id=run_id,
+        run_id=resolved_run_id,
         scenario_id=scenario.scenario_id,
         seed=scenario.seed,
         turn_budget=scenario.turn_budget,
@@ -306,4 +360,216 @@ def simulate_scenario(scenario_path: Path, graph_path: Path, personas_path: Path
 
     write_jsonl(out_dir / "run_trace.jsonl", actions)
     write_json(out_dir / "summary.json", summary.model_dump())
+    return summary, actions
+
+
+def simulate_scenario(scenario_path: Path, graph_path: Path, personas_path: Path, out_dir: Path) -> RunTrace:
+    scenario = load_scenario(scenario_path)
+    summary, _ = _simulate_loaded_scenario(scenario, graph_path, personas_path, out_dir)
     return summary
+
+
+def _branch_label(injection_ids: tuple[str, ...]) -> str:
+    if not injection_ids:
+        return "Reference"
+    if len(injection_ids) == 1:
+        return f"Intervention: {injection_ids[0]}"
+    return "Intervention mix: " + ", ".join(injection_ids)
+
+
+def _branch_execution_plans(scenario: Scenario) -> list[BranchExecutionPlan]:
+    available_index_sets = [()] + [
+        combo
+        for size in range(1, len(scenario.injections) + 1)
+        for combo in combinations(range(len(scenario.injections)), size)
+    ]
+
+    if scenario.branch_count > len(available_index_sets):
+        raise ValueError(
+            f"Scenario {scenario.scenario_id} requests branch_count={scenario.branch_count}, "
+            f"but only {len(available_index_sets)} deterministic injection subsets are available."
+        )
+
+    plans: list[BranchExecutionPlan] = []
+    for combo in available_index_sets[: scenario.branch_count]:
+        injection_ids = tuple(scenario.injections[index].injection_id for index in combo)
+        branch_id = "branch_reference" if not injection_ids else f"branch_{slugify('__'.join(injection_ids))}"
+        branch_scenario = scenario.model_copy(
+            update={"injections": [scenario.injections[index] for index in combo]}
+        )
+        plans.append(
+            BranchExecutionPlan(
+                branch_id=branch_id,
+                label=_branch_label(injection_ids),
+                scenario=branch_scenario,
+                injection_ids=injection_ids,
+            )
+        )
+    return plans
+
+
+def _delta_value(reference: Any, candidate: Any) -> Any:
+    if (
+        isinstance(reference, (int, float))
+        and isinstance(candidate, (int, float))
+        and not isinstance(reference, bool)
+        and not isinstance(candidate, bool)
+    ):
+        return candidate - reference
+    return None
+
+
+def _outcome_deltas(reference: RunTrace, candidate: RunTrace) -> dict[str, CompareOutcomeDelta]:
+    reference_values = {
+        "ledger_public_turn": reference.ledger_public_turn,
+        "budget_exposed_turn": reference.budget_exposed_turn,
+        "evacuation_turn": reference.evacuation_turn,
+        **{field: reference.final_state.get(field) for field in OUTCOME_DELTA_FIELDS if field in reference.final_state},
+    }
+    candidate_values = {
+        "ledger_public_turn": candidate.ledger_public_turn,
+        "budget_exposed_turn": candidate.budget_exposed_turn,
+        "evacuation_turn": candidate.evacuation_turn,
+        **{field: candidate.final_state.get(field) for field in OUTCOME_DELTA_FIELDS if field in candidate.final_state},
+    }
+    outcome_keys = sorted(set(reference_values) | set(candidate_values))
+    return {
+        key: CompareOutcomeDelta(
+            reference=reference_values.get(key),
+            candidate=candidate_values.get(key),
+            delta=_delta_value(reference_values.get(key), candidate_values.get(key)),
+        )
+        for key in outcome_keys
+    }
+
+
+def _divergent_turns(reference_actions: list[TurnAction], candidate_actions: list[TurnAction]) -> list[CompareTurnDelta]:
+    divergent_turns: list[CompareTurnDelta] = []
+    for index in range(max(len(reference_actions), len(candidate_actions))):
+        reference_action = reference_actions[index] if index < len(reference_actions) else None
+        candidate_action = candidate_actions[index] if index < len(candidate_actions) else None
+        if reference_action is None or candidate_action is None:
+            divergent_turns.append(
+                CompareTurnDelta(
+                    turn_index=index + 1,
+                    reference_turn_id=reference_action.turn_id if reference_action else None,
+                    candidate_turn_id=candidate_action.turn_id if candidate_action else None,
+                )
+            )
+            continue
+
+        if (
+            reference_action.actor_id != candidate_action.actor_id
+            or reference_action.action_type != candidate_action.action_type
+            or reference_action.target_id != candidate_action.target_id
+        ):
+            divergent_turns.append(
+                CompareTurnDelta(
+                    turn_index=index + 1,
+                    reference_turn_id=reference_action.turn_id,
+                    candidate_turn_id=candidate_action.turn_id,
+                )
+            )
+    return divergent_turns
+
+
+def write_compare_artifact(
+    scope_root: Path,
+    compare_dir: Path,
+    *,
+    scenario_id: str,
+    seed: int,
+    branch_runs: list[BranchRunArtifacts],
+    reference_branch_id: str,
+) -> CompareArtifact:
+    reference_branch = next((branch for branch in branch_runs if branch.branch_id == reference_branch_id), None)
+    if reference_branch is None:
+        raise ValueError(f"Missing reference branch {reference_branch_id} for compare artifact {scenario_id}.")
+
+    compare = CompareArtifact(
+        compare_id=f"compare_{slugify(scenario_id)}_{seed}",
+        scenario_id=scenario_id,
+        seed=seed,
+        branch_count=len(branch_runs),
+        reference_branch_id=reference_branch_id,
+        branches=[
+            CompareBranch(
+                branch_id=branch.branch_id,
+                label=branch.label,
+                run_id=branch.summary.run_id,
+                is_reference=branch.branch_id == reference_branch_id,
+                summary_path=(branch.run_dir.relative_to(scope_root) / "summary.json").as_posix(),
+                trace_path=(branch.run_dir.relative_to(scope_root) / "run_trace.jsonl").as_posix(),
+                snapshot_dir=(branch.run_dir.relative_to(scope_root) / "snapshots").as_posix(),
+            )
+            for branch in branch_runs
+        ],
+        reference_deltas=[
+            CompareBranchDelta(
+                branch_id=branch.branch_id,
+                divergent_turn_count=len(_divergent_turns(reference_branch.actions, branch.actions)),
+                divergent_turns=_divergent_turns(reference_branch.actions, branch.actions),
+                outcome_deltas=_outcome_deltas(reference_branch.summary, branch.summary),
+            )
+            for branch in branch_runs
+            if branch.branch_id != reference_branch_id
+        ],
+    )
+
+    if compare_dir.exists():
+        shutil.rmtree(compare_dir)
+    write_json(compare_dir / "compare.json", compare.model_dump())
+    return compare
+
+
+def simulate_branching_scenario(
+    scenario_path: Path,
+    graph_path: Path,
+    personas_path: Path,
+    run_root: Path,
+    scope_root: Path,
+    *,
+    compare_dir: Path | None = None,
+) -> CompareArtifact:
+    scenario = load_scenario(scenario_path)
+    if scenario.branch_count <= 1:
+        raise ValueError(f"Scenario {scenario.scenario_id} does not request multi-branch execution.")
+
+    branches_root = run_root / "branches"
+    if branches_root.exists():
+        shutil.rmtree(branches_root)
+    ensure_dir(branches_root)
+
+    branch_runs: list[BranchRunArtifacts] = []
+    for plan in _branch_execution_plans(scenario):
+        branch_run_dir = branches_root / plan.branch_id
+        branch_notes = [
+            "Branch injections: " + (", ".join(plan.injection_ids) if plan.injection_ids else "none")
+        ]
+        summary, actions = _simulate_loaded_scenario(
+            plan.scenario,
+            graph_path,
+            personas_path,
+            branch_run_dir,
+            run_id=f"run_{scenario.scenario_id}_{scenario.seed}_{plan.branch_id}",
+            notes_prefix=branch_notes,
+        )
+        branch_runs.append(
+            BranchRunArtifacts(
+                branch_id=plan.branch_id,
+                label=plan.label,
+                summary=summary,
+                actions=actions,
+                run_dir=branch_run_dir,
+            )
+        )
+
+    resolved_compare_dir = compare_dir or (scope_root / "compare" / scenario.scenario_id)
+    return write_compare_artifact(
+        scope_root,
+        resolved_compare_dir,
+        scenario_id=scenario.scenario_id,
+        seed=scenario.seed,
+        branch_runs=branch_runs,
+        reference_branch_id="branch_reference",
+    )

--- a/backend/tests/test_automation.py
+++ b/backend/tests/test_automation.py
@@ -45,6 +45,7 @@ def test_phase1_and_phase2_audit_pass_with_demo_artifacts(tmp_path: Path) -> Non
     phase2 = run_phase_audit("phase2", settings=settings, artifacts_root=tmp_path / "demo")
     assert phase1.status == "pass"
     assert phase2.status == "pass"
+    assert any(check.name == "compare_artifact_present" and check.passed for check in phase2.checks)
 
 
 def test_phase3_audit_passes_with_current_workbench_contract(tmp_path: Path) -> None:

--- a/backend/tests/test_pipeline.py
+++ b/backend/tests/test_pipeline.py
@@ -11,7 +11,8 @@ from backend.app.ingest.service import ingest_manifest
 from backend.app.personas.service import build_personas
 from backend.app.reports.service import generate_report
 from backend.app.scenarios.service import validate_scenario
-from backend.app.simulation.service import simulate_scenario
+from backend.app.simulation.service import simulate_branching_scenario, simulate_scenario
+from backend.app.utils import read_json
 
 
 def test_ingest_writes_documents_and_chunks(tmp_path: Path) -> None:
@@ -104,6 +105,76 @@ def test_scenario_validation_and_simulation_are_deterministic(tmp_path: Path) ->
     assert first.model_dump() == second.model_dump()
 
 
+def test_branching_scenario_writes_stable_compare_artifact(tmp_path: Path) -> None:
+    settings = get_settings()
+    ingest_manifest(settings.manifest_path, tmp_path / "ingest")
+    build_graph(tmp_path / "ingest" / "chunks.jsonl", tmp_path / "graph")
+    build_personas(tmp_path / "graph" / "graph.json", tmp_path / "personas")
+
+    scenario_path = tmp_path / "scenario_branch_matrix.yaml"
+    scenario_path.write_text(
+        "\n".join(
+            [
+                "scenario_id: scenario_branch_matrix",
+                "world_id: fog-harbor-east-gate",
+                "title: Branch Matrix Runner Test",
+                "description: Deterministic runner test for multi-branch compare artifacts.",
+                "seed: 7",
+                "turn_budget: 8",
+                "branch_count: 4",
+                "evaluation_questions:",
+                "  - Which branch delays the ledger most?",
+                "  - Which branch loses the direct warning path?",
+                "injections:",
+                "  - injection_id: inj_reporter_detained",
+                "    kind: delay_document",
+                "    target_id: doc_ledger_copy",
+                "    actor_id: entity_lin_lan",
+                "    params:",
+                "      delay_turns: 2",
+                "  - injection_id: inj_harbor_comms_failure",
+                "    kind: resource_failure",
+                "    actor_id: persona_chen_yu",
+                "    target_id: entity_east_wharf",
+                "    params:",
+                "      duration_turns: 3",
+                "  - injection_id: inj_mayor_signal_blocked",
+                "    kind: block_contact",
+                "    actor_id: persona_chen_yu",
+                "    target_id: persona_zhao_ke",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    first_compare = simulate_branching_scenario(
+        scenario_path,
+        tmp_path / "graph" / "graph.json",
+        tmp_path / "personas" / "personas.json",
+        tmp_path / "demo-one" / "run" / "branch_matrix",
+        tmp_path / "demo-one",
+    )
+    second_compare = simulate_branching_scenario(
+        scenario_path,
+        tmp_path / "graph" / "graph.json",
+        tmp_path / "personas" / "personas.json",
+        tmp_path / "demo-two" / "run" / "branch_matrix",
+        tmp_path / "demo-two",
+    )
+
+    assert first_compare.model_dump() == second_compare.model_dump()
+    assert first_compare.reference_branch_id == "branch_reference"
+    assert [branch.branch_id for branch in first_compare.branches] == [
+        "branch_reference",
+        "branch_inj_reporter_detained",
+        "branch_inj_harbor_comms_failure",
+        "branch_inj_mayor_signal_blocked",
+    ]
+    assert (tmp_path / "demo-one" / "compare" / "scenario_branch_matrix" / "compare.json").exists()
+    assert (tmp_path / "demo-one" / "run" / "branch_matrix" / "branches" / "branch_inj_reporter_detained" / "summary.json").exists()
+
+
 def test_report_contains_labeled_claims(tmp_path: Path) -> None:
     settings = get_settings()
     ingest_manifest(settings.manifest_path, tmp_path / "ingest")
@@ -147,6 +218,10 @@ def test_eval_demo_writes_canonical_scenario_matrix(tmp_path: Path) -> None:
         assert (artifacts_root / "scenario" / f"{stem}.json").exists()
         assert (artifacts_root / "run" / stem / "summary.json").exists()
         assert (artifacts_root / "run" / stem / "run_trace.jsonl").exists()
+
+    compare_payload = read_json(artifacts_root / "compare" / "scenario_fog_harbor_phase44_matrix" / "compare.json")
+    assert compare_payload["reference_branch_id"] == "branch_baseline"
+    assert len(compare_payload["branches"]) == 4
 
 
 def test_eval_redlines_cover_query_outputs(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- implement deterministic multi-branch runner support for `branch_count > 1`
- add durable compare artifact models plus compare writer logic for both true multi-branch scenarios and the current Phase 44 demo matrix
- update the demo pipeline, CLI simulate path, phase2 audit, and tests so compare artifacts are generated and enforced end-to-end

## Testing
- python -m compileall backend/app backend/tests
- python -m backend.app.cli classify-lane --files backend/app/domain/models.py backend/app/simulation/service.py backend/app/evals/service.py backend/app/automation/service.py backend/app/cli.py backend/tests/test_pipeline.py backend/tests/test_automation.py
- ./make.ps1 test
- ./make.ps1 smoke
- ./make.ps1 eval-demo
- python -m backend.app.cli audit-phase phase1
- python -m backend.app.cli audit-phase phase2
- python -m backend.app.cli audit-phase phase3

## Notes
- `smoke` and `eval-demo` both rewrite `artifacts/demo/*`, so they were verified sequentially rather than in parallel.

Closes #325