### PR TITLE
[codex] Close Phase 46 into paused stop-state

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ mirror-sim
 ## Current Status | 当前状态
 
 - **Formal release `v0.1.0` | 正式版本 `v0.1.0`**: The first formal GitHub Release remains published and anchors the current repository baseline.
-- **Active successor queue | 当前后继队列**: Phase 46, `Workbench Focus and Modularity`, is now the sole open execution milestone and the GitHub queue reports `ready`.
-- **Recent closeout | 最近收口**: Phase 45 is formally closed after landing the compare-contract ADR, the branch-count runner and compare artifacts, and the focused diff-surface handoff.
-- **Planned next route | 已定后续主线**: No Phase 47 milestone is pre-opened in this round; any successor beyond Phase 46 requires a fresh decision against the `mirror.md` trigger conditions.
-- **Repo truth lives in docs | 仓库真相以文档为准**: See [mirror.md](mirror.md) for the project blueprint, [docs/plans/current-state-baseline.md](docs/plans/current-state-baseline.md) for the active queue baseline, and [docs/releases/v0.1.0.md](docs/releases/v0.1.0.md) for the canonical release notes.
+- **Queue state | 当前队列状态**: Phase 46, `Workbench Focus and Modularity`, is formally closed. No approved Phase 47 milestone exists, so the GitHub queue is intentionally `paused` with no open milestone.
+- **Recent closeout | 最近收口**: Phase 46 is formally closed after modularizing the review scorecard, centering the default path on compare/evidence/eval, and moving packet-heavy surfaces behind advanced navigation.
+- **Planned next route | 已定后续主线**: No Phase 47 milestone is approved or open in this round; any successor beyond Phase 46 requires a fresh decision against the `mirror.md` trigger conditions.
+- **Repo truth lives in docs | 仓库真相以文档为准**: See [mirror.md](mirror.md) for the project blueprint, [docs/plans/current-state-baseline.md](docs/plans/current-state-baseline.md) for the current stop-state baseline, and [docs/releases/v0.1.0.md](docs/releases/v0.1.0.md) for the canonical release notes.
 
 ---
 

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, the first formal release remains published as `v0.1.0`, and the repo has now advanced the active queue to Phase 46.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, the first formal release remains published as `v0.1.0`, and the repo has returned to the intentional `paused` stop-state with no approved successor milestone.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -146,19 +146,19 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - `#324` `Phase 45: ratify multi-branch compare ADR and contracts` is merged and closed via PR `#329`.
 - `#325` `Phase 45: implement branch_count runner and compare artifacts` is merged and closed via PR `#331`.
 - `#326` `Phase 45: consume compare artifacts in focused diff surfaces` is merged and closed via PR `#333`.
-- Phase 46 is now open in GitHub.
-- milestone `Phase 46 - Workbench Focus and Modularity` is open.
-- `Phase 46 exit gate` is open and remains `status:blocked`.
-- `Phase 46: sync repo truth to Phase 46 queue` is closed after the successor bootstrap PR merges.
-- `Phase 46: extract review-scorecard into modular feature slices` is merged and closed via PR `#340`.
-- `Phase 46: define the default operator path around compare-evidence-eval` is merged and closed via PR `#342`.
-- `Phase 46: move secondary packet surfaces behind advanced navigation` is now the current `status:ready` work item.
-- `audit-github-queue` now reports `ready` against the active Phase 46 milestone.
-- No Phase 47 milestone is pre-opened in this round.
+- Phase 46 is now closed in GitHub after landing the final advanced-navigation slice.
+- milestone `Phase 46 - Workbench Focus and Modularity` is closed.
+- `#335` `Phase 46 exit gate` is closed after the formal closeout.
+- `#336` `Phase 46: sync repo truth to Phase 46 queue` is closed after the successor bootstrap PR merges.
+- `#337` `Phase 46: extract review-scorecard into modular feature slices` is merged and closed via PR `#340`.
+- `#338` `Phase 46: define the default operator path around compare-evidence-eval` is merged and closed via PR `#342`.
+- `#339` `Phase 46: move secondary packet surfaces behind advanced navigation` is merged and closed via PR `#344`.
+- `audit-github-queue` now reports `paused` with no active milestone because no approved successor queue is open.
+- No Phase 47 milestone is approved or open in this round.
 - The first formal repository release is published as `v0.1.0`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
-- The local Codex queue heartbeat should now follow the active Phase 46 queue instead of reporting the interim no-ready-item state as `paused`.
+- The local Codex queue heartbeat should now remain `paused` until an approved successor milestone is defined.
 
 ## Day 0 Bootstrap
 
@@ -211,5 +211,5 @@ Before builder automation is allowed to write code or auto-merge:
 - Long-running execution must run from isolated worktrees rather than the current `main` checkout.
 - Queue pickup order, one-writer ownership, and branch hygiene should follow `docs/plans/long-running-loop-runbook.md`.
 - When the active milestone exists and the queue reports `ready`, the builder may resume against that milestone only.
-- While Phase 46 is active, do not open a Phase 47 milestone without a fresh approval round.
+- No Phase 47 milestone is approved in this round; reopening the queue after Phase 46 requires a fresh approval round.
 - When no open milestone exists and `audit-github-queue` reports `paused`, treat that state as an intentional released stop-state rather than a broken queue.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the active Phase 46 queue baseline after the formal `v0.1.0` release closeout, the completed Phase 45 closeout, and the completed successor handoff into the workbench-focus queue.
+This note is the intentional post-Phase-46 stop-state baseline after the formal `v0.1.0` release closeout, the completed Phase 46 workbench-focus queue, and the absence of an approved Phase 47 successor.
 
 ## Snapshot
 
@@ -201,18 +201,20 @@ This note is the active Phase 46 queue baseline after the formal `v0.1.0` releas
     - Phase 45 runner/artifact issue is `closed` after merging PR `#331`
   - `gh api repos/YSCJRH/mirror-sim/issues/326`
     - Phase 45 focused diff-surface issue is `closed` after merging PR `#333`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/46`
+    - milestone `Phase 46 - Workbench Focus and Modularity` is `closed` after the formal closeout
   - `gh api "repos/YSCJRH/mirror-sim/milestones?state=open"`
-    - exactly one open milestone exists: `Phase 46 - Workbench Focus and Modularity`
+    - no open milestone remains after the Phase 46 closeout
   - `gh issue list --milestone "Phase 46 - Workbench Focus and Modularity" --state all`
-    - `Phase 46 exit gate` is `open` and remains `status:blocked`
+    - `Phase 46 exit gate` is `closed` after the formal closeout
     - `Phase 46: sync repo truth to Phase 46 queue` is `closed` after the successor bootstrap PR merges
     - `Phase 46: extract review-scorecard into modular feature slices` is `closed` after merging PR `#340`
     - `Phase 46: define the default operator path around compare-evidence-eval` is `closed` after merging PR `#342`
-    - `Phase 46: move secondary packet surfaces behind advanced navigation` is `open` and is the current `status:ready` work item
+    - `Phase 46: move secondary packet surfaces behind advanced navigation` is `closed` after merging PR `#344`
   - `gh api repos/YSCJRH/mirror-sim/releases`
     - release `v0.1.0` exists and matches the committed release notes baseline
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - queue now reports `ready` against the active `Phase 46 - Workbench Focus and Modularity` milestone
+    - queue now reports `paused` with no active milestone because no approved successor phase is open
 
 ## Trusted Source Of Truth
 
@@ -234,13 +236,13 @@ This note is the active Phase 46 queue baseline after the formal `v0.1.0` releas
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
 - The default workbench path now consumes the canonical compare artifact directly and keeps focused divergent trace surfaces ahead of heavier packet-driven review flows.
 - The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, execution recovery release boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, escalation acknowledgment packets, and escalation closure packets without introducing backend API expansion.
-- The current repository state has advanced from the Phase 45 branch-generalization queue into the Phase 46 workbench-focus queue while preserving `v0.1.0` as the latest published release baseline.
+- The current repository state has now completed the Phase 46 workbench-focus queue and returned to the intentional `paused` stop-state while preserving `v0.1.0` as the latest published release baseline.
 
 ## Next Entry Point
 
-- Phase 46 is now the sole active milestone, and `Phase 46: move secondary packet surfaces behind advanced navigation` is the current ready work item.
-- The next unlock order is fixed: `Phase 46 exit gate` remains blocked, the queue-sync issue is already closed after successor bootstrap, the review-scorecard modularization issue is closed after merging PR `#340`, the default-operator-path issue is closed after merging PR `#342`, and the advanced-navigation issue is now ready as the last remaining execution slice before Phase 46 closeout.
-- No Phase 47 milestone is pre-opened in this round; any successor beyond Phase 46 requires a fresh decision against the blueprint triggers in `mirror.md`.
+- The repo is now in the intentional `paused` stop-state with no open milestone and no approved Phase 47 successor.
+- The Phase 46 unlock order is now fully resolved: the queue-sync issue is closed after successor bootstrap, the review-scorecard modularization issue is closed after merging PR `#340`, the default-operator-path issue is closed after merging PR `#342`, the advanced-navigation issue is closed after merging PR `#344`, and the exit gate closes with the milestone.
+- No Phase 47 milestone is approved or open in this round; any successor beyond Phase 46 requires a fresh decision against the blueprint triggers in `mirror.md`.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
-- The local queue heartbeat remains active as `mirror-queue-heartbeat` and should now report the Phase 46 queue as `ready`; it must not open another milestone while Phase 46 is active.
+- The local queue heartbeat remains active as `mirror-queue-heartbeat` but should now report the repo as `paused` until an approved successor milestone exists.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 45 closeout, and the Phase 46 successor bootstrap.
+This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 46 closeout, and the return to the intentional stop-state with no approved successor milestone.
 
 ## Current Gate State
 
@@ -49,7 +49,7 @@ This note records the current post-Day-0 execution status for Mirror after the f
 - Phase 43 exit gate: closed
 - Phase 44 exit gate: closed
 - Phase 45 exit gate: closed
-- Phase 46 exit gate: open
+- Phase 46 exit gate: closed
 
 Local phase audits currently report:
 
@@ -57,13 +57,12 @@ Local phase audits currently report:
 - `phase2`: pass
 - `phase3`: pass
 
-## Active Phase 46 Queue
+## Post-Phase 46 Stop-State
 
 - milestone `Phase 46 - Workbench Focus and Modularity`
-  - open
+  - closed
 - `Phase 46 exit gate`
-  - open
-  - `status:blocked`
+  - closed
 - `Phase 46: sync repo truth to Phase 46 queue`
   - closed
   - merged via the Phase 46 queue-sync PR
@@ -74,11 +73,10 @@ Local phase audits currently report:
   - closed
   - merged via PR `#342`
 - `Phase 46: move secondary packet surfaces behind advanced navigation`
-  - open
-  - `status:ready`
+  - closed
+  - merged via PR `#344`
 - `audit-github-queue`
-  - reports `ready` against the Phase 46 milestone because exactly one open milestone exists with a protected blocked exit gate and ready work items
-  - the current ready work item is `Phase 46: move secondary packet surfaces behind advanced navigation`
+  - reports `paused` with no active milestone because no approved successor phase is open
 - recent closeout
   - milestone `Phase 45 - Branch Generalization and Compare Contracts`
     - closed
@@ -111,7 +109,7 @@ Local phase audits currently report:
     - closed
     - merged via PR `#321`
 - successor posture
-  - no Phase 47 milestone is pre-opened in this round
+  - no Phase 47 milestone is approved or open in this round
   - any successor beyond Phase 46 must be decided separately against the trigger conditions in `mirror.md`
 
 ## Closeout Snapshot
@@ -570,7 +568,7 @@ Local phase audits currently report:
 - Protected-core changes still require explicit review and must not auto-merge.
 - Long-running execution should assign exactly one writer worktree per issue.
 - When `audit-github-queue` reports `ready`, consume only the currently active milestone and do not parallel-open another execution queue.
-- While Phase 46 is active, do not open a Phase 47 milestone without a fresh approval round.
+- No Phase 47 milestone is approved in this round; reopening the queue after Phase 46 requires a fresh approval round.
 
 ## Historical Branch Status
 


### PR DESCRIPTION
## Summary
- update README and active-state docs from an active Phase 46 queue to the intentional paused stop-state
- record that Phase 46 is complete and no approved Phase 47 milestone is open
- keep `v0.1.0` as the current published release baseline while the repo waits for a fresh successor decision

## Testing
- python -m backend.app.cli classify-lane --files README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
- ./make.ps1 test
- python -m backend.app.cli audit-phase phase1
- python -m backend.app.cli audit-phase phase2
- python -m backend.app.cli audit-phase phase3

## Post-merge closeout
- close milestone `Phase 46 - Workbench Focus and Modularity`
- close `#335` `Phase 46 exit gate`
- verify `audit-github-queue --repo YSCJRH/mirror-sim` returns `paused` with no active milestone
