### PR TITLE
[codex] Bootstrap Phase 46 successor queue

### DIFF
--- a/.github/automation/bootstrap-spec.json
+++ b/.github/automation/bootstrap-spec.json
@@ -179,6 +179,10 @@
     {
       "title": "Phase 45 - Branch Generalization and Compare Contracts",
       "description": "Turn the Phase 44 counterfactual matrix into a formal multi-branch compare contract by ratifying branch-count semantics, durable compare artifacts, and focused diff consumption without widening the product surface."
+    },
+    {
+      "title": "Phase 46 - Workbench Focus and Modularity",
+      "description": "Turn the expanded compare-capable workbench into a more focused and maintainable operator surface by modularizing review-scorecard code, centering the default path on compare/evidence/eval, and moving secondary packet-heavy surfaces behind advanced navigation."
     }
   ],
   "labels": [
@@ -406,6 +410,11 @@
       "name": "phase:45",
       "color": "FFE2B8",
       "description": "Phase 45 branch generalization and compare contract work."
+    },
+    {
+      "name": "phase:46",
+      "color": "FFD1A6",
+      "description": "Phase 46 workbench focus and modularity work."
     },
     {
       "name": "area:backend",
@@ -2438,6 +2447,62 @@
         "lane:auto-safe"
       ],
       "body": "## Summary\nConsume the new compare artifacts in focused workbench diff surfaces that stay centered on branch understanding.\n\n## Scope\n- update the workbench to consume the durable compare artifacts instead of reconstructing every contrast client-side\n- focus the UI on scenario compare, trace diff, claim and evidence context, and eval-facing deltas\n- keep the workbench compatible with the ratified multi-branch compare contract\n\n## Constraints\n- do not introduce new operator packet families in this phase\n- do not change backend APIs beyond the ratified compare-artifact contract\n- keep the default path focused on compare -> trace -> claim/evidence -> eval"
+    },
+    {
+      "title": "Phase 46 exit gate",
+      "milestone": "Phase 46 - Workbench Focus and Modularity",
+      "labels": [
+        "phase:46",
+        "area:docs-evals",
+        "status:blocked",
+        "lane:protected-core"
+      ],
+      "body": "Close this issue only after the full Phase 46 workbench-focus queue is complete.\n\nExit criteria:\n- the Phase 46 queue-sync issue is merged\n- the review-scorecard modularization issue is merged\n- the default operator-path issue is merged\n- the advanced-navigation issue is merged\n- `npm run build --prefix frontend` passes\n- `./make.ps1 smoke` passes\n- `./make.ps1 test` passes\n- `./make.ps1 eval-demo` passes\n- `python -m backend.app.cli audit-phase phase1` passes\n- `python -m backend.app.cli audit-phase phase2` passes\n- `python -m backend.app.cli audit-phase phase3` passes\n- if no approved successor phase exists, the repo closes into an intentional `paused` stop-state with no open milestone"
+    },
+    {
+      "title": "Phase 46: sync repo truth to Phase 46 queue",
+      "milestone": "Phase 46 - Workbench Focus and Modularity",
+      "labels": [
+        "phase:46",
+        "area:docs-evals",
+        "risk:ci",
+        "status:ready",
+        "lane:protected-core"
+      ],
+      "body": "## Summary\nSync the repo truth from the closing Phase 45 queue to the active Phase 46 queue.\n\n## Scope\n- add the Phase 46 milestone, label, and issue definitions to the bootstrap spec\n- update README and active-state docs to show Phase 46 as the sole active queue after Phase 45 closeout\n- record that no Phase 47 milestone is pre-approved in this round\n- create the Phase 46 milestone and issues from the updated bootstrap spec\n- complete the GitHub closeout handoff from Phase 45 to Phase 46\n\n## Constraints\n- no simulation, report, claim, evidence, scenario, or schema contract changes\n- do not leave more than one active execution milestone open after closeout\n- no backend/runtime behavior changes beyond queue-governance sync"
+    },
+    {
+      "title": "Phase 46: extract review-scorecard into modular feature slices",
+      "milestone": "Phase 46 - Workbench Focus and Modularity",
+      "labels": [
+        "phase:46",
+        "area:frontend",
+        "status:blocked",
+        "lane:auto-safe"
+      ],
+      "body": "## Summary\nExtract the oversized review-scorecard implementation into maintainable frontend feature slices without changing the current compare contract.\n\n## Scope\n- split `frontend/src/app/review-scorecard.tsx` into smaller modules with clearer ownership boundaries\n- preserve current artifact-reading behavior, review logic, and packet/export semantics unless another Phase 46 issue explicitly narrows the default path\n- keep the resulting composition straightforward enough for future compare/evidence/eval workbench changes\n\n## Constraints\n- no backend API changes\n- no artifact schema changes\n- do not widen the packet surface while modularizing"
+    },
+    {
+      "title": "Phase 46: define the default operator path around compare-evidence-eval",
+      "milestone": "Phase 46 - Workbench Focus and Modularity",
+      "labels": [
+        "phase:46",
+        "area:frontend",
+        "status:blocked",
+        "lane:auto-safe"
+      ],
+      "body": "## Summary\nDefine the default workbench path around scenario compare, trace diff, claim/evidence review, and eval summary.\n\n## Scope\n- make compare -> trace -> claim/evidence -> eval the clearly favored default operator path\n- keep review-scorecard and related handoff surfaces accessible without letting them dominate the first-read experience\n- stay within the current artifact set and compare contract\n\n## Constraints\n- no backend API changes\n- no new compare contract changes\n- do not add new packet families in this issue"
+    },
+    {
+      "title": "Phase 46: move secondary packet surfaces behind advanced navigation",
+      "milestone": "Phase 46 - Workbench Focus and Modularity",
+      "labels": [
+        "phase:46",
+        "area:frontend",
+        "status:blocked",
+        "lane:auto-safe"
+      ],
+      "body": "## Summary\nMove the secondary packet-heavy surfaces behind an explicitly advanced navigation path so the default workbench entry stays focused.\n\n## Scope\n- group or gate secondary packet/export surfaces behind clearly secondary navigation\n- keep the existing packet-heavy surfaces reachable for established workflows\n- preserve artifact compatibility and current copy/export behavior while reducing default-path clutter\n\n## Constraints\n- no backend API changes\n- no packet schema changes\n- do not delete legacy packet surfaces in this phase"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ mirror-sim
 ## Current Status | 当前状态
 
 - **Formal release `v0.1.0` | 正式版本 `v0.1.0`**: The first formal GitHub Release remains published and anchors the current repository baseline.
-- **Active successor queue | 当前后继队列**: Phase 45, `Branch Generalization and Compare Contracts`, is now the sole open execution milestone and the GitHub queue reports `ready`.
-- **Recent closeout | 最近收口**: Phase 44 is formally closed after landing queue sync, canonical scenario-matrix eval hardening, and the comparison-first workbench overview.
-- **Planned next route | 已定后续主线**: Phase 46 remains the documented next workbench-focus direction, but it is not an open milestone yet.
+- **Active successor queue | 当前后继队列**: Phase 46, `Workbench Focus and Modularity`, is now the sole open execution milestone and the GitHub queue reports `ready`.
+- **Recent closeout | 最近收口**: Phase 45 is formally closed after landing the compare-contract ADR, the branch-count runner and compare artifacts, and the focused diff-surface handoff.
+- **Planned next route | 已定后续主线**: No Phase 47 milestone is pre-opened in this round; any successor beyond Phase 46 requires a fresh decision against the `mirror.md` trigger conditions.
 - **Repo truth lives in docs | 仓库真相以文档为准**: See [mirror.md](mirror.md) for the project blueprint, [docs/plans/current-state-baseline.md](docs/plans/current-state-baseline.md) for the active queue baseline, and [docs/releases/v0.1.0.md](docs/releases/v0.1.0.md) for the canonical release notes.
 
 ---

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, the first formal release remains published as `v0.1.0`, and the repo has now advanced the active queue to Phase 45.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, the first formal release remains published as `v0.1.0`, and the repo has now advanced the active queue to Phase 46.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -139,19 +139,26 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - `#314` `Phase 44: sync repo truth to Phase 44 queue` is merged and closed via PR `#317`.
 - `#315` `Phase 44: add canonical scenario matrix and eval coverage` is merged and closed via PR `#319`.
 - `#316` `Phase 44: add workbench counterfactual comparison overview` is merged and closed via PR `#321`.
-- Phase 45 is now open in GitHub.
-- Phase 45 milestone `Phase 45 - Branch Generalization and Compare Contracts` is open.
-- `#322` `Phase 45 exit gate` is open and remains `status:blocked`.
+- Phase 45 is now closed in GitHub after the successor handoff to Phase 46.
+- Phase 45 milestone `Phase 45 - Branch Generalization and Compare Contracts` is closed.
+- `#322` `Phase 45 exit gate` is closed after the Phase 46 successor queue is opened.
 - `#323` `Phase 45: sync repo truth to Phase 45 queue` is merged and closed via PR `#327`.
 - `#324` `Phase 45: ratify multi-branch compare ADR and contracts` is merged and closed via PR `#329`.
 - `#325` `Phase 45: implement branch_count runner and compare artifacts` is merged and closed via PR `#331`.
-- `#326` `Phase 45: consume compare artifacts in focused diff surfaces` is open and is now the current `status:ready` work item.
-- `audit-github-queue` now reports `ready` against the active Phase 45 milestone.
-- Phase 46 remains a documented successor direction only and is not an open milestone.
+- `#326` `Phase 45: consume compare artifacts in focused diff surfaces` is merged and closed via PR `#333`.
+- Phase 46 is now open in GitHub.
+- milestone `Phase 46 - Workbench Focus and Modularity` is open.
+- `Phase 46 exit gate` is open and remains `status:blocked`.
+- `Phase 46: sync repo truth to Phase 46 queue` is closed after the successor bootstrap PR merges.
+- `Phase 46: extract review-scorecard into modular feature slices` is now the current `status:ready` work item.
+- `Phase 46: define the default operator path around compare-evidence-eval` remains open and `status:blocked`.
+- `Phase 46: move secondary packet surfaces behind advanced navigation` remains open and `status:blocked`.
+- `audit-github-queue` now reports `ready` against the active Phase 46 milestone.
+- No Phase 47 milestone is pre-opened in this round.
 - The first formal repository release is published as `v0.1.0`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
-- The local Codex queue heartbeat should now follow the active Phase 45 queue instead of reporting the released stop-state as `paused`.
+- The local Codex queue heartbeat should now follow the active Phase 46 queue instead of reporting the interim no-ready-item state as `paused`.
 
 ## Day 0 Bootstrap
 
@@ -204,5 +211,5 @@ Before builder automation is allowed to write code or auto-merge:
 - Long-running execution must run from isolated worktrees rather than the current `main` checkout.
 - Queue pickup order, one-writer ownership, and branch hygiene should follow `docs/plans/long-running-loop-runbook.md`.
 - When the active milestone exists and the queue reports `ready`, the builder may resume against that milestone only.
-- While Phase 45 is active, do not open the planned Phase 46 milestone.
+- While Phase 46 is active, do not open a Phase 47 milestone without a fresh approval round.
 - When no open milestone exists and `audit-github-queue` reports `paused`, treat that state as an intentional released stop-state rather than a broken queue.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the active Phase 45 queue baseline after the formal `v0.1.0` release closeout and the completed Phase 44 successor handoff.
+This note is the active Phase 46 queue baseline after the formal `v0.1.0` release closeout, the completed Phase 45 closeout, and the completed successor handoff into the workbench-focus queue.
 
 ## Snapshot
 
@@ -190,9 +190,9 @@ This note is the active Phase 45 queue baseline after the formal `v0.1.0` releas
   - `gh api repos/YSCJRH/mirror-sim/issues/316`
     - Phase 44 comparison-overview issue is `closed` after merging PR `#321`
   - `gh api repos/YSCJRH/mirror-sim/milestones/45`
-    - milestone `Phase 45 - Branch Generalization and Compare Contracts` is `open`
+    - milestone `Phase 45 - Branch Generalization and Compare Contracts` is `closed`
   - `gh api repos/YSCJRH/mirror-sim/issues/322`
-    - Phase 45 exit issue is `open` and remains `status:blocked`
+    - Phase 45 exit issue is `closed` after the Phase 46 successor handoff
   - `gh api repos/YSCJRH/mirror-sim/issues/323`
     - Phase 45 queue-sync issue is `closed` after merging PR `#327`
   - `gh api repos/YSCJRH/mirror-sim/issues/324`
@@ -200,13 +200,19 @@ This note is the active Phase 45 queue baseline after the formal `v0.1.0` releas
   - `gh api repos/YSCJRH/mirror-sim/issues/325`
     - Phase 45 runner/artifact issue is `closed` after merging PR `#331`
   - `gh api repos/YSCJRH/mirror-sim/issues/326`
-    - Phase 45 focused diff-surface issue is `open` and is now the current `status:ready` work item
+    - Phase 45 focused diff-surface issue is `closed` after merging PR `#333`
   - `gh api "repos/YSCJRH/mirror-sim/milestones?state=open"`
-    - exactly one open milestone exists: `Phase 45 - Branch Generalization and Compare Contracts`
+    - exactly one open milestone exists: `Phase 46 - Workbench Focus and Modularity`
+  - `gh issue list --milestone "Phase 46 - Workbench Focus and Modularity" --state all`
+    - `Phase 46 exit gate` is `open` and remains `status:blocked`
+    - `Phase 46: sync repo truth to Phase 46 queue` is `closed` after the successor bootstrap PR merges
+    - `Phase 46: extract review-scorecard into modular feature slices` is `open` and is the current `status:ready` work item
+    - `Phase 46: define the default operator path around compare-evidence-eval` is `open` and remains `status:blocked`
+    - `Phase 46: move secondary packet surfaces behind advanced navigation` is `open` and remains `status:blocked`
   - `gh api repos/YSCJRH/mirror-sim/releases`
     - release `v0.1.0` exists and matches the committed release notes baseline
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - queue now reports `ready` against the active `Phase 45 - Branch Generalization and Compare Contracts` milestone
+    - queue now reports `ready` against the active `Phase 46 - Workbench Focus and Modularity` milestone
 
 ## Trusted Source Of Truth
 
@@ -226,14 +232,15 @@ This note is the active Phase 45 queue baseline after the formal `v0.1.0` releas
 - The backend can ingest corpus documents, build a graph, build personas, validate scenarios, simulate deterministic runs, generate reports, inspect world objects, and run evals.
 - The simulation runner now also supports deterministic multi-branch execution under the ratified `branch_count` contract and emits durable compare artifacts for the canonical scenario matrix.
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
+- The default workbench path now consumes the canonical compare artifact directly and keeps focused divergent trace surfaces ahead of heavier packet-driven review flows.
 - The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, execution recovery release boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, escalation acknowledgment packets, and escalation closure packets without introducing backend API expansion.
-- The current repository state has advanced from the Phase 44 counterfactual-depth queue into the Phase 45 branch-generalization queue while preserving `v0.1.0` as the latest published release baseline.
+- The current repository state has advanced from the Phase 45 branch-generalization queue into the Phase 46 workbench-focus queue while preserving `v0.1.0` as the latest published release baseline.
 
 ## Next Entry Point
 
-- Phase 45 is now the sole active milestone, and `#326` `Phase 45: consume compare artifacts in focused diff surfaces` is the current ready work item.
-- The next unlock order is fixed: `#322` remains blocked as the Phase 45 exit gate, `#323` is closed after queue bootstrap, `#324` is closed after ADR ratification, `#325` is closed after merging the runner and compare-artifact implementation, and `#326` is now ready for focused diff-surface consumption work.
-- Phase 46 remains the documented successor direction, but it must not be opened while Phase 45 remains active.
+- Phase 46 is now the sole active milestone, and `Phase 46: extract review-scorecard into modular feature slices` is the current ready work item.
+- The next unlock order is fixed: `Phase 46 exit gate` remains blocked, the queue-sync issue is already closed after successor bootstrap, the review-scorecard modularization issue is ready, and the remaining two frontend work items stay blocked until the queue advances.
+- No Phase 47 milestone is pre-opened in this round; any successor beyond Phase 46 requires a fresh decision against the blueprint triggers in `mirror.md`.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
-- The local queue heartbeat remains active as `mirror-queue-heartbeat` and should now report the Phase 45 queue as `ready`; it must not open another milestone while Phase 45 is active.
+- The local queue heartbeat remains active as `mirror-queue-heartbeat` and should now report the Phase 46 queue as `ready`; it must not open another milestone while Phase 46 is active.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 44 counterfactual-depth queue, and the Phase 45 successor bootstrap.
+This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 45 closeout, and the Phase 46 successor bootstrap.
 
 ## Current Gate State
 
@@ -48,7 +48,8 @@ This note records the current post-Day-0 execution status for Mirror after the f
 - Phase 42 exit gate: closed
 - Phase 43 exit gate: closed
 - Phase 44 exit gate: closed
-- Phase 45 exit gate: open
+- Phase 45 exit gate: closed
+- Phase 46 exit gate: open
 
 Local phase audits currently report:
 
@@ -56,29 +57,46 @@ Local phase audits currently report:
 - `phase2`: pass
 - `phase3`: pass
 
-## Active Phase 45 Queue
+## Active Phase 46 Queue
 
-- milestone `Phase 45 - Branch Generalization and Compare Contracts`
+- milestone `Phase 46 - Workbench Focus and Modularity`
   - open
-- `#322` `Phase 45 exit gate`
+- `Phase 46 exit gate`
   - open
   - `status:blocked`
-- `#323` `Phase 45: sync repo truth to Phase 45 queue`
+- `Phase 46: sync repo truth to Phase 46 queue`
   - closed
-  - merged via PR `#327`
-- `#324` `Phase 45: ratify multi-branch compare ADR and contracts`
-  - closed
-  - merged via PR `#329`
-- `#325` `Phase 45: implement branch_count runner and compare artifacts`
-  - closed
-  - merged via PR `#331`
-- `#326` `Phase 45: consume compare artifacts in focused diff surfaces`
+  - merged via the Phase 46 queue-sync PR
+- `Phase 46: extract review-scorecard into modular feature slices`
   - open
   - `status:ready`
+- `Phase 46: define the default operator path around compare-evidence-eval`
+  - open
+  - `status:blocked`
+- `Phase 46: move secondary packet surfaces behind advanced navigation`
+  - open
+  - `status:blocked`
 - `audit-github-queue`
-  - reports `ready` against the Phase 45 milestone because exactly one open milestone exists with a protected blocked exit gate and ready work items
-  - the current ready work item is `#326`
+  - reports `ready` against the Phase 46 milestone because exactly one open milestone exists with a protected blocked exit gate and ready work items
+  - the current ready work item is `Phase 46: extract review-scorecard into modular feature slices`
 - recent closeout
+  - milestone `Phase 45 - Branch Generalization and Compare Contracts`
+    - closed
+  - `#322` `Phase 45 exit gate`
+    - closed
+  - `#323` `Phase 45: sync repo truth to Phase 45 queue`
+    - closed
+    - merged via PR `#327`
+  - `#324` `Phase 45: ratify multi-branch compare ADR and contracts`
+    - closed
+    - merged via PR `#329`
+  - `#325` `Phase 45: implement branch_count runner and compare artifacts`
+    - closed
+    - merged via PR `#331`
+  - `#326` `Phase 45: consume compare artifacts in focused diff surfaces`
+    - closed
+    - merged via PR `#333`
+- earlier closeout
   - milestone `Phase 44 - Counterfactual Depth and Eval Hardening`
     - closed
   - `#313` `Phase 44 exit gate`
@@ -92,9 +110,9 @@ Local phase audits currently report:
   - `#316` `Phase 44: add workbench counterfactual comparison overview`
     - closed
     - merged via PR `#321`
-- planned successor direction
-  - Phase 46: workbench focus and modularity
-  - it remains documented as the next route, but it is not an open milestone yet
+- successor posture
+  - no Phase 47 milestone is pre-opened in this round
+  - any successor beyond Phase 46 must be decided separately against the trigger conditions in `mirror.md`
 
 ## Closeout Snapshot
 
@@ -552,7 +570,7 @@ Local phase audits currently report:
 - Protected-core changes still require explicit review and must not auto-merge.
 - Long-running execution should assign exactly one writer worktree per issue.
 - When `audit-github-queue` reports `ready`, consume only the currently active milestone and do not parallel-open another execution queue.
-- While Phase 45 is active, do not open the planned Phase 46 milestone.
+- While Phase 46 is active, do not open a Phase 47 milestone without a fresh approval round.
 
 ## Historical Branch Status
 


### PR DESCRIPTION
## Summary
- add the Phase 46 milestone, label, and issue definitions to `.github/automation/bootstrap-spec.json`
- sync README and active-state docs to the post-closeout truth where Phase 46 becomes the sole active queue
- record that the Phase 46 queue-sync work closes immediately after bootstrap, leaving the review-scorecard modularization issue as the next ready work item

## Pre-merge validation
- `python scripts/bootstrap_github.py --repo YSCJRH/mirror-sim`
- `python -m backend.app.cli classify-lane --files .github/automation/bootstrap-spec.json README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`
- `./make.ps1 test`
- `./make.ps1 smoke`
- `./make.ps1 eval-demo`
- `python -m backend.app.cli audit-phase phase1`
- `python -m backend.app.cli audit-phase phase2`
- `python -m backend.app.cli audit-phase phase3`

## Post-merge GitHub handoff
- apply the bootstrap spec to create the Phase 46 milestone, label, and issues
- close the Phase 46 queue-sync issue immediately because this PR fulfills that work
- relabel `Phase 46: extract review-scorecard into modular feature slices` as the current `status:ready` work item
- close `#322` and close milestone `Phase 45 - Branch Generalization and Compare Contracts`
- verify `audit-github-queue --repo YSCJRH/mirror-sim` returns `ready` on Phase 46
