### PR TITLE
[codex] Sync Phase 46 queue docs after operator-path merge

### DIFF
--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -151,8 +151,8 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - `Phase 46 exit gate` is open and remains `status:blocked`.
 - `Phase 46: sync repo truth to Phase 46 queue` is closed after the successor bootstrap PR merges.
 - `Phase 46: extract review-scorecard into modular feature slices` is merged and closed via PR `#340`.
-- `Phase 46: define the default operator path around compare-evidence-eval` is now the current `status:ready` work item.
-- `Phase 46: move secondary packet surfaces behind advanced navigation` remains open and `status:blocked`.
+- `Phase 46: define the default operator path around compare-evidence-eval` is merged and closed via PR `#342`.
+- `Phase 46: move secondary packet surfaces behind advanced navigation` is now the current `status:ready` work item.
 - `audit-github-queue` now reports `ready` against the active Phase 46 milestone.
 - No Phase 47 milestone is pre-opened in this round.
 - The first formal repository release is published as `v0.1.0`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -207,8 +207,8 @@ This note is the active Phase 46 queue baseline after the formal `v0.1.0` releas
     - `Phase 46 exit gate` is `open` and remains `status:blocked`
     - `Phase 46: sync repo truth to Phase 46 queue` is `closed` after the successor bootstrap PR merges
     - `Phase 46: extract review-scorecard into modular feature slices` is `closed` after merging PR `#340`
-    - `Phase 46: define the default operator path around compare-evidence-eval` is `open` and is the current `status:ready` work item
-    - `Phase 46: move secondary packet surfaces behind advanced navigation` is `open` and remains `status:blocked`
+    - `Phase 46: define the default operator path around compare-evidence-eval` is `closed` after merging PR `#342`
+    - `Phase 46: move secondary packet surfaces behind advanced navigation` is `open` and is the current `status:ready` work item
   - `gh api repos/YSCJRH/mirror-sim/releases`
     - release `v0.1.0` exists and matches the committed release notes baseline
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
@@ -238,8 +238,8 @@ This note is the active Phase 46 queue baseline after the formal `v0.1.0` releas
 
 ## Next Entry Point
 
-- Phase 46 is now the sole active milestone, and `Phase 46: define the default operator path around compare-evidence-eval` is the current ready work item.
-- The next unlock order is fixed: `Phase 46 exit gate` remains blocked, the queue-sync issue is already closed after successor bootstrap, the review-scorecard modularization issue is closed after merging PR `#340`, the default-operator-path issue is now ready, and the advanced-navigation issue stays blocked until the queue advances.
+- Phase 46 is now the sole active milestone, and `Phase 46: move secondary packet surfaces behind advanced navigation` is the current ready work item.
+- The next unlock order is fixed: `Phase 46 exit gate` remains blocked, the queue-sync issue is already closed after successor bootstrap, the review-scorecard modularization issue is closed after merging PR `#340`, the default-operator-path issue is closed after merging PR `#342`, and the advanced-navigation issue is now ready as the last remaining execution slice before Phase 46 closeout.
 - No Phase 47 milestone is pre-opened in this round; any successor beyond Phase 46 requires a fresh decision against the blueprint triggers in `mirror.md`.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -71,14 +71,14 @@ Local phase audits currently report:
   - closed
   - merged via PR `#340`
 - `Phase 46: define the default operator path around compare-evidence-eval`
-  - open
-  - `status:ready`
+  - closed
+  - merged via PR `#342`
 - `Phase 46: move secondary packet surfaces behind advanced navigation`
   - open
-  - `status:blocked`
+  - `status:ready`
 - `audit-github-queue`
   - reports `ready` against the Phase 46 milestone because exactly one open milestone exists with a protected blocked exit gate and ready work items
-  - the current ready work item is `Phase 46: define the default operator path around compare-evidence-eval`
+  - the current ready work item is `Phase 46: move secondary packet surfaces behind advanced navigation`
 - recent closeout
   - milestone `Phase 45 - Branch Generalization and Compare Contracts`
     - closed


### PR DESCRIPTION
## Summary
- sync the Phase 46 queue docs after merging the default-operator-path work
- record that `#338` is closed via PR `#342`
- update the active ready work item to `#339` `Phase 46: move secondary packet surfaces behind advanced navigation`

## Testing
- `python -m backend.app.cli classify-lane --files docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md`
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
