### PR TITLE
[codex] Prove two-world transferability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,62 +1,73 @@
-﻿# AGENTS.md
+# AGENTS.md
 
-鏈粨搴撶殑闀挎湡椤圭洰钃濆浘銆佽竟鐣屻€佹灦鏋勬剰鍥句笌闃舵璺嚎瑙佹牴鐩綍 `mirror.md`銆? 
-鏈枃浠跺彧淇濈暀 Codex 鎵ц鏃堕渶瑕佷紭鍏堥伒瀹堢殑鐭鍒欏拰鍛戒护鍏ュ彛銆? 
-濡傛棤鏄庣‘渚嬪锛屾墍鏈夊疄鐜板簲涓?`mirror.md` 淇濇寔涓€鑷淬€?
+Mirror's long-term blueprint, safety boundaries, and architecture intent live in the repo-root `mirror.md`.
+Unless a task explicitly says otherwise, implementation should stay aligned with `mirror.md`.
+
+This file keeps only the short execution rules that Codex should follow first.
+
 ## Intent
 
-Mirror 鏄彈闄愬煙銆佸彲杩芥函銆佽瘉鎹害鏉熺殑鏉′欢鍖栨帹婕旀矙鐩樸€?
-## Non-goals
+Mirror is a constrained, evidence-backed, replayable what-if simulation sandbox for fictional or explicitly authorized worlds.
 
-- 涓嶅仛鐪熷疄涓栫晫棰勬祴鏈哄櫒
-- 涓嶅仛鐪熷疄浜虹墿鐢诲儚鎴栨暟瀛楁浛韬?- 涓嶅仛鏀挎不鎿嶆帶銆佹墽娉曢娴嬨€佹嫑鑱?淇¤捶/鍖荤枟/鍙告硶涓綋鍖栬瘎鍒?- 涓嶆妸妯℃嫙缁撴灉鍖呰鎴愮幇瀹炵粨璁?
+## Non-Goals
+
+- Do not present Mirror as a real-world prediction machine.
+- Do not build real-person personas or digital doubles.
+- Do not build political persuasion, law-enforcement scoring, hiring, credit, medical, or judicial decision systems.
+- Do not package simulation output as certain real-world conclusions.
+
 ## Repo Map
 
-- `mirror.md`: 椤跺眰钃濆浘涓庨暱鏈熺害鏉?- `README.md`: 瀵瑰绠€浠嬨€佸揩閫熷紑濮嬨€佸懡浠ゅ叆鍙?- `docs/plans/`: 鍏蜂綋浠诲姟璁″垝
-- `docs/decisions/`: ADR / 鍐崇瓥璁板綍
-- `.agents/skills/`: 绐勮亴璐?Codex workflows
-- `data/demo/`: demo corpus銆乻cenarios銆乪xpectations
-- `backend/`: FastAPI銆丳ydantic銆丆LI銆乸ipeline
-- `evals/`: assertions銆乨ataset銆佽剼鏈?- `artifacts/`: 杩愯浜х墿锛岄粯璁や笉鍏ュ簱
+- `mirror.md`: long-term project blueprint and boundaries
+- `README.md`: public overview and quickstart
+- `docs/plans/`: active plans and baselines
+- `docs/decisions/`: ADRs and durable design decisions
+- `data/demo/`: canonical Fog Harbor demo data
+- `data/worlds/`: additional bounded worlds such as transfer demos
+- `backend/`: CLI, pipeline, automation, and service code
+- `frontend/`: review workbench
+- `evals/`: assertions and eval assets
+- `artifacts/`: generated outputs, not committed
 
-## Commands
-
-Canonical target names:
+## Canonical Commands
 
 - `make setup`
 - `make smoke`
 - `make test`
 - `make eval-demo`
+- `make eval-transfer`
 - `make dev-api`
 - `make dev-web`
 
-Windows/PowerShell 鍏煎鍏ュ彛锛?
+Windows entrypoints:
+
 - `./make.ps1 setup`
 - `./make.ps1 smoke`
 - `./make.ps1 test`
 - `./make.ps1 eval-demo`
+- `./make.ps1 eval-transfer`
 
 ## Working Rules
 
-- 瑙﹀強瓒呰繃 3 涓枃浠跺墠锛屽厛缁欑畝鐭鍒掋€?- 瑙﹀強 schema銆乻cenario DSL銆乧laim label銆乺un trace銆乤rtifacts tree 鍓嶏紝鍏堟敹鍙ｅ绾︺€?- 鏀规牳蹇冨绾︽椂锛屽悓姝ユ洿鏂?`docs/architecture/contracts.md`锛屽繀瑕佹椂鏂板 `docs/decisions/` 璁板綍銆?- 姣忎釜浠诲姟閮借甯︽渶灏忓懡浠ゆ垨娴嬭瘯銆?- 姣忎釜鏂板 report claim 閮藉繀椤讳繚鐣?`label` 涓?`evidence_ids`銆?- 鎵€鏈変笉纭畾椤规樉寮忓啓鎴?`TODO[verify]: ...`锛屼笉鍏佽缂栭€犮€?
-## Subagent Rules
-- 子代理默认采用最新最强模型（如 \gpt-5.4\，配合 \xhigh\ 级推理强度），仅在明确追求速度、成本或其他性能需求时，才可降级到更轻量模型（如 \gpt-5.4-mini\、\gpt-5.2-codex\）。
-
-- 瀛愪唬鐞嗕笉鏄粯璁ゆ洿寮猴紝榛樿妯″紡鏄€滀富浠ｇ悊 + 鍙渚﹀療 + 鍗曞啓鎵嬧€濄€?- 浠呭綋浠诲姟鑷冲皯婊¤冻涓嬪垪 2 鏉℃椂锛屾墠寤鸿 spawn 瀛愪唬鐞嗭細
-  - 鍙媶鎴?2 涓互涓婄浉瀵圭嫭绔嬬殑瀛愰棶棰?  - 瀛愰棶棰樹箣闂翠富瑕佹槸淇℃伅姹囨€诲叧绯伙紝涓嶆槸鎸佺画鍏卞悓鍐欎綔
-  - 姣忎釜瀛愰棶棰橀兘鑳藉畾涔夋竻鏅拌緭鍑烘牸寮?- 瀛愪唬鐞嗕紭鍏堢敤浜庯細浠撳簱鎽稿簳銆佹枃妗?瑙勮寖鏍搁獙銆佹祴璇曠己鍙ｆ壂鎻忋€乪val 褰掑洜銆乁I/bug 澶嶇幇鍙栬瘉銆佸畨鍏ㄧ孩绾垮鏌ャ€?- 瀛愪唬鐞嗕笉閫傚悎锛歚mirror.md` 绾ц摑鍥句慨鏀广€佹牳蹇?schema/graph/scenario DSL/simulation contract 鏀瑰啓銆佸叧閿皟搴﹂€昏緫骞惰鏀瑰啓銆侀渶瑕佸涓?writer 鍚屾椂纰板悓涓€鏍稿績鏂囦欢鎴栨牳蹇?contract 鐨勪换鍔°€?- 娑夊強鏍稿績鏋舵瀯銆佸绾︽敹鍙ｃ€佹槸鍚︽敼 `mirror.md`銆佹槸鍚︽敼 `docs/architecture/contracts.md`銆佹槸鍚︽柊澧?ADR銆佹渶缁堟柟妗堥€夋嫨锛屽繀椤荤敱涓讳唬鐞嗗崟绾跨▼鎷嶆澘銆?- `repo_explorer`銆乣docs_researcher`銆乣safety_reviewer` 蹇呴』鍙锛沗evaluator` 鍙厑璁歌窇楠岃瘉鍛戒护鍜屾鏌?artifacts锛屼笉鏀?tracked files锛沗implementer` 鏄敮涓€寤鸿鍙啓瑙掕壊銆?- 榛樿鍙紑 1-2 涓彧璇诲瓙浠ｇ悊鍋氭悳璇佹垨鏍搁獙锛泈riter 蹇呴』鍦ㄤ富浠ｇ悊瀹屾垚姹囨€诲悗鍐嶅嚭鎵嬶紝涓嶄笌鍙︿竴涓?writer 骞惰鏀瑰悓涓€鐗囦唬鐮併€?- 涓讳唬鐞嗗湪 spawn 鍓嶅繀椤诲厛鍐欐竻瀛愪换鍔¤竟鐣屻€佺洰鏍囨枃浠舵垨鐩爣璇佹嵁闈紝涓嶅厑璁告ā绯婂鎵樸€?- 姣忎釜瀛愪唬鐞嗚繑鍥炲繀椤诲敖閲忎娇鐢ㄧ粺涓€缁撴瀯锛?  - `summary`
-  - `evidence`
-  - `risks`
-  - `recommended_action`
-  - `needs_decision`
-- `evidence` 搴斾紭鍏堝寘鍚枃浠惰矾寰勩€佺鍙峰悕銆佸懡浠ゃ€乤rtifact 璺緞鎴栨枃妗ｄ綅缃紱涓嶇‘瀹氶」缁х画鍐欐垚 `TODO[verify]: ...`銆?- 閲嶅鎬ч珮銆佽竟鐣岀ǔ瀹氱殑娴佺▼锛屼紭鍏堟矇娣€涓?`.agents/skills/`锛屼笉瑕佹瘡娆′复鏃?prompt 涓€涓€滃ぇ鑰屽叏鈥濆瓙浠ｇ悊銆?- 鏇撮暱鐢熷懡鍛ㄦ湡鐨勫苟琛屽紑鍙戜紭鍏堢敤 thread / worktree 鎷嗗垎锛屼笉鐢ㄩ€掑綊 delegation锛涢」鐩骇 subagent 瑙勫垯瑙?`docs/subagents.md` 涓?`.codex/`.
+- If a change touches more than 3 files, share a brief plan first.
+- Before changing schema, scenario DSL, claim labels, run trace shape, or artifact layout, confirm the contract boundary.
+- If a task changes a core contract, update `docs/architecture/contracts.md` and add an ADR when the contract is long-lived.
+- Every task should end with at least one concrete validation command or test.
+- Every report claim must keep both `label` and `evidence_ids`.
+- Write uncertainty explicitly as `TODO[verify]: ...`; do not invent facts.
 
 ## Safety And Licensing
 
-- 鍙?ingest 鏄庣‘鍏佽鐨勬暟鎹€?- `data/demo/` 涓€寰嬩负鍘熷垱銆佽櫄鏋勩€佸彲鍏紑灞曠ず鍐呭銆?- 榛樿鎷︽埅鐪熷疄浜虹墿 persona銆佹斂娌昏鏈嶃€佹墽娉?鎷涜仒/淇¤捶/鍖荤枟/鍙告硶棰勬祴銆侀殣钄界洃鎺с€?- 鍙傝€冨紑婧愰」鐩椂瀛?workflow锛屼笉鐩存帴鎼唬鐮侊紱鑻ユ湭鏉ュ紩鍏?AGPL 渚濊禆锛屽繀椤诲厛鍐欏喅绛栬褰曘€?
+- Only ingest clearly permitted data.
+- `data/demo/` and `data/worlds/` should remain original, fictional, or explicitly authorized.
+- Default to blocking real-person personas, political persuasion, hidden surveillance, and high-risk decision domains.
+- Borrow workflow ideas from open source projects, not copy-paste code. Record AGPL-sensitive dependency decisions before adoption.
+
 ## Definition Of Done
 
-- 鏈夊疄鐜?- 鏈夋渶灏忔祴璇曟垨 smoke 鍛戒护
-- 鏈夊彲瑙傚療杈撳嚭鎴?artifacts
-- 鏂囨。/濂戠害宸插悓姝?- 鏈牬鍧?claim / evidence 閾?- 鏈紩鍏ユ湭璁板綍鐨勯珮椋庨櫓杈圭晫
-
+- The feature or fix is implemented.
+- Minimal validation exists and passes, or the blocker is stated clearly.
+- Observable output or artifacts exist when the task is pipeline-facing.
+- Docs and contracts are synced when behavior changed.
+- Claim/evidence integrity is preserved.
+- New risks or unresolved edges are written down explicitly.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON ?= python
 
-.PHONY: setup smoke test eval-demo dev-api dev-web
+.PHONY: setup smoke test eval-demo eval-transfer dev-api dev-web
 
 setup:
 	$(PYTHON) -m pip install -e backend
@@ -13,6 +13,9 @@ test:
 
 eval-demo:
 	$(PYTHON) -m backend.app.cli eval-demo
+
+eval-transfer:
+	$(PYTHON) -m backend.app.cli eval-transfer
 
 dev-api:
 	$(PYTHON) -m uvicorn backend.app.main:app --reload

--- a/README.md
+++ b/README.md
@@ -4,147 +4,152 @@
   <img src="mirror.png" alt="Mirror concept illustration" width="100%" />
 </p>
 
-**A constrained multi-agent scenario simulation engine inspired by Liu Cixin's _The Mirror_.**
+**A constrained, evidence-backed scenario simulation engine for fictional or explicitly authorized worlds.**
 
-**基于刘慈欣《镜子》启发设计的受约束多智能体情景模拟引擎。**
-
----
-
-## Introduction | 简介
-
-Mirror Engine aims to build a controlled, evidence-backed virtual environment for multi-agent simulation and scenario exploration. It combines graph-based world modeling, scenario injection, deterministic runs, and a browser review workbench so researchers and developers can inspect how disturbances propagate through actors, information flows, and outcomes.
-
-Mirror Engine 项目旨在构建一个可控、可追踪、可验证的多智能体情景推演环境。项目融合知识图谱、情景注入、确定性模拟、报告生成与浏览器审查工作台，用于帮助研究者和开发者观察扰动如何沿着角色、信息流和结果路径传播。
-
-The repository is designed for fictional or explicitly authorized knowledge environments. It is not presented as an open-world prediction machine, but as a constrained sandbox for interpretable scenario analysis.
-
-本仓库面向虚构或经明确授权的知识环境，不将自己包装成现实世界预测机器，而是一个用于可解释情景分析的受约束模拟沙盒。
+**一个面向虚构或明确授权知识环境的、受约束且证据可追溯的情景推演引擎。**
 
 ---
 
-## Features | 功能特性
+## What Mirror Is | Mirror 是什么
 
-- **Deterministic simulation backbone | 确定性模拟主干**: Build a repeatable flow from corpus ingestion to graph, personas, validated scenarios, simulation runs, reports, and evals.
-- **Graph-based world modeling | 图谱化世界建模**: Organize entities, relationships, and constraints into a queryable world model for scenario execution.
-- **Scenario injection and control | 情景注入与控制**: Define disturbances explicitly and compare baseline versus injected runs in a traceable way.
-- **Review workbench | 审查工作台**: Inspect claims, evidence, traces, reviewer views, and release-closeout surfaces in the browser workbench.
-- **Explainability and verifiability | 可解释与可验证**: Keep reports grounded in labeled claims and `evidence_ids` so outputs remain auditable.
-- **GitHub-native governance | GitHub 原生治理**: Use phase audits, queue audits, lane classification, and protected `main` workflows to support long-running execution safely.
+Mirror turns a small bounded corpus into a replayable pipeline:
+
+`corpus -> chunks -> graph -> personas -> scenarios -> deterministic runs -> report/claims -> eval`
+
+It is built for what-if analysis in constrained worlds, not for open-world prediction.
+
+Mirror 用于在受限世界中做条件化 what-if 推演，而不是做开放世界预测。
+
+## What Mirror Is Not | Mirror 不是什么
+
+- Not a real-world prediction machine
+- Not a real-person profiling system
+- Not a political influence, law-enforcement, hiring, credit, medical, or judicial decision system
+- Not an open-world digital twin platform
 
 ---
 
-## Getting Started | 快速开始
+## Why Claims, Evidence, And Eval Matter | 为什么强调 claims、evidence 和 eval
 
-### Prerequisites | 环境要求
+- `evidence_ids` keep world objects, actions, and report claims tied to source chunks.
+- claim labels distinguish direct branch facts from bounded inference.
+- evals prove the pipeline is still deterministic, replayable, and safe enough to trust as a sandbox.
 
-- Python 3.11+
-- Node.js 18+
-- `make` for Unix-like shells, or PowerShell on Windows
+如果没有 `evidence_ids`、claim labels 和 eval，Mirror 就只是“会跑的故事”；有了它们，输出才是可审查、可回放、可评估的推演结果。
 
-### Installation | 安装
+---
 
-Clone the repository:
+## 3-Minute Demo Path | 3 分钟上手路径
+
+Clone the repo:
 
 ```bash
 git clone https://github.com/YSCJRH/mirror-sim.git
 cd mirror-sim
 ```
 
-Install the backend package:
-
-Unix-like shells:
+Install the backend:
 
 ```bash
 make setup
 ```
 
-PowerShell:
-
 ```powershell
 ./make.ps1 setup
 ```
 
-### Running the Application | 启动应用
-
-Start the backend API:
-
-```bash
-make dev-api
-```
-
-```powershell
-./make.ps1 dev-api
-```
-
-Launch the frontend workbench:
-
-```bash
-make dev-web
-```
-
-```powershell
-./make.ps1 dev-web
-```
-
-Validate the local baseline:
+Run the canonical checks:
 
 ```bash
 make smoke
 make test
 make eval-demo
+make eval-transfer
 ```
 
 ```powershell
 ./make.ps1 smoke
 ./make.ps1 test
 ./make.ps1 eval-demo
+./make.ps1 eval-transfer
+```
+
+Start the local workbench:
+
+```bash
+make dev-api
+make dev-web
+```
+
+```powershell
+./make.ps1 dev-api
+./make.ps1 dev-web
+```
+
+Extra transfer proof:
+
+```bash
+python -m backend.app.cli eval-world --world museum-night
 ```
 
 ---
 
-## Project Structure | 项目结构
+## What You Can Inspect Locally | 本地能看到什么
 
-```text
-mirror-sim
-├── .github/         # GitHub workflows, templates, and automation governance
-├── backend/         # FastAPI app, CLI, automation helpers, and pipeline code
-├── frontend/        # Next.js review workbench
-├── data/            # Demo corpus, scenarios, and world-model inputs
-├── docs/            # Plans, decisions, architecture notes, and release docs
-├── evals/           # Assertions and evaluation assets
-└── scripts/         # Bootstrap and utility scripts
-```
+- Canonical Fog Harbor artifacts under `artifacts/demo/`
+- Second-world transfer artifacts under `artifacts/worlds/museum-night/`
+- Transfer summary under `artifacts/transfer/summary.json`
+- Review workbench reading from the canonical compare/evidence/eval path
+
+Useful artifact checkpoints:
+
+- `artifacts/demo/graph/graph.json`
+- `artifacts/demo/personas/personas.json`
+- `artifacts/demo/report/claims.json`
+- `artifacts/demo/eval/summary.json`
+- `artifacts/worlds/museum-night/eval/summary.json`
+
+For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-walkthrough.md](docs/demo/fog-harbor-walkthrough.md).
 
 ---
 
 ## Current Status | 当前状态
 
-- **Formal release `v0.1.0` | 正式版本 `v0.1.0`**: The first formal GitHub Release remains published and anchors the current repository baseline.
-- **Queue state | 当前队列状态**: Phase 46, `Workbench Focus and Modularity`, is formally closed. No approved Phase 47 milestone exists, so the GitHub queue is intentionally `paused` with no open milestone.
-- **Recent closeout | 最近收口**: Phase 46 is formally closed after modularizing the review scorecard, centering the default path on compare/evidence/eval, and moving packet-heavy surfaces behind advanced navigation.
-- **Planned next route | 已定后续主线**: No Phase 47 milestone is approved or open in this round; any successor beyond Phase 46 requires a fresh decision against the `mirror.md` trigger conditions.
-- **Repo truth lives in docs | 仓库真相以文档为准**: See [mirror.md](mirror.md) for the project blueprint, [docs/plans/current-state-baseline.md](docs/plans/current-state-baseline.md) for the current stop-state baseline, and [docs/releases/v0.1.0.md](docs/releases/v0.1.0.md) for the canonical release notes.
+- `v0.1.0` is the formal release baseline.
+- The current stop-state / queue state lives in [docs/plans/current-state-baseline.md](docs/plans/current-state-baseline.md).
+- No Phase 47 is pre-opened or implied here.
+- Fog Harbor remains the canonical demo world; `museum-night` is the minimal transfer world used to prove the pipeline is not single-world-only.
 
 ---
 
-## Contribution | 贡献方式
+## Repo Layout | 仓库结构
 
-We welcome contributions and feedback. To participate:
+```text
+mirror-sim
+├── backend/          # CLI, pipeline, eval, and automation services
+├── frontend/         # review workbench
+├── data/demo/        # canonical Fog Harbor demo
+├── data/worlds/      # additional bounded worlds such as museum-night
+├── docs/             # plans, ADRs, contracts, walkthroughs, release notes
+├── evals/            # assertions and eval assets
+└── scripts/          # bootstrap and utility scripts
+```
 
-1. Fork this repository.
-2. Create a branch for your change.
-3. Commit with a focused message.
-4. Push the branch to your fork or remote.
-5. Open a Pull Request against `main`.
+---
 
-提交前请先阅读 [AGENTS.md](AGENTS.md)，了解当前仓库的执行规则、文档约束和协作方式。
+## Contributing | 贡献方式
 
-Pull requests will run the repository's existing checks and protection rules. This README refresh does not change the underlying governance flow.
+Read [AGENTS.md](AGENTS.md) before changing contracts, pipeline behavior, or docs. Mirror favors small, reviewable changes with explicit validation.
+
+Typical flow:
+
+1. Create a focused branch
+2. Make a bounded change
+3. Run the relevant checks
+4. Open a PR against `main`
 
 ---
 
 ## License | 许可证
 
-This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
-
-本项目采用 MIT License，详情请见 [LICENSE](LICENSE)。
+Mirror is released under the MIT License. See [LICENSE](LICENSE) for details.

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from backend.app.automation.service import audit_github_queue, classify_git_refs, classify_paths, run_phase_audit
 from backend.app.config import get_settings
-from backend.app.evals.service import run_phase0_demo
+from backend.app.evals.service import run_phase0_demo, run_transfer_eval, run_world_eval
 from backend.app.graph.service import build_graph
 from backend.app.ingest.service import ingest_manifest
 from backend.app.personas.service import build_personas
@@ -17,7 +17,7 @@ from backend.app.world_query import inspect_world
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Mirror Engine Phase 0 CLI")
+    parser = argparse.ArgumentParser(description="Mirror Engine CLI")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     ingest = subparsers.add_parser("ingest", help="Ingest a manifest-backed corpus")
@@ -46,6 +46,7 @@ def build_parser() -> argparse.ArgumentParser:
     report.add_argument("run")
     report.add_argument("--baseline")
     report.add_argument("--out", required=True)
+    report.add_argument("--simulation-rules")
 
     inspect = subparsers.add_parser("inspect-world", help="Inspect a world object from graph/persona artifacts")
     inspect.add_argument("--kind", required=True, choices=["entity", "persona", "event"])
@@ -67,6 +68,9 @@ def build_parser() -> argparse.ArgumentParser:
     queue.add_argument("--repo", required=True)
 
     subparsers.add_parser("eval-demo", help="Run the full Phase 0 demo pipeline")
+    eval_world = subparsers.add_parser("eval-world", help="Run the full world pipeline and transfer eval for one world")
+    eval_world.add_argument("--world", required=True)
+    subparsers.add_parser("eval-transfer", help="Run the transfer eval across the canonical demo and the second world")
     subparsers.add_parser("smoke", help="Run the end-to-end smoke pipeline")
     return parser
 
@@ -114,7 +118,12 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.command == "report":
-        claims = generate_report(Path(args.run), Path(args.out), baseline_dir=Path(args.baseline) if args.baseline else None)
+        claims = generate_report(
+            Path(args.run),
+            Path(args.out),
+            baseline_dir=Path(args.baseline) if args.baseline else None,
+            simulation_rules_path=Path(args.simulation_rules) if args.simulation_rules else None,
+        )
         print(f"Generated report with {len(claims)} claims.")
         return 0
 
@@ -146,6 +155,16 @@ def main(argv: list[str] | None = None) -> int:
         audit = audit_github_queue(args.repo, repo_root=settings.repo_root)
         print(json.dumps(audit.as_dict(), indent=2, ensure_ascii=False))
         return 0 if audit.status in {"ready", "paused"} else 1
+
+    if args.command == "eval-world":
+        result = run_world_eval(args.world, repo_root=settings.repo_root)
+        print(json.dumps(result.model_dump(), indent=2, ensure_ascii=False))
+        return 0 if result.status == "pass" else 1
+
+    if args.command == "eval-transfer":
+        result = run_transfer_eval(repo_root=settings.repo_root)
+        print(json.dumps(result.model_dump(), indent=2, ensure_ascii=False))
+        return 0 if result.status == "pass" else 1
 
     if args.command in {"eval-demo", "smoke"}:
         result = run_phase0_demo(settings=settings)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -3,14 +3,18 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from backend.app.worlds import CANONICAL_DEMO_WORLD_ID, resolve_world_paths
+
 
 @dataclass(frozen=True)
 class Settings:
     repo_root: Path
+    world_id: str
     data_root: Path
     artifacts_root: Path
     manifest_path: Path
     world_model_path: Path
+    simulation_rules_path: Path
     scenario_dir: Path
     baseline_scenario_path: Path
     intervention_scenario_path: Path
@@ -20,17 +24,18 @@ class Settings:
 
 def get_settings() -> Settings:
     repo_root = Path(__file__).resolve().parents[2]
-    data_root = repo_root / "data" / "demo"
-    artifacts_root = repo_root / "artifacts" / "demo"
+    world_paths = resolve_world_paths(CANONICAL_DEMO_WORLD_ID, repo_root=repo_root)
     return Settings(
         repo_root=repo_root,
-        data_root=data_root,
-        artifacts_root=artifacts_root,
-        manifest_path=data_root / "corpus" / "manifest.yaml",
-        world_model_path=data_root / "config" / "world_model.yaml",
-        scenario_dir=data_root / "scenarios",
-        baseline_scenario_path=data_root / "scenarios" / "baseline.yaml",
-        intervention_scenario_path=data_root / "scenarios" / "reporter_detained.yaml",
-        expectations_path=data_root / "expectations" / "demo_eval.yaml",
+        world_id=world_paths.world_id,
+        data_root=world_paths.data_root,
+        artifacts_root=world_paths.artifacts_root,
+        manifest_path=world_paths.manifest_path,
+        world_model_path=world_paths.world_model_path,
+        simulation_rules_path=world_paths.simulation_rules_path,
+        scenario_dir=world_paths.scenario_dir,
+        baseline_scenario_path=world_paths.baseline_scenario_path,
+        intervention_scenario_path=world_paths.scenario_dir / "reporter_detained.yaml",
+        expectations_path=world_paths.expectations_path or (world_paths.data_root / "expectations" / "demo_eval.yaml"),
         redlines_path=repo_root / "evals" / "assertions" / "redlines.yaml",
     )

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -168,7 +168,9 @@ class Claim(MirrorBaseModel):
 
 class EvalResult(MirrorBaseModel):
     eval_name: str
+    world_id: str | None = None
     status: str
     metrics: dict[str, Any] = Field(default_factory=dict)
     failures: list[str] = Field(default_factory=list)
     notes: list[str] = Field(default_factory=list)
+    artifact_paths: dict[str, str] = Field(default_factory=dict)

--- a/backend/app/evals/service.py
+++ b/backend/app/evals/service.py
@@ -12,6 +12,7 @@ from backend.app.ingest.service import ingest_manifest
 from backend.app.personas.service import build_personas
 from backend.app.reports.service import generate_report
 from backend.app.scenarios.service import validate_scenario
+from backend.app.simulation.rules import SimulationPlan, load_simulation_plan
 from backend.app.simulation.service import (
     BranchRunArtifacts,
     load_run_artifacts,
@@ -19,10 +20,12 @@ from backend.app.simulation.service import (
     simulate_scenario,
     write_compare_artifact,
 )
-from backend.app.utils import load_yaml, read_json, write_json
+from backend.app.utils import ensure_dir, load_yaml, read_json, read_jsonl, write_json
 from backend.app.world_query import inspect_world
+from backend.app.worlds import CANONICAL_DEMO_WORLD_ID, WorldPaths, resolve_world_paths
 
-DEMO_MATRIX_COMPARE_SCENARIO_ID = "scenario_fog_harbor_phase44_matrix"
+
+DEFAULT_TRANSFER_WORLD_IDS = [CANONICAL_DEMO_WORLD_ID, "museum-night"]
 
 
 def _compare(op: str, left: Any, right: Any) -> bool:
@@ -50,6 +53,29 @@ def _graph_collection_id_field(collection: str) -> str:
     raise ValueError(f"Unsupported graph collection: {collection}")
 
 
+def _artifact_paths(artifacts_root: Path) -> dict[str, str]:
+    return {
+        "ingest": str((artifacts_root / "ingest").as_posix()),
+        "graph": str((artifacts_root / "graph" / "graph.json").as_posix()),
+        "personas": str((artifacts_root / "personas" / "personas.json").as_posix()),
+        "scenario": str((artifacts_root / "scenario").as_posix()),
+        "run": str((artifacts_root / "run").as_posix()),
+        "compare": str((artifacts_root / "compare").as_posix()),
+        "report": str((artifacts_root / "report" / "report.md").as_posix()),
+        "claims": str((artifacts_root / "report" / "claims.json").as_posix()),
+        "eval": str((artifacts_root / "eval" / "summary.json").as_posix()),
+    }
+
+
+def _load_run_payloads(artifacts_root: Path) -> dict[str, dict[str, Any]]:
+    run_payloads: dict[str, dict[str, Any]] = {}
+    for run_dir in sorted((artifacts_root / "run").iterdir()):
+        summary_path = run_dir / "summary.json"
+        if run_dir.is_dir() and summary_path.exists():
+            run_payloads[run_dir.name] = read_json(summary_path)
+    return run_payloads
+
+
 def _redline_texts(artifacts_root: Path) -> dict[str, str]:
     graph_path = artifacts_root / "graph" / "graph.json"
     personas_path = artifacts_root / "personas" / "personas.json"
@@ -74,18 +100,8 @@ def _redline_texts(artifacts_root: Path) -> dict[str, str]:
     return texts
 
 
-def _load_run_payloads(artifacts_root: Path) -> dict[str, dict[str, Any]]:
-    run_payloads: dict[str, dict[str, Any]] = {}
-    for run_dir in sorted((artifacts_root / "run").iterdir()):
-        summary_path = run_dir / "summary.json"
-        if run_dir.is_dir() and summary_path.exists():
-            run_payloads[run_dir.name] = read_json(summary_path)
-    return run_payloads
-
-
-def _evaluate_redlines(redlines_path: Path, artifacts_root: Path) -> list[str]:
+def _evaluate_redlines_texts(redlines_path: Path, texts: dict[str, str]) -> list[str]:
     rules = load_yaml(redlines_path)
-    texts = _redline_texts(artifacts_root)
     failures: list[str] = []
     for label, text in texts.items():
         topic_hits = _scan_terms(text, rules["blocked_topics"])
@@ -95,6 +111,10 @@ def _evaluate_redlines(redlines_path: Path, artifacts_root: Path) -> list[str]:
         if phrase_hits:
             failures.append(f"redlines[{label}]: blocked phrases {phrase_hits}")
     return failures
+
+
+def _evaluate_redlines(redlines_path: Path, artifacts_root: Path) -> list[str]:
+    return _evaluate_redlines_texts(redlines_path, _redline_texts(artifacts_root))
 
 
 def evaluate_runs(expectations_path: Path, artifacts_root: Path, out_dir: Path, redlines_path: Path) -> EvalResult:
@@ -190,6 +210,7 @@ def evaluate_runs(expectations_path: Path, artifacts_root: Path, out_dir: Path, 
 
     result = EvalResult(
         eval_name=expectations["eval_name"],
+        world_id=graph_payload.get("world_id"),
         status="pass" if not failures else "fail",
         metrics={
             "checks_total": len(expectations["checks"]) + 1,
@@ -207,60 +228,72 @@ def evaluate_runs(expectations_path: Path, artifacts_root: Path, out_dir: Path, 
         },
         failures=failures,
         notes=["Phase 1 eval covers deterministic demo behavior, world-model provenance, and redline checks."],
+        artifact_paths=_artifact_paths(artifacts_root),
     )
     write_json(out_dir / "summary.json", result.model_dump())
     return result
 
 
-def run_phase0_demo(settings: Settings | None = None, artifacts_root: Path | None = None) -> EvalResult:
-    settings = settings or get_settings()
-    artifacts_root = artifacts_root or settings.artifacts_root
-    scenario_paths = [settings.baseline_scenario_path] + sorted(
-        path for path in settings.scenario_dir.glob("*.yaml") if path != settings.baseline_scenario_path
+def _reset_artifacts_root(artifacts_root: Path) -> None:
+    for name in ("ingest", "graph", "personas", "scenario", "run", "compare", "report", "eval"):
+        target = artifacts_root / name
+        if target.is_dir():
+            shutil.rmtree(target)
+        elif target.exists():
+            target.unlink()
+
+
+def _load_plan(world_paths: WorldPaths) -> SimulationPlan:
+    plan = load_simulation_plan(world_paths.simulation_rules_path)
+    if plan.world_id != world_paths.world_id:
+        raise ValueError(
+            f"World path resolver expected {world_paths.world_id}, "
+            f"but simulation rules declare {plan.world_id}."
+        )
+    return plan
+
+
+def _materialize_world(world_paths: WorldPaths) -> SimulationPlan:
+    _reset_artifacts_root(world_paths.artifacts_root)
+    ingest_manifest(world_paths.manifest_path, world_paths.artifacts_root / "ingest")
+    build_graph(
+        world_paths.artifacts_root / "ingest" / "chunks.jsonl",
+        world_paths.artifacts_root / "graph",
+        world_paths.world_model_path,
+    )
+    build_personas(
+        world_paths.artifacts_root / "graph" / "graph.json",
+        world_paths.artifacts_root / "personas",
+        world_paths.world_model_path,
     )
 
-    ingest_manifest(settings.manifest_path, artifacts_root / "ingest")
-    build_graph(artifacts_root / "ingest" / "chunks.jsonl", artifacts_root / "graph", settings.world_model_path)
-    build_personas(artifacts_root / "graph" / "graph.json", artifacts_root / "personas", settings.world_model_path)
-    scenario_out_dir = artifacts_root / "scenario"
-    run_root = artifacts_root / "run"
-    compare_root = artifacts_root / "compare"
-    scenario_out_dir.mkdir(parents=True, exist_ok=True)
-    run_root.mkdir(parents=True, exist_ok=True)
-    compare_root.mkdir(parents=True, exist_ok=True)
-    for scenario_json in scenario_out_dir.glob("*.json"):
-        scenario_json.unlink()
-    for run_dir in run_root.iterdir():
-        if run_dir.is_dir():
-            shutil.rmtree(run_dir)
-    for compare_dir in compare_root.iterdir():
-        if compare_dir.is_dir():
-            shutil.rmtree(compare_dir)
-
+    plan = _load_plan(world_paths)
+    scenario_out_dir = world_paths.artifacts_root / "scenario"
+    run_root = world_paths.artifacts_root / "run"
     scenario_payloads: dict[str, Any] = {}
-    for scenario_path in scenario_paths:
+    for scenario_path in world_paths.scenario_paths():
         stem = scenario_path.stem
         scenario = validate_scenario(scenario_path, scenario_out_dir / f"{stem}.json")
         scenario_payloads[stem] = scenario
         if scenario.branch_count > 1:
             simulate_branching_scenario(
                 scenario_path,
-                artifacts_root / "graph" / "graph.json",
-                artifacts_root / "personas" / "personas.json",
+                world_paths.artifacts_root / "graph" / "graph.json",
+                world_paths.artifacts_root / "personas" / "personas.json",
                 run_root / stem,
-                artifacts_root,
-                compare_dir=compare_root / scenario.scenario_id,
+                world_paths.artifacts_root,
+                compare_dir=world_paths.artifacts_root / "compare" / scenario.scenario_id,
             )
         else:
             simulate_scenario(
                 scenario_path,
-                artifacts_root / "graph" / "graph.json",
-                artifacts_root / "personas" / "personas.json",
+                world_paths.artifacts_root / "graph" / "graph.json",
+                world_paths.artifacts_root / "personas" / "personas.json",
                 run_root / stem,
             )
 
     matrix_branch_runs: list[BranchRunArtifacts] = []
-    for scenario_path in scenario_paths:
+    for scenario_path in world_paths.scenario_paths():
         stem = scenario_path.stem
         run_dir = run_root / stem
         if not (run_dir / "summary.json").exists():
@@ -275,18 +308,257 @@ def run_phase0_demo(settings: Settings | None = None, artifacts_root: Path | Non
                 run_dir=run_dir,
             )
         )
+
     if matrix_branch_runs:
         write_compare_artifact(
-            artifacts_root,
-            compare_root / DEMO_MATRIX_COMPARE_SCENARIO_ID,
-            scenario_id=DEMO_MATRIX_COMPARE_SCENARIO_ID,
+            world_paths.artifacts_root,
+            world_paths.artifacts_root / "compare" / plan.compare_id,
+            scenario_id=plan.compare_id,
             seed=matrix_branch_runs[0].summary.seed,
             branch_runs=matrix_branch_runs,
             reference_branch_id="branch_baseline",
+            tracked_outcomes=plan.tracked_outcomes,
+        )
+
+    report_run_dir = run_root / plan.default_report_scenario
+    if not report_run_dir.exists():
+        raise ValueError(
+            f"Default report scenario `{plan.default_report_scenario}` is missing under {run_root}."
         )
     generate_report(
-        run_root / settings.intervention_scenario_path.stem,
-        artifacts_root / "report",
+        report_run_dir,
+        world_paths.artifacts_root / "report",
         baseline_dir=run_root / "baseline",
+        simulation_rules_path=world_paths.simulation_rules_path,
     )
-    return evaluate_runs(settings.expectations_path, artifacts_root, artifacts_root / "eval", settings.redlines_path)
+    return plan
+
+
+def _transfer_redline_texts(artifacts_root: Path) -> dict[str, str]:
+    graph_path = artifacts_root / "graph" / "graph.json"
+    personas_path = artifacts_root / "personas" / "personas.json"
+    graph_payload = read_json(graph_path)
+    personas_payload = read_json(personas_path)
+    texts = {
+        "report": (artifacts_root / "report" / "report.md").read_text(encoding="utf-8"),
+        "claims": json.dumps(read_json(artifacts_root / "report" / "claims.json"), ensure_ascii=False),
+        "graph": json.dumps(graph_payload, ensure_ascii=False),
+        "personas": json.dumps(personas_payload, ensure_ascii=False),
+    }
+    if graph_payload.get("entities"):
+        texts["inspect_entity"] = json.dumps(
+            inspect_world(
+                "entity",
+                graph_payload["entities"][0]["entity_id"],
+                graph_path,
+                personas_path,
+            ),
+            ensure_ascii=False,
+        )
+    if personas_payload.get("personas"):
+        texts["inspect_persona"] = json.dumps(
+            inspect_world(
+                "persona",
+                personas_payload["personas"][0]["persona_id"],
+                graph_path,
+                personas_path,
+            ),
+            ensure_ascii=False,
+        )
+    if graph_payload.get("events"):
+        texts["inspect_event"] = json.dumps(
+            inspect_world(
+                "event",
+                graph_payload["events"][0]["event_id"],
+                graph_path,
+                personas_path,
+            ),
+            ensure_ascii=False,
+        )
+    for scenario_path in sorted((artifacts_root / "scenario").glob("*.json")):
+        texts[f"scenario_{scenario_path.stem}"] = json.dumps(read_json(scenario_path), ensure_ascii=False)
+    return texts
+
+
+def evaluate_transfer_world(world_paths: WorldPaths) -> EvalResult:
+    artifacts_root = world_paths.artifacts_root
+    graph_path = artifacts_root / "graph" / "graph.json"
+    personas_path = artifacts_root / "personas" / "personas.json"
+    chunks_path = artifacts_root / "ingest" / "chunks.jsonl"
+    claims_path = artifacts_root / "report" / "claims.json"
+    report_path = artifacts_root / "report" / "report.md"
+    compare_root = artifacts_root / "compare"
+    eval_out_dir = artifacts_root / "eval"
+
+    graph_payload = read_json(graph_path)
+    persona_payload = read_json(personas_path)
+    claims = read_json(claims_path)
+    chunks = read_jsonl(artifacts_root / "ingest" / "chunks.jsonl")
+    scenario_json_paths = sorted((artifacts_root / "scenario").glob("*.json"))
+    run_summary_paths = sorted((artifacts_root / "run").glob("*/summary.json"))
+    compare_json_paths = sorted(compare_root.glob("*/compare.json"))
+
+    failures: list[str] = []
+    checks_total = 0
+    checks_passed = 0
+
+    def record(name: str, passed: bool, details: str) -> None:
+        nonlocal checks_total, checks_passed
+        checks_total += 1
+        if passed:
+            checks_passed += 1
+        else:
+            failures.append(f"{name}: {details}")
+
+    record("ingest_exists", chunks_path.exists(), f"Missing {chunks_path}")
+    record("graph_exists", graph_path.exists(), f"Missing {graph_path}")
+    record("graph_entities_nonempty", len(graph_payload.get("entities", [])) > 0, "graph entities must be non-empty")
+    record("graph_relations_nonempty", len(graph_payload.get("relations", [])) > 0, "graph relations must be non-empty")
+    record("graph_events_nonempty", len(graph_payload.get("events", [])) > 0, "graph events must be non-empty")
+    record("personas_exist", personas_path.exists(), f"Missing {personas_path}")
+
+    provenance_missing: list[str] = []
+    for persona in persona_payload.get("personas", []):
+        provenance = persona.get("field_provenance", {})
+        for field_name in ("public_role", "goals", "constraints", "known_facts", "private_info", "relationships"):
+            if persona.get(field_name) and not provenance.get(field_name):
+                provenance_missing.append(f"{persona['persona_id']}.{field_name}")
+    record(
+        "persona_provenance_complete",
+        not provenance_missing,
+        "Missing provenance for " + ", ".join(provenance_missing),
+    )
+
+    record("scenario_json_written", len(scenario_json_paths) >= 2, "Expected baseline and injected scenario JSON artifacts.")
+    record("run_summaries_written", len(run_summary_paths) >= 2, "Expected baseline and injected run summaries.")
+    record("report_exists", report_path.exists(), f"Missing {report_path}")
+    record("claims_exist", claims_path.exists(), f"Missing {claims_path}")
+    record("compare_exists", len(compare_json_paths) >= 1, "Expected at least one compare artifact.")
+    record("claims_labeled", all(claim.get("label") for claim in claims), "Every claim must carry a label.")
+    record(
+        "claims_have_evidence",
+        all(claim.get("evidence_ids") for claim in claims),
+        "Every claim must carry evidence_ids.",
+    )
+
+    valid_evidence_ids = {chunk["chunk_id"] for chunk in chunks}
+    invalid_evidence_ids = sorted(
+        {
+            evidence_id
+            for claim in claims
+            for evidence_id in claim.get("evidence_ids", [])
+            if evidence_id not in valid_evidence_ids
+        }
+    )
+    record(
+        "claim_evidence_resolves",
+        not invalid_evidence_ids,
+        "Unresolved evidence_ids: " + ", ".join(invalid_evidence_ids),
+    )
+
+    redline_failures = _evaluate_redlines_texts(
+        world_paths.repo_root / "evals" / "assertions" / "redlines.yaml",
+        _transfer_redline_texts(artifacts_root),
+    )
+    record("redlines_pass", not redline_failures, "; ".join(redline_failures) if redline_failures else "ok")
+
+    result = EvalResult(
+        eval_name=f"transfer_{world_paths.world_id}",
+        world_id=world_paths.world_id,
+        status="pass" if not failures else "fail",
+        metrics={
+            "scenario_count": len(scenario_json_paths),
+            "checks_total": checks_total,
+            "checks_passed": checks_passed,
+            "failed_checks": len(failures),
+        },
+        failures=failures,
+        notes=[
+            "Transfer eval validates that the constrained deterministic pipeline can ingest, simulate, report, and evaluate this world without world-specific Python constants."
+        ],
+        artifact_paths=_artifact_paths(artifacts_root),
+    )
+    write_json(eval_out_dir / "summary.json", result.model_dump())
+    return result
+
+
+def run_world_eval(
+    world_id: str,
+    *,
+    repo_root: Path | None = None,
+    artifacts_root: Path | None = None,
+) -> EvalResult:
+    world_paths = resolve_world_paths(world_id, repo_root=repo_root)
+    if artifacts_root is not None:
+        world_paths = WorldPaths(
+            repo_root=world_paths.repo_root,
+            world_id=world_paths.world_id,
+            data_root=world_paths.data_root,
+            artifacts_root=artifacts_root,
+            manifest_path=world_paths.manifest_path,
+            world_model_path=world_paths.world_model_path,
+            simulation_rules_path=world_paths.simulation_rules_path,
+            scenario_dir=world_paths.scenario_dir,
+            baseline_scenario_path=world_paths.baseline_scenario_path,
+            expectations_path=world_paths.expectations_path,
+        )
+    _materialize_world(world_paths)
+    return evaluate_transfer_world(world_paths)
+
+
+def run_transfer_eval(world_ids: list[str] | None = None, *, repo_root: Path | None = None) -> EvalResult:
+    root = repo_root or get_settings().repo_root
+    selected_world_ids = world_ids or DEFAULT_TRANSFER_WORLD_IDS
+    world_results = [run_world_eval(world_id, repo_root=root) for world_id in selected_world_ids]
+    failures = [
+        f"{result.world_id}: {failure}"
+        for result in world_results
+        for failure in result.failures
+    ]
+    summary = EvalResult(
+        eval_name="transfer_eval",
+        world_id="transfer",
+        status="pass" if not failures else "fail",
+        metrics={
+            "world_count": len(world_results),
+            "scenario_count": sum(result.metrics.get("scenario_count", 0) for result in world_results),
+            "checks_total": sum(result.metrics.get("checks_total", 0) for result in world_results),
+            "checks_passed": sum(result.metrics.get("checks_passed", 0) for result in world_results),
+            "failed_checks": len(failures),
+        },
+        failures=failures,
+        notes=[f"{result.world_id}: {result.status}" for result in world_results],
+        artifact_paths={
+            result.world_id or "unknown": result.artifact_paths.get("eval", "")
+            for result in world_results
+        },
+    )
+    write_json(root / "artifacts" / "transfer" / "summary.json", summary.model_dump())
+    return summary
+
+
+def run_phase0_demo(settings: Settings | None = None, artifacts_root: Path | None = None) -> EvalResult:
+    settings = settings or get_settings()
+    if artifacts_root is not None and artifacts_root != settings.artifacts_root:
+        world_paths = WorldPaths(
+            repo_root=settings.repo_root,
+            world_id=settings.world_id,
+            data_root=settings.data_root,
+            artifacts_root=artifacts_root,
+            manifest_path=settings.manifest_path,
+            world_model_path=settings.world_model_path,
+            simulation_rules_path=settings.simulation_rules_path,
+            scenario_dir=settings.scenario_dir,
+            baseline_scenario_path=settings.baseline_scenario_path,
+            expectations_path=settings.expectations_path,
+        )
+    else:
+        world_paths = resolve_world_paths(settings.world_id, repo_root=settings.repo_root)
+
+    _materialize_world(world_paths)
+    return evaluate_runs(
+        settings.expectations_path,
+        world_paths.artifacts_root,
+        world_paths.artifacts_root / "eval",
+        settings.redlines_path,
+    )

--- a/backend/app/reports/service.py
+++ b/backend/app/reports/service.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
+from backend.app.config import get_settings
 from backend.app.domain.models import Claim, RunTrace, TurnAction
 from backend.app.safety.service import ensure_safe_report, validate_claim_payloads
-from backend.app.utils import read_json, read_jsonl, write_json
+from backend.app.simulation.rules import OutcomeDefinition, SimulationPlan, load_simulation_plan
+from backend.app.utils import read_json, read_jsonl, slugify, write_json
 
 
 def _load_summary(path: Path) -> RunTrace:
@@ -15,121 +18,160 @@ def _load_actions(path: Path) -> list[TurnAction]:
     return [TurnAction.model_validate(row) for row in read_jsonl(path / "run_trace.jsonl")]
 
 
-def _first_action(actions: list[TurnAction], action_type: str) -> TurnAction | None:
-    for action in actions:
-        if action.action_type == action_type:
-            return action
-    return None
+def _guess_simulation_rules_path(
+    run_dir: Path,
+    baseline_dir: Path | None,
+    simulation_rules_path: Path | None,
+) -> Path:
+    if simulation_rules_path is not None:
+        return simulation_rules_path
+
+    for seed_path in [run_dir, *(run_dir.parents), *(baseline_dir.parents if baseline_dir else [])]:
+        candidate = seed_path / "config" / "simulation_rules.yaml"
+        if candidate.exists():
+            return candidate
+    return get_settings().simulation_rules_path
 
 
-def generate_report(run_dir: Path, out_dir: Path, baseline_dir: Path | None = None) -> list[Claim]:
+def _summary_outcome_value(summary: RunTrace, field: str):
+    if hasattr(summary, field):
+        return getattr(summary, field)
+    return summary.final_state.get(field)
+
+
+def _format_value(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _candidate_actions_for_outcome(
+    outcome: OutcomeDefinition,
+    actions: list[TurnAction],
+    summary: RunTrace,
+) -> list[TurnAction]:
+    scoped_actions = [action for action in actions if action.action_type in outcome.action_types] or actions
+    outcome_value = _summary_outcome_value(summary, outcome.field)
+    if isinstance(outcome_value, int) and not isinstance(outcome_value, bool):
+        exact_turns = [action for action in scoped_actions if action.turn_index == outcome_value]
+        if exact_turns:
+            return exact_turns
+    return scoped_actions[:2]
+
+
+def _claim_for_outcome(
+    outcome: OutcomeDefinition,
+    *,
+    baseline_summary: RunTrace,
+    candidate_summary: RunTrace,
+    baseline_actions: list[TurnAction],
+    candidate_actions: list[TurnAction],
+) -> Claim:
+    baseline_value = _summary_outcome_value(baseline_summary, outcome.field)
+    candidate_value = _summary_outcome_value(candidate_summary, outcome.field)
+    baseline_references = _candidate_actions_for_outcome(outcome, baseline_actions, baseline_summary)
+    candidate_references = _candidate_actions_for_outcome(outcome, candidate_actions, candidate_summary)
+    evidence_ids = sorted(
+        {
+            *(evidence_id for action in baseline_references for evidence_id in action.evidence_ids),
+            *(evidence_id for action in candidate_references for evidence_id in action.evidence_ids),
+        }
+    )
+    related_turn_ids = [action.turn_id for action in [*baseline_references, *candidate_references]]
+
+    return Claim(
+        claim_id=f"claim_{slugify(outcome.field)}",
+        text=(
+            f"Based on the current corpus and deterministic rules, {outcome.label} changed from "
+            f"{_format_value(baseline_value)} in `{baseline_summary.scenario_id}` to "
+            f"{_format_value(candidate_value)} in `{candidate_summary.scenario_id}`."
+        ),
+        label="evidence_backed",
+        evidence_ids=evidence_ids,
+        related_turn_ids=related_turn_ids,
+        confidence_note="Directly derived from deterministic branch summaries and linked action evidence.",
+    )
+
+
+def _fallback_claim(candidate_summary: RunTrace, candidate_actions: list[TurnAction]) -> Claim:
+    references = candidate_actions[:2]
+    return Claim(
+        claim_id="claim_single_branch_outcome",
+        text=(
+            f"Based on the current corpus and deterministic rules, `{candidate_summary.scenario_id}` stays bounded and "
+            "auditable as a single deterministic branch."
+        ),
+        label="inferred",
+        evidence_ids=sorted({evidence_id for action in references for evidence_id in action.evidence_ids}),
+        related_turn_ids=[action.turn_id for action in references],
+        confidence_note="Single-branch fallback summary.",
+    )
+
+
+def generate_report(
+    run_dir: Path,
+    out_dir: Path,
+    baseline_dir: Path | None = None,
+    *,
+    simulation_rules_path: Path | None = None,
+) -> list[Claim]:
     candidate_summary = _load_summary(run_dir)
     candidate_actions = _load_actions(run_dir)
+    plan = load_simulation_plan(_guess_simulation_rules_path(run_dir, baseline_dir, simulation_rules_path))
 
     claims: list[Claim]
+    key_differences: list[str]
+    scenario_line: str
+
     if baseline_dir is not None:
         baseline_summary = _load_summary(baseline_dir)
         baseline_actions = _load_actions(baseline_dir)
-        baseline_publish = _first_action(baseline_actions, "publish")
-        candidate_publish = _first_action(candidate_actions, "publish")
-        baseline_evacuate = _first_action(baseline_actions, "evacuate")
-        candidate_evacuate = _first_action(candidate_actions, "evacuate")
-        candidate_hide = _first_action(candidate_actions, "hide")
-
-        claims = [
-            Claim(
-                claim_id="claim_ledger_delay",
-                text=(
-                    f"Based on the current corpus and rules, the maintenance ledger reached the public decision loop on "
-                    f"turn {candidate_summary.ledger_public_turn} instead of turn {baseline_summary.ledger_public_turn}."
-                ),
-                label="evidence_backed",
-                evidence_ids=sorted(
-                    {
-                        *(baseline_publish.evidence_ids if baseline_publish else []),
-                        *(candidate_publish.evidence_ids if candidate_publish else []),
-                    }
-                ),
-                related_turn_ids=[
-                    baseline_publish.turn_id if baseline_publish else "",
-                    candidate_publish.turn_id if candidate_publish else "",
-                ],
-                confidence_note="Directly derived from the deterministic run summaries.",
-            ),
-            Claim(
-                claim_id="claim_festival_pressure",
-                text=(
-                    "In this scenario branch, Zhao Ke kept the festival on schedule longer because documentary pressure "
-                    "had not surfaced by the time he first chose between disruption and concealment."
-                ),
-                label="inferred",
-                evidence_ids=sorted(
-                    {
-                        *(candidate_hide.evidence_ids if candidate_hide else []),
-                        *(candidate_publish.evidence_ids if candidate_publish else []),
-                    }
-                ),
-                related_turn_ids=[
-                    candidate_hide.turn_id if candidate_hide else "",
-                    candidate_publish.turn_id if candidate_publish else "",
-                ],
-                confidence_note="Inferred from the candidate hide action and the later publish turn.",
-            ),
-            Claim(
-                claim_id="claim_evacuation_delay",
-                text=(
-                    f"In this scenario branch, evacuation moved from turn {baseline_summary.evacuation_turn} to "
-                    f"turn {candidate_summary.evacuation_turn}, shrinking the response window before storm arrival."
-                ),
-                label="inferred",
-                evidence_ids=sorted(
-                    {
-                        *(baseline_evacuate.evidence_ids if baseline_evacuate else []),
-                        *(candidate_evacuate.evidence_ids if candidate_evacuate else []),
-                    }
-                ),
-                related_turn_ids=[
-                    baseline_evacuate.turn_id if baseline_evacuate else "",
-                    candidate_evacuate.turn_id if candidate_evacuate else "",
-                ],
-                confidence_note="Derived from branch comparison of deterministic evacuation turns.",
-            ),
+        changed_outcomes = [
+            outcome
+            for outcome in plan.tracked_outcomes
+            if _summary_outcome_value(baseline_summary, outcome.field)
+            != _summary_outcome_value(candidate_summary, outcome.field)
         ]
-
-        key_differences = [
-            f"- Ledger publish turn: baseline {baseline_summary.ledger_public_turn}, candidate {candidate_summary.ledger_public_turn}",
-            f"- Evacuation turn: baseline {baseline_summary.evacuation_turn}, candidate {candidate_summary.evacuation_turn}",
-            f"- Festival status at end: baseline {baseline_summary.final_state['festival_status']}, candidate {candidate_summary.final_state['festival_status']}",
-        ]
-        scenario_line = f"Comparing `{baseline_summary.scenario_id}` with `{candidate_summary.scenario_id}` under seed {candidate_summary.seed}."
-    else:
-        publish_action = _first_action(candidate_actions, "publish")
-        evacuate_action = _first_action(candidate_actions, "evacuate")
+        selected_outcomes = changed_outcomes[:3] or plan.tracked_outcomes[:1]
         claims = [
-            Claim(
-                claim_id="claim_single_branch_outcome",
-                text="Based on the current corpus and rules, the branch exposes the maintenance issue before final storm arrival.",
-                label="inferred",
-                evidence_ids=sorted(
-                    {
-                        *(publish_action.evidence_ids if publish_action else []),
-                        *(evacuate_action.evidence_ids if evacuate_action else []),
-                    }
-                ),
-                related_turn_ids=[
-                    publish_action.turn_id if publish_action else "",
-                    evacuate_action.turn_id if evacuate_action else "",
-                ],
-                confidence_note="Single-branch summary.",
+            _claim_for_outcome(
+                outcome,
+                baseline_summary=baseline_summary,
+                candidate_summary=candidate_summary,
+                baseline_actions=baseline_actions,
+                candidate_actions=candidate_actions,
             )
+            for outcome in selected_outcomes
         ]
-        key_differences = [f"- Final festival status: {candidate_summary.final_state['festival_status']}"]
-        scenario_line = f"Scenario `{candidate_summary.scenario_id}` under seed {candidate_summary.seed}."
+        key_differences = [
+            f"- {outcome.label}: baseline {_format_value(_summary_outcome_value(baseline_summary, outcome.field))}, "
+            f"candidate {_format_value(_summary_outcome_value(candidate_summary, outcome.field))}"
+            for outcome in selected_outcomes
+        ]
+        scenario_line = (
+            f"Comparing `{baseline_summary.scenario_id}` with `{candidate_summary.scenario_id}` under seed "
+            f"{candidate_summary.seed} in world `{plan.world_id}`."
+        )
+    else:
+        claims = [_fallback_claim(candidate_summary, candidate_actions)]
+        key_differences = [
+            f"- {outcome.label}: {_format_value(_summary_outcome_value(candidate_summary, outcome.field))}"
+            for outcome in plan.tracked_outcomes[:3]
+        ]
+        scenario_line = (
+            f"Scenario `{candidate_summary.scenario_id}` under seed {candidate_summary.seed} in world `{plan.world_id}`."
+        )
 
     claim_payloads = [claim.model_dump() for claim in claims]
     validate_claim_payloads(claim_payloads)
     claim_rows = "\n".join(
-        f"| {claim.claim_id} | {claim.label} | {', '.join(claim.evidence_ids)} | {claim.text} |" for claim in claims
+        f"| {claim.claim_id} | {claim.label} | {', '.join(claim.evidence_ids)} | {claim.text} |"
+        for claim in claims
+    )
+    action_chain = "\n".join(
+        f"- T{action.turn_index}: `{action.actor_id}` performs `{action.action_type}`"
+        + (f" toward `{action.target_id}`." if action.target_id else ".")
+        for action in candidate_actions[:4]
     )
     report = "\n".join(
         [
@@ -142,16 +184,14 @@ def generate_report(run_dir: Path, out_dir: Path, baseline_dir: Path | None = No
             *key_differences,
             "",
             "## 3. Key Action Chain",
-            "- Su He inspects the gate and escalates pressure through a bounded turn sequence.",
-            "- Lin Lan either publishes the ledger on time or loses turns to the document delay.",
-            "- Zhao Ke reacts to visible evidence rather than free-form agent improvisation.",
+            action_chain,
             "",
             "## 4. Result Summary",
             f"- Final state: {candidate_summary.final_state}",
             "",
             "## 5. Uncertainties",
             "- This report describes a bounded simulation branch, not a claim about the real world.",
-            "- Communication side effects outside the scripted action set remain speculative.",
+            "- Outcome deltas remain constrained to the explicit corpus, rules, and injected disturbances in this world.",
             "",
             "## 6. Claim Table",
             "| Claim ID | Label | Evidence IDs | Text |",
@@ -160,7 +200,7 @@ def generate_report(run_dir: Path, out_dir: Path, baseline_dir: Path | None = No
             "",
             "## 7. Evidence And Reasoning Labels",
             "- `evidence_backed`: direct branch facts visible in run artifacts.",
-            "- `inferred`: comparison logic derived from the deterministic branch artifacts.",
+            "- `inferred`: bounded conclusions drawn from deterministic branch artifacts.",
             "- `speculative`: reserved for narrative extensions outside direct branch proof.",
         ]
     )

--- a/backend/app/simulation/rules.py
+++ b/backend/app/simulation/rules.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import Field
+
+from backend.app.domain.models import ActionType, InjectionKind, MirrorBaseModel
+from backend.app.utils import load_yaml
+
+
+class OutcomeDefinition(MirrorBaseModel):
+    field: str
+    label: str
+    action_types: list[ActionType] = Field(default_factory=list)
+
+
+class InjectionRule(MirrorBaseModel):
+    kind: InjectionKind
+    operation: Literal["add_int", "max_int", "append_contact"]
+    field: str
+    param: str | None = None
+    note_template: str | None = None
+
+
+class StepCondition(MirrorBaseModel):
+    kind: Literal["state_equals", "state_truthy", "state_falsy", "turn_gte_state", "communication_available"]
+    field: str | None = None
+    value: Any = None
+    target_id: str | None = None
+
+
+class StateUpdate(MirrorBaseModel):
+    kind: Literal["set", "set_current_turn", "union_actor_entity"]
+    field: str
+    value: Any = None
+
+
+class StepAction(MirrorBaseModel):
+    action_type: ActionType
+    target_id: str | None = None
+    rationale: str
+    updates: list[StateUpdate] = Field(default_factory=list)
+
+
+class StepChoice(MirrorBaseModel):
+    when: list[StepCondition] = Field(default_factory=list)
+    action: StepAction
+
+
+class StepRule(MirrorBaseModel):
+    turn_index: int = Field(ge=1)
+    choices: list[StepChoice] = Field(default_factory=list)
+
+
+class SimulationPlan(MirrorBaseModel):
+    world_id: str
+    compare_id: str
+    default_report_scenario: str
+    communications_down_field: str = "communications_down_until"
+    blocked_contacts_field: str = "blocked_contacts"
+    turn_sequence: list[str] = Field(default_factory=list)
+    initial_state: dict[str, Any] = Field(default_factory=dict)
+    tracked_outcomes: list[OutcomeDefinition] = Field(default_factory=list)
+    injection_rules: list[InjectionRule] = Field(default_factory=list)
+    steps: list[StepRule] = Field(default_factory=list)
+
+
+def load_simulation_plan(path: Path) -> SimulationPlan:
+    return SimulationPlan.model_validate(load_yaml(path))

--- a/backend/app/simulation/service.py
+++ b/backend/app/simulation/service.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import shutil
+from copy import deepcopy
 from dataclasses import dataclass
 from itertools import combinations
 from pathlib import Path
 from typing import Any
 
+from backend.app.config import get_settings
 from backend.app.domain.models import (
     CompareArtifact,
     CompareBranch,
@@ -18,30 +20,8 @@ from backend.app.domain.models import (
     TurnAction,
 )
 from backend.app.scenarios.service import load_scenario
+from backend.app.simulation.rules import OutcomeDefinition, SimulationPlan, StepChoice, load_simulation_plan
 from backend.app.utils import ensure_dir, read_json, read_jsonl, slugify, write_json, write_jsonl
-
-
-TURN_SEQUENCE = [
-    "persona_su_he",
-    "persona_chen_yu",
-    "persona_lin_lan",
-    "persona_su_he",
-    "persona_zhao_ke",
-    "persona_lin_lan",
-    "persona_su_he",
-    "persona_zhao_ke",
-]
-
-OUTCOME_DELTA_FIELDS = (
-    "ledger_public_turn",
-    "budget_exposed_turn",
-    "evacuation_turn",
-    "festival_status",
-    "budget_exposed",
-    "ledger_public",
-    "evacuation_triggered",
-    "risk_known_by",
-)
 
 
 @dataclass(frozen=True)
@@ -72,27 +52,70 @@ def load_run_artifacts(run_dir: Path) -> tuple[RunTrace, list[TurnAction]]:
     return summary, actions
 
 
-def _apply_injections(scenario: Scenario, state: dict[str, Any], notes: list[str]) -> None:
+def _simulation_plan_path_for_scenario(scenario_path: Path) -> Path:
+    return scenario_path.parent.parent / "config" / "simulation_rules.yaml"
+
+
+def _load_plan_for_scenario(scenario_path: Path, scenario: Scenario) -> SimulationPlan:
+    plan_path = _simulation_plan_path_for_scenario(scenario_path)
+    if not plan_path.exists():
+        plan_path = get_settings().simulation_rules_path
+    plan = load_simulation_plan(plan_path)
+    if plan.world_id != scenario.world_id:
+        raise ValueError(
+            f"Scenario {scenario.scenario_id} targets world_id={scenario.world_id}, "
+            f"but simulation rules declare world_id={plan.world_id}."
+        )
+    return plan
+
+
+def _format_injection_note(rule_kind: str, injection: dict[str, Any], template: str | None) -> str:
+    if template:
+        return template.format(**injection)
+    return f"{injection['injection_id']}: applied {rule_kind}."
+
+
+def _apply_injections(scenario: Scenario, plan: SimulationPlan, state: dict[str, Any], notes: list[str]) -> None:
+    rules_by_kind = {rule.kind: rule for rule in plan.injection_rules}
     for injection in scenario.injections:
-        if injection.kind == "delay_document":
-            delay_turns = int(injection.params.get("delay_turns", 0))
-            state["ledger_available_turn"] += delay_turns
-            notes.append(f"{injection.injection_id}: ledger availability delayed by {delay_turns} turn(s).")
-        elif injection.kind == "resource_failure":
-            outage_turns = int(injection.params.get("duration_turns", 1))
-            state["communications_down_until"] = max(state["communications_down_until"], outage_turns)
-            notes.append(f"{injection.injection_id}: communications degraded for {outage_turns} turn(s).")
-        elif injection.kind == "block_contact":
-            state["blocked_contacts"].append((injection.actor_id, injection.target_id))
-            notes.append(f"{injection.injection_id}: contact blocked between {injection.actor_id} and {injection.target_id}.")
+        rule = rules_by_kind.get(injection.kind)
+        if rule is None:
+            raise ValueError(f"Missing simulation injection rule for kind={injection.kind}.")
+
+        payload = {
+            "injection_id": injection.injection_id,
+            "actor_id": injection.actor_id,
+            "target_id": injection.target_id,
+            **injection.params,
+        }
+        if rule.operation == "add_int":
+            param_name = rule.param or "value"
+            state[rule.field] = int(state.get(rule.field, 0)) + int(injection.params.get(param_name, 0))
+        elif rule.operation == "max_int":
+            param_name = rule.param or "value"
+            state[rule.field] = max(int(state.get(rule.field, 0)), int(injection.params.get(param_name, 0)))
+        elif rule.operation == "append_contact":
+            blocked = list(state.get(rule.field, []))
+            blocked.append((injection.actor_id, injection.target_id))
+            state[rule.field] = blocked
+        else:
+            raise ValueError(f"Unsupported injection operation: {rule.operation}")
+        notes.append(_format_injection_note(rule.kind, payload, rule.note_template))
 
 
-def _supports_communication(state: dict[str, Any], turn_index: int, actor_id: str, target_id: str | None) -> bool:
-    if turn_index <= state["communications_down_until"]:
+def _supports_communication(
+    state: dict[str, Any],
+    turn_index: int,
+    actor_id: str,
+    target_id: str | None,
+    plan: SimulationPlan,
+) -> bool:
+    if turn_index <= int(state.get(plan.communications_down_field, 0)):
         return False
     if target_id is None:
         return True
-    return (actor_id, target_id) not in state["blocked_contacts"]
+    blocked_pairs = {tuple(pair) for pair in state.get(plan.blocked_contacts_field, [])}
+    return (actor_id, target_id) not in blocked_pairs
 
 
 def _persona_evidence(personas: dict[str, Persona], persona_id: str) -> list[str]:
@@ -103,197 +126,125 @@ def _state_patch(before: dict[str, Any], after: dict[str, Any]) -> dict[str, Any
     return {key: value for key, value in after.items() if before.get(key) != value}
 
 
+def _condition_matches(
+    condition_kind: str,
+    *,
+    condition_field: str | None,
+    condition_value: Any,
+    condition_target_id: str | None,
+    state: dict[str, Any],
+    turn_index: int,
+    actor_id: str,
+    plan: SimulationPlan,
+) -> bool:
+    if condition_kind == "state_equals":
+        return state.get(condition_field or "") == condition_value
+    if condition_kind == "state_truthy":
+        return bool(state.get(condition_field or ""))
+    if condition_kind == "state_falsy":
+        return not bool(state.get(condition_field or ""))
+    if condition_kind == "turn_gte_state":
+        return turn_index >= int(state.get(condition_field or "", 0))
+    if condition_kind == "communication_available":
+        return _supports_communication(state, turn_index, actor_id, condition_target_id, plan)
+    raise ValueError(f"Unsupported step condition: {condition_kind}")
+
+
+def _choice_matches(
+    choice: StepChoice,
+    *,
+    state: dict[str, Any],
+    turn_index: int,
+    actor_id: str,
+    plan: SimulationPlan,
+) -> bool:
+    return all(
+        _condition_matches(
+            condition.kind,
+            condition_field=condition.field,
+            condition_value=condition.value,
+            condition_target_id=condition.target_id,
+            state=state,
+            turn_index=turn_index,
+            actor_id=actor_id,
+            plan=plan,
+        )
+        for condition in choice.when
+    )
+
+
+def _apply_updates(
+    *,
+    state: dict[str, Any],
+    actor_entity_id: str,
+    turn_index: int,
+    updates: list[Any],
+) -> None:
+    for update in updates:
+        if update.kind == "set":
+            state[update.field] = deepcopy(update.value)
+        elif update.kind == "set_current_turn":
+            state[update.field] = turn_index
+        elif update.kind == "union_actor_entity":
+            state[update.field] = sorted({*state.get(update.field, []), actor_entity_id})
+        else:
+            raise ValueError(f"Unsupported state update kind: {update.kind}")
+
+
 def _action_for_turn(
     turn_index: int,
     run_id: str,
     persona_id: str,
     personas: dict[str, Persona],
     state: dict[str, Any],
+    plan: SimulationPlan,
+    step_choices: list[StepChoice],
 ) -> TurnAction:
     evidence_ids = _persona_evidence(personas, persona_id)
     actor_entity = personas[persona_id].entity_id
-    before = dict(state)
+    before = deepcopy(state)
 
-    if turn_index == 1:
-        state["risk_known_by"] = sorted({*state["risk_known_by"], actor_entity})
-        action = TurnAction(
-            turn_id=f"{run_id}_turn_{turn_index:02d}",
-            run_id=run_id,
-            turn_index=turn_index,
-            actor_id=persona_id,
-            action_type="inspect",
-            target_id="entity_east_gate",
-            rationale="Su He inspects the gate because the fracture is already widening under storm pressure.",
-            evidence_ids=evidence_ids,
-            state_patch={},
-        )
-    elif turn_index == 2:
-        target_id = "persona_zhao_ke"
-        if _supports_communication(state, turn_index, persona_id, target_id):
-            state["risk_known_by"] = sorted({*state["risk_known_by"], actor_entity})
-            state["mayor_alerted"] = True
-            action_type = "inform"
-            rationale = "Chen Yu escalates the tide anomaly toward the deputy mayor."
-        else:
-            state["communications_status"] = "degraded"
-            action_type = "delay"
-            rationale = "The harbor warning is delayed by a communication problem."
-        action = TurnAction(
-            turn_id=f"{run_id}_turn_{turn_index:02d}",
-            run_id=run_id,
-            turn_index=turn_index,
-            actor_id=persona_id,
-            action_type=action_type,
-            target_id=target_id,
-            rationale=rationale,
-            evidence_ids=evidence_ids,
-            state_patch={},
-        )
-    elif turn_index == 3:
-        can_publish = turn_index >= state["ledger_available_turn"] and _supports_communication(
-            state, turn_index, persona_id, "entity_maintenance_ledger"
-        )
-        if can_publish:
-            state["ledger_public"] = True
-            state["ledger_public_turn"] = turn_index
-            state["budget_exposed"] = True
-            state["budget_exposed_turn"] = turn_index
-            action_type = "publish"
-            rationale = "Lin Lan publishes the copied ledger into the decision loop."
-        else:
-            action_type = "delay"
-            rationale = "Lin Lan cannot surface the ledger yet and holds position."
-        action = TurnAction(
-            turn_id=f"{run_id}_turn_{turn_index:02d}",
-            run_id=run_id,
-            turn_index=turn_index,
-            actor_id=persona_id,
-            action_type=action_type,
-            target_id="entity_maintenance_ledger",
-            rationale=rationale,
-            evidence_ids=evidence_ids,
-            state_patch={},
-        )
-    elif turn_index == 4:
-        if state["ledger_public"]:
-            state["evacuation_requested"] = True
-            target_id = "entity_east_wharf"
-            rationale = "Su He requests evacuation once the engineering risk and budget diversion align."
-        else:
-            state["repair_request_reissued"] = True
-            target_id = "entity_maintenance_ledger"
-            rationale = "Su He renews the repair request while waiting for documentary proof."
-        action = TurnAction(
-            turn_id=f"{run_id}_turn_{turn_index:02d}",
-            run_id=run_id,
-            turn_index=turn_index,
-            actor_id=persona_id,
-            action_type="request",
-            target_id=target_id,
-            rationale=rationale,
-            evidence_ids=evidence_ids,
-            state_patch={},
-        )
-    elif turn_index == 5:
-        if state["evacuation_requested"]:
-            state["evacuation_triggered"] = True
-            state["evacuation_turn"] = turn_index
-            state["festival_status"] = "suspended"
-            action_type = "evacuate"
-            rationale = "Zhao Ke authorizes evacuation once the combined pressure is too visible to ignore."
-        else:
-            state["festival_status"] = "scheduled"
-            action_type = "hide"
-            rationale = "Zhao Ke suppresses disruption and keeps the festival plan intact."
-        action = TurnAction(
-            turn_id=f"{run_id}_turn_{turn_index:02d}",
-            run_id=run_id,
-            turn_index=turn_index,
-            actor_id=persona_id,
-            action_type=action_type,
-            target_id="entity_sea_lantern_festival",
-            rationale=rationale,
-            evidence_ids=evidence_ids,
-            state_patch={},
-        )
-    elif turn_index == 6:
-        can_publish = not state["ledger_public"] and turn_index >= state["ledger_available_turn"] and _supports_communication(
-            state, turn_index, persona_id, "entity_maintenance_ledger"
-        )
-        if can_publish:
-            state["ledger_public"] = True
-            state["ledger_public_turn"] = turn_index
-            state["budget_exposed"] = True
-            state["budget_exposed_turn"] = turn_index
-            action_type = "publish"
-            target_id = "entity_maintenance_ledger"
-            rationale = "Lin Lan finally surfaces the copied ledger after the disruption clears."
-        else:
-            state["public_pressure"] = "mounting"
-            action_type = "inform"
-            target_id = "persona_su_he"
-            rationale = "Lin Lan keeps the archive evidence circulating among trusted allies."
-        action = TurnAction(
-            turn_id=f"{run_id}_turn_{turn_index:02d}",
-            run_id=run_id,
-            turn_index=turn_index,
-            actor_id=persona_id,
-            action_type=action_type,
-            target_id=target_id,
-            rationale=rationale,
-            evidence_ids=evidence_ids,
-            state_patch={},
-        )
-    elif turn_index == 7:
-        if state["budget_exposed"] and not state["evacuation_requested"]:
-            state["evacuation_requested"] = True
-            action_type = "request"
-            target_id = "entity_east_wharf"
-            rationale = "Su He renews the evacuation request once the ledger becomes public."
-        else:
-            action_type = "inspect"
-            target_id = "entity_east_gate"
-            rationale = "Su He monitors the gate while waiting for the mayor's order to take effect."
-        action = TurnAction(
-            turn_id=f"{run_id}_turn_{turn_index:02d}",
-            run_id=run_id,
-            turn_index=turn_index,
-            actor_id=persona_id,
-            action_type=action_type,
-            target_id=target_id,
-            rationale=rationale,
-            evidence_ids=evidence_ids,
-            state_patch={},
-        )
-    else:
-        if state["evacuation_requested"] and not state["evacuation_triggered"]:
-            state["evacuation_triggered"] = True
-            state["evacuation_turn"] = turn_index
-            state["festival_status"] = "suspended"
-            action_type = "evacuate"
-            rationale = "Zhao Ke orders evacuation at the last viable moment in this branch."
-        else:
-            state["command_post"] = "harbor_square"
-            action_type = "move"
-            rationale = "Zhao Ke repositions to manage the festival command post."
-        action = TurnAction(
-            turn_id=f"{run_id}_turn_{turn_index:02d}",
-            run_id=run_id,
-            turn_index=turn_index,
-            actor_id=persona_id,
-            action_type=action_type,
-            target_id="entity_east_wharf",
-            rationale=rationale,
-            evidence_ids=evidence_ids,
-            state_patch={},
-        )
+    selected = next(
+        (
+            choice
+            for choice in step_choices
+            if _choice_matches(choice, state=state, turn_index=turn_index, actor_id=persona_id, plan=plan)
+        ),
+        None,
+    )
+    if selected is None:
+        raise ValueError(f"No matching simulation step choice for turn {turn_index} in world {plan.world_id}.")
 
+    _apply_updates(
+        state=state,
+        actor_entity_id=actor_entity,
+        turn_index=turn_index,
+        updates=selected.action.updates,
+    )
+    action = TurnAction(
+        turn_id=f"{run_id}_turn_{turn_index:02d}",
+        run_id=run_id,
+        turn_index=turn_index,
+        actor_id=persona_id,
+        action_type=selected.action.action_type,
+        target_id=selected.action.target_id,
+        rationale=selected.action.rationale,
+        evidence_ids=evidence_ids,
+        state_patch={},
+    )
     action.state_patch = _state_patch(before, state)
     return action
 
 
+def _summary_outcome_value(summary: RunTrace, field: str) -> Any:
+    if hasattr(summary, field):
+        return getattr(summary, field)
+    return summary.final_state.get(field)
+
+
 def _simulate_loaded_scenario(
     scenario: Scenario,
+    plan: SimulationPlan,
     graph_path: Path,
     personas_path: Path,
     out_dir: Path,
@@ -303,27 +254,17 @@ def _simulate_loaded_scenario(
 ) -> tuple[RunTrace, list[TurnAction]]:
     _ = read_json(graph_path)
     personas = _load_personas(personas_path)
+    if scenario.turn_budget > len(plan.turn_sequence):
+        raise ValueError(
+            f"Scenario {scenario.scenario_id} requests turn_budget={scenario.turn_budget}, "
+            f"but only {len(plan.turn_sequence)} turn owners are defined in simulation rules."
+        )
+
+    step_index = {step.turn_index: step for step in plan.steps}
     resolved_run_id = run_id or f"run_{scenario.scenario_id}_{scenario.seed}"
-    notes = [f"Deterministic Phase 0 run for {scenario.scenario_id}.", *(notes_prefix or [])]
-    state: dict[str, Any] = {
-        "east_gate_status": "fractured",
-        "festival_status": "scheduled",
-        "risk_known_by": [],
-        "budget_exposed": False,
-        "budget_exposed_turn": None,
-        "ledger_public": False,
-        "ledger_public_turn": None,
-        "ledger_available_turn": 3,
-        "evacuation_requested": False,
-        "evacuation_triggered": False,
-        "evacuation_turn": None,
-        "communications_status": "stable",
-        "communications_down_until": 0,
-        "blocked_contacts": [],
-        "mayor_alerted": False,
-        "storm_arrival_turn": scenario.turn_budget,
-    }
-    _apply_injections(scenario, state, notes)
+    notes = [f"Deterministic run for {scenario.scenario_id}.", *(notes_prefix or [])]
+    state = deepcopy(plan.initial_state)
+    _apply_injections(scenario, plan, state, notes)
 
     snapshots_dir = ensure_dir(out_dir / "snapshots")
     for existing in snapshots_dir.glob("*.json"):
@@ -331,8 +272,19 @@ def _simulate_loaded_scenario(
 
     actions: list[TurnAction] = []
     for turn_index in range(1, scenario.turn_budget + 1):
-        persona_id = TURN_SEQUENCE[turn_index - 1]
-        action = _action_for_turn(turn_index, resolved_run_id, persona_id, personas, state)
+        persona_id = plan.turn_sequence[turn_index - 1]
+        step = step_index.get(turn_index)
+        if step is None:
+            raise ValueError(f"Missing simulation step definition for turn {turn_index} in world {plan.world_id}.")
+        action = _action_for_turn(
+            turn_index,
+            resolved_run_id,
+            persona_id,
+            personas,
+            state,
+            plan,
+            step.choices,
+        )
         actions.append(action)
         write_json(snapshots_dir / f"turn-{turn_index:02d}.json", {"turn_index": turn_index, "state": state})
 
@@ -342,17 +294,10 @@ def _simulate_loaded_scenario(
         seed=scenario.seed,
         turn_budget=scenario.turn_budget,
         executed_turns=len(actions),
-        ledger_public_turn=state["ledger_public_turn"],
-        budget_exposed_turn=state["budget_exposed_turn"],
-        evacuation_turn=state["evacuation_turn"],
-        final_state={
-            "east_gate_status": state["east_gate_status"],
-            "festival_status": state["festival_status"],
-            "budget_exposed": state["budget_exposed"],
-            "ledger_public": state["ledger_public"],
-            "evacuation_triggered": state["evacuation_triggered"],
-            "risk_known_by": state["risk_known_by"],
-        },
+        ledger_public_turn=state.get("ledger_public_turn"),
+        budget_exposed_turn=state.get("budget_exposed_turn"),
+        evacuation_turn=state.get("evacuation_turn"),
+        final_state=deepcopy(state),
         action_count=len(actions),
         action_types=[action.action_type for action in actions],
         notes=notes,
@@ -365,7 +310,8 @@ def _simulate_loaded_scenario(
 
 def simulate_scenario(scenario_path: Path, graph_path: Path, personas_path: Path, out_dir: Path) -> RunTrace:
     scenario = load_scenario(scenario_path)
-    summary, _ = _simulate_loaded_scenario(scenario, graph_path, personas_path, out_dir)
+    plan = _load_plan_for_scenario(scenario_path, scenario)
+    summary, _ = _simulate_loaded_scenario(scenario, plan, graph_path, personas_path, out_dir)
     return summary
 
 
@@ -394,9 +340,7 @@ def _branch_execution_plans(scenario: Scenario) -> list[BranchExecutionPlan]:
     for combo in available_index_sets[: scenario.branch_count]:
         injection_ids = tuple(scenario.injections[index].injection_id for index in combo)
         branch_id = "branch_reference" if not injection_ids else f"branch_{slugify('__'.join(injection_ids))}"
-        branch_scenario = scenario.model_copy(
-            update={"injections": [scenario.injections[index] for index in combo]}
-        )
+        branch_scenario = scenario.model_copy(update={"injections": [scenario.injections[index] for index in combo]})
         plans.append(
             BranchExecutionPlan(
                 branch_id=branch_id,
@@ -419,27 +363,21 @@ def _delta_value(reference: Any, candidate: Any) -> Any:
     return None
 
 
-def _outcome_deltas(reference: RunTrace, candidate: RunTrace) -> dict[str, CompareOutcomeDelta]:
-    reference_values = {
-        "ledger_public_turn": reference.ledger_public_turn,
-        "budget_exposed_turn": reference.budget_exposed_turn,
-        "evacuation_turn": reference.evacuation_turn,
-        **{field: reference.final_state.get(field) for field in OUTCOME_DELTA_FIELDS if field in reference.final_state},
-    }
-    candidate_values = {
-        "ledger_public_turn": candidate.ledger_public_turn,
-        "budget_exposed_turn": candidate.budget_exposed_turn,
-        "evacuation_turn": candidate.evacuation_turn,
-        **{field: candidate.final_state.get(field) for field in OUTCOME_DELTA_FIELDS if field in candidate.final_state},
-    }
-    outcome_keys = sorted(set(reference_values) | set(candidate_values))
+def _outcome_deltas(
+    reference: RunTrace,
+    candidate: RunTrace,
+    tracked_outcomes: list[OutcomeDefinition],
+) -> dict[str, CompareOutcomeDelta]:
     return {
-        key: CompareOutcomeDelta(
-            reference=reference_values.get(key),
-            candidate=candidate_values.get(key),
-            delta=_delta_value(reference_values.get(key), candidate_values.get(key)),
+        outcome.field: CompareOutcomeDelta(
+            reference=_summary_outcome_value(reference, outcome.field),
+            candidate=_summary_outcome_value(candidate, outcome.field),
+            delta=_delta_value(
+                _summary_outcome_value(reference, outcome.field),
+                _summary_outcome_value(candidate, outcome.field),
+            ),
         )
-        for key in outcome_keys
+        for outcome in tracked_outcomes
     }
 
 
@@ -481,6 +419,7 @@ def write_compare_artifact(
     seed: int,
     branch_runs: list[BranchRunArtifacts],
     reference_branch_id: str,
+    tracked_outcomes: list[OutcomeDefinition],
 ) -> CompareArtifact:
     reference_branch = next((branch for branch in branch_runs if branch.branch_id == reference_branch_id), None)
     if reference_branch is None:
@@ -509,7 +448,7 @@ def write_compare_artifact(
                 branch_id=branch.branch_id,
                 divergent_turn_count=len(_divergent_turns(reference_branch.actions, branch.actions)),
                 divergent_turns=_divergent_turns(reference_branch.actions, branch.actions),
-                outcome_deltas=_outcome_deltas(reference_branch.summary, branch.summary),
+                outcome_deltas=_outcome_deltas(reference_branch.summary, branch.summary, tracked_outcomes),
             )
             for branch in branch_runs
             if branch.branch_id != reference_branch_id
@@ -534,6 +473,7 @@ def simulate_branching_scenario(
     scenario = load_scenario(scenario_path)
     if scenario.branch_count <= 1:
         raise ValueError(f"Scenario {scenario.scenario_id} does not request multi-branch execution.")
+    plan = _load_plan_for_scenario(scenario_path, scenario)
 
     branches_root = run_root / "branches"
     if branches_root.exists():
@@ -541,23 +481,22 @@ def simulate_branching_scenario(
     ensure_dir(branches_root)
 
     branch_runs: list[BranchRunArtifacts] = []
-    for plan in _branch_execution_plans(scenario):
-        branch_run_dir = branches_root / plan.branch_id
-        branch_notes = [
-            "Branch injections: " + (", ".join(plan.injection_ids) if plan.injection_ids else "none")
-        ]
+    for branch_plan in _branch_execution_plans(scenario):
+        branch_run_dir = branches_root / branch_plan.branch_id
+        branch_notes = ["Branch injections: " + (", ".join(branch_plan.injection_ids) if branch_plan.injection_ids else "none")]
         summary, actions = _simulate_loaded_scenario(
-            plan.scenario,
+            branch_plan.scenario,
+            plan,
             graph_path,
             personas_path,
             branch_run_dir,
-            run_id=f"run_{scenario.scenario_id}_{scenario.seed}_{plan.branch_id}",
+            run_id=f"run_{scenario.scenario_id}_{scenario.seed}_{branch_plan.branch_id}",
             notes_prefix=branch_notes,
         )
         branch_runs.append(
             BranchRunArtifacts(
-                branch_id=plan.branch_id,
-                label=plan.label,
+                branch_id=branch_plan.branch_id,
+                label=branch_plan.label,
                 summary=summary,
                 actions=actions,
                 run_dir=branch_run_dir,
@@ -572,4 +511,5 @@ def simulate_branching_scenario(
         seed=scenario.seed,
         branch_runs=branch_runs,
         reference_branch_id="branch_reference",
+        tracked_outcomes=plan.tracked_outcomes,
     )

--- a/backend/app/worlds.py
+++ b/backend/app/worlds.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+CANONICAL_DEMO_WORLD_ID = "fog-harbor-east-gate"
+
+
+@dataclass(frozen=True)
+class WorldPaths:
+    repo_root: Path
+    world_id: str
+    data_root: Path
+    artifacts_root: Path
+    manifest_path: Path
+    world_model_path: Path
+    simulation_rules_path: Path
+    scenario_dir: Path
+    baseline_scenario_path: Path
+    expectations_path: Path | None = None
+
+    def scenario_paths(self) -> list[Path]:
+        return [self.baseline_scenario_path] + sorted(
+            path for path in self.scenario_dir.glob("*.yaml") if path != self.baseline_scenario_path
+        )
+
+
+def resolve_world_paths(world_id: str, repo_root: Path | None = None) -> WorldPaths:
+    root = repo_root or Path(__file__).resolve().parents[2]
+    if world_id == CANONICAL_DEMO_WORLD_ID:
+        data_root = root / "data" / "demo"
+        artifacts_root = root / "artifacts" / "demo"
+        expectations_path = data_root / "expectations" / "demo_eval.yaml"
+    else:
+        data_root = root / "data" / "worlds" / world_id
+        artifacts_root = root / "artifacts" / "worlds" / world_id
+        expectations_path = None
+
+    return WorldPaths(
+        repo_root=root,
+        world_id=world_id,
+        data_root=data_root,
+        artifacts_root=artifacts_root,
+        manifest_path=data_root / "corpus" / "manifest.yaml",
+        world_model_path=data_root / "config" / "world_model.yaml",
+        simulation_rules_path=data_root / "config" / "simulation_rules.yaml",
+        scenario_dir=data_root / "scenarios",
+        baseline_scenario_path=data_root / "scenarios" / "baseline.yaml",
+        expectations_path=expectations_path,
+    )
+
+
+def list_world_ids(repo_root: Path | None = None) -> list[str]:
+    root = repo_root or Path(__file__).resolve().parents[2]
+    worlds_root = root / "data" / "worlds"
+    world_ids = [CANONICAL_DEMO_WORLD_ID]
+    if worlds_root.exists():
+        world_ids.extend(
+            sorted(path.name for path in worlds_root.iterdir() if path.is_dir())
+        )
+    return world_ids

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -22,10 +22,12 @@ def test_demo_report_endpoint_reflects_artifact_state(tmp_path: Path, monkeypatc
     run_phase0_demo(settings=settings, artifacts_root=tmp_path / "demo")
     patched_settings = Settings(
         repo_root=settings.repo_root,
+        world_id=settings.world_id,
         data_root=settings.data_root,
         artifacts_root=tmp_path / "demo",
         manifest_path=settings.manifest_path,
         world_model_path=settings.world_model_path,
+        simulation_rules_path=settings.simulation_rules_path,
         scenario_dir=settings.scenario_dir,
         baseline_scenario_path=settings.baseline_scenario_path,
         intervention_scenario_path=settings.intervention_scenario_path,

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -103,6 +103,20 @@ def test_cli_audit_github_queue_outputs_json(monkeypatch, capsys) -> None:
     assert payload["active_milestone"] == milestone_title
 
 
+def test_cli_eval_world_outputs_json(capsys) -> None:
+    assert main(["eval-world", "--world", "museum-night"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["world_id"] == "museum-night"
+    assert payload["status"] == "pass"
+
+
+def test_cli_eval_transfer_outputs_json(capsys) -> None:
+    assert main(["eval-transfer"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["world_id"] == "transfer"
+    assert payload["status"] == "pass"
+
+
 def test_safety_blocks_redline_payload() -> None:
     unsafe_payload = {"description": "This scenario performs political persuasion and voter targeting."}
     try:

--- a/backend/tests/test_worlds.py
+++ b/backend/tests/test_worlds.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.app.evals.service import run_world_eval
+from backend.app.simulation.rules import load_simulation_plan
+from backend.app.worlds import CANONICAL_DEMO_WORLD_ID, resolve_world_paths
+
+
+def test_resolve_world_paths_supports_canonical_and_transfer_world() -> None:
+    demo_paths = resolve_world_paths(CANONICAL_DEMO_WORLD_ID)
+    museum_paths = resolve_world_paths("museum-night")
+
+    assert demo_paths.data_root.name == "demo"
+    assert demo_paths.artifacts_root.name == "demo"
+    assert museum_paths.data_root.name == "museum-night"
+    assert museum_paths.artifacts_root.name == "museum-night"
+    assert museum_paths.simulation_rules_path.name == "simulation_rules.yaml"
+
+
+def test_transfer_world_simulation_rules_load() -> None:
+    plan = load_simulation_plan(resolve_world_paths("museum-night").simulation_rules_path)
+    assert plan.world_id == "museum-night"
+    assert plan.compare_id == "scenario_museum_night_matrix"
+    assert plan.default_report_scenario == "checklist_delayed"
+    assert len(plan.turn_sequence) == 8
+
+
+def test_museum_night_world_eval_passes(tmp_path: Path) -> None:
+    result = run_world_eval("museum-night", artifacts_root=tmp_path / "museum-night")
+    assert result.status == "pass"
+    assert result.world_id == "museum-night"
+    assert result.metrics["scenario_count"] == 2
+    assert Path(result.artifact_paths["report"]).exists()
+    assert Path(result.artifact_paths["eval"]).exists()

--- a/data/demo/config/simulation_rules.yaml
+++ b/data/demo/config/simulation_rules.yaml
@@ -1,0 +1,266 @@
+world_id: fog-harbor-east-gate
+compare_id: scenario_fog_harbor_phase44_matrix
+default_report_scenario: reporter_detained
+communications_down_field: communications_down_until
+blocked_contacts_field: blocked_contacts
+turn_sequence:
+  - persona_su_he
+  - persona_chen_yu
+  - persona_lin_lan
+  - persona_su_he
+  - persona_zhao_ke
+  - persona_lin_lan
+  - persona_su_he
+  - persona_zhao_ke
+initial_state:
+  east_gate_status: fractured
+  festival_status: scheduled
+  risk_known_by: []
+  budget_exposed: false
+  budget_exposed_turn: null
+  ledger_public: false
+  ledger_public_turn: null
+  ledger_available_turn: 3
+  evacuation_requested: false
+  evacuation_triggered: false
+  evacuation_turn: null
+  communications_status: stable
+  communications_down_until: 0
+  blocked_contacts: []
+  mayor_alerted: false
+  storm_arrival_turn: 8
+tracked_outcomes:
+  - field: ledger_public_turn
+    label: Ledger publish turn
+    action_types:
+      - publish
+  - field: budget_exposed_turn
+    label: Budget exposure turn
+    action_types:
+      - publish
+  - field: evacuation_turn
+    label: Evacuation turn
+    action_types:
+      - evacuate
+  - field: festival_status
+    label: Festival status
+    action_types:
+      - hide
+      - evacuate
+  - field: budget_exposed
+    label: Budget exposure state
+    action_types:
+      - publish
+  - field: ledger_public
+    label: Ledger publication state
+    action_types:
+      - publish
+  - field: evacuation_triggered
+    label: Evacuation trigger state
+    action_types:
+      - evacuate
+  - field: risk_known_by
+    label: Risk knowledge spread
+    action_types:
+      - inspect
+      - inform
+injection_rules:
+  - kind: delay_document
+    operation: add_int
+    field: ledger_available_turn
+    param: delay_turns
+    note_template: "{injection_id}: ledger availability delayed by {delay_turns} turn(s)."
+  - kind: resource_failure
+    operation: max_int
+    field: communications_down_until
+    param: duration_turns
+    note_template: "{injection_id}: communications degraded for {duration_turns} turn(s)."
+  - kind: block_contact
+    operation: append_contact
+    field: blocked_contacts
+    note_template: "{injection_id}: contact blocked between {actor_id} and {target_id}."
+steps:
+  - turn_index: 1
+    choices:
+      - action:
+          action_type: inspect
+          target_id: entity_east_gate
+          rationale: Su He inspects the gate because the fracture is already widening under storm pressure.
+          updates:
+            - kind: union_actor_entity
+              field: risk_known_by
+  - turn_index: 2
+    choices:
+      - when:
+          - kind: communication_available
+            target_id: persona_zhao_ke
+        action:
+          action_type: inform
+          target_id: persona_zhao_ke
+          rationale: Chen Yu escalates the tide anomaly toward the deputy mayor.
+          updates:
+            - kind: union_actor_entity
+              field: risk_known_by
+            - kind: set
+              field: mayor_alerted
+              value: true
+      - action:
+          action_type: delay
+          target_id: persona_zhao_ke
+          rationale: The harbor warning is delayed by a communication problem.
+          updates:
+            - kind: set
+              field: communications_status
+              value: degraded
+  - turn_index: 3
+    choices:
+      - when:
+          - kind: turn_gte_state
+            field: ledger_available_turn
+          - kind: communication_available
+            target_id: entity_maintenance_ledger
+        action:
+          action_type: publish
+          target_id: entity_maintenance_ledger
+          rationale: Lin Lan publishes the copied ledger into the decision loop.
+          updates:
+            - kind: set
+              field: ledger_public
+              value: true
+            - kind: set_current_turn
+              field: ledger_public_turn
+            - kind: set
+              field: budget_exposed
+              value: true
+            - kind: set_current_turn
+              field: budget_exposed_turn
+      - action:
+          action_type: delay
+          target_id: entity_maintenance_ledger
+          rationale: Lin Lan cannot surface the ledger yet and holds position.
+  - turn_index: 4
+    choices:
+      - when:
+          - kind: state_truthy
+            field: ledger_public
+        action:
+          action_type: request
+          target_id: entity_east_wharf
+          rationale: Su He requests evacuation once the engineering risk and budget diversion align.
+          updates:
+            - kind: set
+              field: evacuation_requested
+              value: true
+      - action:
+          action_type: request
+          target_id: entity_maintenance_ledger
+          rationale: Su He renews the repair request while waiting for documentary proof.
+          updates:
+            - kind: set
+              field: repair_request_reissued
+              value: true
+  - turn_index: 5
+    choices:
+      - when:
+          - kind: state_truthy
+            field: evacuation_requested
+        action:
+          action_type: evacuate
+          target_id: entity_sea_lantern_festival
+          rationale: Zhao Ke authorizes evacuation once the combined pressure is too visible to ignore.
+          updates:
+            - kind: set
+              field: evacuation_triggered
+              value: true
+            - kind: set_current_turn
+              field: evacuation_turn
+            - kind: set
+              field: festival_status
+              value: suspended
+      - action:
+          action_type: hide
+          target_id: entity_sea_lantern_festival
+          rationale: Zhao Ke suppresses disruption and keeps the festival plan intact.
+          updates:
+            - kind: set
+              field: festival_status
+              value: scheduled
+  - turn_index: 6
+    choices:
+      - when:
+          - kind: state_falsy
+            field: ledger_public
+          - kind: turn_gte_state
+            field: ledger_available_turn
+          - kind: communication_available
+            target_id: entity_maintenance_ledger
+        action:
+          action_type: publish
+          target_id: entity_maintenance_ledger
+          rationale: Lin Lan finally surfaces the copied ledger after the disruption clears.
+          updates:
+            - kind: set
+              field: ledger_public
+              value: true
+            - kind: set_current_turn
+              field: ledger_public_turn
+            - kind: set
+              field: budget_exposed
+              value: true
+            - kind: set_current_turn
+              field: budget_exposed_turn
+      - action:
+          action_type: inform
+          target_id: persona_su_he
+          rationale: Lin Lan keeps the archive evidence circulating among trusted allies.
+          updates:
+            - kind: set
+              field: public_pressure
+              value: mounting
+  - turn_index: 7
+    choices:
+      - when:
+          - kind: state_truthy
+            field: budget_exposed
+          - kind: state_falsy
+            field: evacuation_requested
+        action:
+          action_type: request
+          target_id: entity_east_wharf
+          rationale: Su He renews the evacuation request once the ledger becomes public.
+          updates:
+            - kind: set
+              field: evacuation_requested
+              value: true
+      - action:
+          action_type: inspect
+          target_id: entity_east_gate
+          rationale: Su He monitors the gate while waiting for the mayor's order to take effect.
+  - turn_index: 8
+    choices:
+      - when:
+          - kind: state_truthy
+            field: evacuation_requested
+          - kind: state_falsy
+            field: evacuation_triggered
+        action:
+          action_type: evacuate
+          target_id: entity_east_wharf
+          rationale: Zhao Ke orders evacuation at the last viable moment in this branch.
+          updates:
+            - kind: set
+              field: evacuation_triggered
+              value: true
+            - kind: set_current_turn
+              field: evacuation_turn
+            - kind: set
+              field: festival_status
+              value: suspended
+      - action:
+          action_type: move
+          target_id: entity_east_wharf
+          rationale: Zhao Ke repositions to manage the festival command post.
+          updates:
+            - kind: set
+              field: command_post
+              value: harbor_square

--- a/data/worlds/museum-night/config/simulation_rules.yaml
+++ b/data/worlds/museum-night/config/simulation_rules.yaml
@@ -1,0 +1,225 @@
+world_id: museum-night
+compare_id: scenario_museum_night_matrix
+default_report_scenario: checklist_delayed
+communications_down_field: communications_down_until
+blocked_contacts_field: blocked_contacts
+turn_sequence:
+  - persona_tomas_reed
+  - persona_iris_vale
+  - persona_mina_park
+  - persona_noa_bell
+  - persona_iris_vale
+  - persona_mina_park
+  - persona_noa_bell
+  - persona_iris_vale
+initial_state:
+  opening_status: scheduled
+  checklist_available_turn: 3
+  checklist_public: false
+  checklist_public_turn: null
+  safety_hold_requested: false
+  safety_hold_triggered: false
+  safety_hold_turn: null
+  lighting_status: unstable
+  risk_known_by: []
+  communications_status: stable
+  communications_down_until: 0
+  blocked_contacts: []
+tracked_outcomes:
+  - field: checklist_public_turn
+    label: Checklist publication turn
+    action_types:
+      - publish
+  - field: safety_hold_turn
+    label: Safety-hold turn
+    action_types:
+      - move
+  - field: opening_status
+    label: Opening status
+    action_types:
+      - hide
+      - move
+  - field: safety_hold_triggered
+    label: Safety-hold trigger state
+    action_types:
+      - move
+  - field: risk_known_by
+    label: Risk knowledge spread
+    action_types:
+      - inspect
+      - inform
+injection_rules:
+  - kind: delay_document
+    operation: add_int
+    field: checklist_available_turn
+    param: delay_turns
+    note_template: "{injection_id}: checklist availability delayed by {delay_turns} turn(s)."
+  - kind: resource_failure
+    operation: max_int
+    field: communications_down_until
+    param: duration_turns
+    note_template: "{injection_id}: communication relay degraded for {duration_turns} turn(s)."
+  - kind: block_contact
+    operation: append_contact
+    field: blocked_contacts
+    note_template: "{injection_id}: contact blocked between {actor_id} and {target_id}."
+steps:
+  - turn_index: 1
+    choices:
+      - action:
+          action_type: inspect
+          target_id: entity_west_hall_lights
+          rationale: Tomas Reed inspects the lighting rig before guests reach the hall.
+          updates:
+            - kind: union_actor_entity
+              field: risk_known_by
+  - turn_index: 2
+    choices:
+      - when:
+          - kind: communication_available
+            target_id: persona_noa_bell
+        action:
+          action_type: inform
+          target_id: persona_noa_bell
+          rationale: Iris Vale escalates the queue and hold posture toward the curator.
+          updates:
+            - kind: union_actor_entity
+              field: risk_known_by
+      - action:
+          action_type: delay
+          target_id: persona_noa_bell
+          rationale: The queue warning is delayed by a communication problem.
+          updates:
+            - kind: set
+              field: communications_status
+              value: degraded
+  - turn_index: 3
+    choices:
+      - when:
+          - kind: turn_gte_state
+            field: checklist_available_turn
+        action:
+          action_type: publish
+          target_id: entity_opening_checklist
+          rationale: Mina Park publishes the printed opening checklist into the lobby handoff.
+          updates:
+            - kind: set
+              field: checklist_public
+              value: true
+            - kind: set_current_turn
+              field: checklist_public_turn
+      - action:
+          action_type: delay
+          target_id: entity_opening_checklist
+          rationale: Mina Park cannot surface the checklist copy yet and holds the volunteer handoff.
+  - turn_index: 4
+    choices:
+      - when:
+          - kind: state_truthy
+            field: checklist_public
+        action:
+          action_type: request
+          target_id: entity_museum_entry
+          rationale: Noa Bell requests a safety hold once the checklist and setup issues are visible.
+          updates:
+            - kind: set
+              field: safety_hold_requested
+              value: true
+      - action:
+          action_type: request
+          target_id: entity_opening_checklist
+          rationale: Noa Bell asks for the missing checklist evidence before delaying guests.
+  - turn_index: 5
+    choices:
+      - when:
+          - kind: state_truthy
+            field: safety_hold_requested
+        action:
+          action_type: move
+          target_id: entity_museum_entry
+          rationale: Iris Vale reroutes the entry queue into a safety hold.
+          updates:
+            - kind: set
+              field: safety_hold_triggered
+              value: true
+            - kind: set_current_turn
+              field: safety_hold_turn
+            - kind: set
+              field: opening_status
+              value: paused
+      - action:
+          action_type: hide
+          target_id: entity_twilight_preview
+          rationale: Iris Vale keeps the preview flow moving while waiting for firmer evidence.
+          updates:
+            - kind: set
+              field: opening_status
+              value: scheduled
+  - turn_index: 6
+    choices:
+      - when:
+          - kind: state_falsy
+            field: checklist_public
+          - kind: turn_gte_state
+            field: checklist_available_turn
+        action:
+          action_type: publish
+          target_id: entity_opening_checklist
+          rationale: Mina Park surfaces the backup checklist after the delay clears.
+          updates:
+            - kind: set
+              field: checklist_public
+              value: true
+            - kind: set_current_turn
+              field: checklist_public_turn
+      - action:
+          action_type: inform
+          target_id: persona_noa_bell
+          rationale: Mina Park keeps the volunteer team aligned while the checklist stays late.
+  - turn_index: 7
+    choices:
+      - when:
+          - kind: state_truthy
+            field: checklist_public
+          - kind: state_falsy
+            field: safety_hold_requested
+        action:
+          action_type: request
+          target_id: entity_museum_entry
+          rationale: Noa Bell renews the hold request once the checklist finally becomes visible.
+          updates:
+            - kind: set
+              field: safety_hold_requested
+              value: true
+      - action:
+          action_type: inspect
+          target_id: entity_west_hall_lights
+          rationale: Noa Bell keeps checking the lighting risk while the preview remains in motion.
+  - turn_index: 8
+    choices:
+      - when:
+          - kind: state_truthy
+            field: safety_hold_requested
+          - kind: state_falsy
+            field: safety_hold_triggered
+        action:
+          action_type: move
+          target_id: entity_museum_entry
+          rationale: Iris Vale triggers the hold at the last safe moment before the preview crowd compresses.
+          updates:
+            - kind: set
+              field: safety_hold_triggered
+              value: true
+            - kind: set_current_turn
+              field: safety_hold_turn
+            - kind: set
+              field: opening_status
+              value: paused
+      - action:
+          action_type: hide
+          target_id: entity_twilight_preview
+          rationale: Iris Vale preserves the scheduled preview path after the risk window closes.
+          updates:
+            - kind: set
+              field: opening_status
+              value: scheduled

--- a/data/worlds/museum-night/config/world_model.yaml
+++ b/data/worlds/museum-night/config/world_model.yaml
@@ -1,0 +1,422 @@
+world_id: museum-night
+entities:
+  - entity_id: entity_noa_bell
+    name: Noa Bell
+    type: person
+    aliases:
+      - noa bell
+      - curator noa bell
+      - curator
+  - entity_id: entity_iris_vale
+    name: Iris Vale
+    type: person
+    aliases:
+      - iris vale
+      - security lead iris vale
+      - security lead
+  - entity_id: entity_tomas_reed
+    name: Tomas Reed
+    type: person
+    aliases:
+      - tomas reed
+      - facilities technician tomas reed
+      - facilities technician
+  - entity_id: entity_mina_park
+    name: Mina Park
+    type: person
+    aliases:
+      - mina park
+      - volunteer coordinator mina park
+      - volunteer coordinator
+  - entity_id: entity_west_hall_lights
+    name: West Hall Lights
+    type: infrastructure
+    aliases:
+      - west hall lights
+      - lighting rig
+      - ballast rack
+  - entity_id: entity_opening_checklist
+    name: Opening Checklist
+    type: document
+    aliases:
+      - opening checklist
+      - printed checklist
+      - checklist copy
+  - entity_id: entity_twilight_preview
+    name: Twilight Preview
+    type: event
+    aliases:
+      - twilight preview
+      - preview guests
+      - preview opening
+  - entity_id: entity_museum_entry
+    name: Museum Entry
+    type: location
+    aliases:
+      - museum entry
+      - front steps
+      - lobby doors
+
+relations:
+  - relation_id: relation_tomas_inspects_lights
+    source_entity_id: entity_tomas_reed
+    relation_type: inspects
+    target_entity_id: entity_west_hall_lights
+    match:
+      all:
+        - tomas reed
+        - west hall lights
+      any:
+        - inspected
+        - unstable ballast
+        - ballast rack
+  - relation_id: relation_mina_controls_checklist
+    source_entity_id: entity_mina_park
+    relation_type: controls
+    target_entity_id: entity_opening_checklist
+    match:
+      all:
+        - mina park
+        - opening checklist
+      any:
+        - printed checklist
+        - checklist copy
+        - print room
+  - relation_id: relation_noa_protects_preview
+    source_entity_id: entity_noa_bell
+    relation_type: protects
+    target_entity_id: entity_twilight_preview
+    match:
+      all:
+        - noa bell
+      any:
+        - twilight preview
+        - keep the preview on schedule
+        - opening on time
+  - relation_id: relation_iris_secures_entry
+    source_entity_id: entity_iris_vale
+    relation_type: secures
+    target_entity_id: entity_museum_entry
+    match:
+      all:
+        - iris vale
+        - museum entry
+      any:
+        - queue
+        - front steps
+        - security hold
+
+events:
+  - event_id: event_lighting_fault
+    name: West Hall Lighting Fault Narrows Setup Time
+    kind: facilities_risk
+    participant_entity_ids:
+      - entity_tomas_reed
+      - entity_west_hall_lights
+      - entity_noa_bell
+    match:
+      any:
+        - unstable ballast
+        - west hall lights
+        - fail before doors open
+        - spare ballast
+  - event_id: event_checklist_delay
+    name: Opening Checklist Delay Slows Volunteer Coordination
+    kind: document_delay
+    participant_entity_ids:
+      - entity_mina_park
+      - entity_opening_checklist
+      - entity_museum_entry
+    match:
+      any:
+        - opening checklist
+        - printed checklist
+        - print room
+        - late copy
+  - event_id: event_preview_pressure
+    name: Curatorial Pressure Keeps The Preview On Schedule
+    kind: schedule_pressure
+    participant_entity_ids:
+      - entity_noa_bell
+      - entity_twilight_preview
+      - entity_museum_entry
+    match:
+      any:
+        - twilight preview
+        - keep the preview on schedule
+        - opening on time
+        - guest list
+  - event_id: event_entry_bottleneck
+    name: Entry Queue Bottleneck Raises A Safety-Hold Decision
+    kind: queue_pressure
+    participant_entity_ids:
+      - entity_iris_vale
+      - entity_museum_entry
+      - entity_opening_checklist
+      - entity_twilight_preview
+    match:
+      any:
+        - museum entry
+        - queue
+        - security hold
+        - front steps
+
+personas:
+  - persona_id: persona_noa_bell
+    entity_id: entity_noa_bell
+    public_role:
+      text: Curator responsible for the Twilight Preview opening.
+      evidence:
+        entity_ids:
+          - entity_noa_bell
+          - entity_twilight_preview
+        relation_ids:
+          - relation_noa_protects_preview
+    goals:
+      - text: Keep the Twilight Preview credible without opening under avoidable safety confusion.
+        evidence:
+          event_ids:
+            - event_preview_pressure
+            - event_entry_bottleneck
+      - text: Get a clear signal about whether the lighting fault and checklist delay justify a hold.
+        evidence:
+          event_ids:
+            - event_lighting_fault
+            - event_checklist_delay
+    constraints:
+      - text: Depends on Tomas Reed, Iris Vale, and Mina Park for operational truth.
+        evidence:
+          relation_ids:
+            - relation_tomas_inspects_lights
+            - relation_iris_secures_entry
+            - relation_mina_controls_checklist
+      - text: Faces pressure to keep the preview on schedule.
+        evidence:
+          event_ids:
+            - event_preview_pressure
+    known_facts:
+      - text: The preview guest list and curatorial memo assume the doors open on time.
+        evidence:
+          event_ids:
+            - event_preview_pressure
+      - text: A security hold at the museum entry would visibly delay the preview.
+        evidence:
+          event_ids:
+            - event_entry_bottleneck
+    private_info:
+      - text: Noa Bell will accept a delay if the checklist and lighting evidence line up clearly enough.
+        evidence:
+          event_ids:
+            - event_lighting_fault
+            - event_checklist_delay
+    relationships:
+      - target_id: persona_iris_vale
+        kind: relies_on
+        evidence:
+          relation_ids:
+            - relation_iris_secures_entry
+          event_ids:
+            - event_entry_bottleneck
+      - target_id: persona_tomas_reed
+        kind: trusts
+        evidence:
+          relation_ids:
+            - relation_tomas_inspects_lights
+          event_ids:
+            - event_lighting_fault
+
+  - persona_id: persona_iris_vale
+    entity_id: entity_iris_vale
+    public_role:
+      text: Security lead managing the museum entry and queue posture.
+      evidence:
+        entity_ids:
+          - entity_iris_vale
+          - entity_museum_entry
+        relation_ids:
+          - relation_iris_secures_entry
+    goals:
+      - text: Keep the museum entry orderly enough to trigger a hold before the queue becomes unsafe.
+        evidence:
+          event_ids:
+            - event_entry_bottleneck
+      - text: Surface the hold decision without losing sight of curatorial pressure.
+        evidence:
+          event_ids:
+            - event_entry_bottleneck
+            - event_preview_pressure
+    constraints:
+      - text: Needs a credible reason before delaying guests at the front steps.
+        evidence:
+          event_ids:
+            - event_entry_bottleneck
+            - event_preview_pressure
+      - text: Can redirect the queue, but cannot finalize the checklist or repair the lights.
+        evidence:
+          relation_ids:
+            - relation_mina_controls_checklist
+            - relation_tomas_inspects_lights
+    known_facts:
+      - text: A late checklist copy slows volunteer handoff at the museum entry.
+        evidence:
+          event_ids:
+            - event_checklist_delay
+            - event_entry_bottleneck
+      - text: The front steps become fragile once guests arrive before the queue map is ready.
+        evidence:
+          event_ids:
+            - event_entry_bottleneck
+    private_info:
+      - text: Iris Vale will support a safety hold if the checklist delay becomes visible enough to justify it.
+        evidence:
+          event_ids:
+            - event_checklist_delay
+            - event_entry_bottleneck
+    relationships:
+      - target_id: persona_noa_bell
+        kind: reports_to
+        evidence:
+          relation_ids:
+            - relation_noa_protects_preview
+          event_ids:
+            - event_preview_pressure
+      - target_id: persona_mina_park
+        kind: coordinates_with
+        evidence:
+          relation_ids:
+            - relation_mina_controls_checklist
+          event_ids:
+            - event_checklist_delay
+
+  - persona_id: persona_tomas_reed
+    entity_id: entity_tomas_reed
+    public_role:
+      text: Facilities technician inspecting the West Hall lights before the preview opens.
+      evidence:
+        entity_ids:
+          - entity_tomas_reed
+          - entity_west_hall_lights
+        relation_ids:
+          - relation_tomas_inspects_lights
+    goals:
+      - text: Stabilize the lighting rig before guest traffic reaches the hall.
+        evidence:
+          event_ids:
+            - event_lighting_fault
+      - text: Push the operational team to respect the fault before the preview starts.
+        evidence:
+          event_ids:
+            - event_lighting_fault
+            - event_preview_pressure
+    constraints:
+      - text: Can diagnose the ballast rack but cannot hold the doors alone.
+        evidence:
+          relation_ids:
+            - relation_tomas_inspects_lights
+          event_ids:
+            - event_lighting_fault
+      - text: Needs the checklist and security posture to line up before a hold becomes credible.
+        evidence:
+          event_ids:
+            - event_checklist_delay
+            - event_entry_bottleneck
+    known_facts:
+      - text: The west hall lights already flicker under the current ballast load.
+        evidence:
+          relation_ids:
+            - relation_tomas_inspects_lights
+          event_ids:
+            - event_lighting_fault
+      - text: A rushed opening would make the unstable ballast harder to isolate.
+        evidence:
+          event_ids:
+            - event_lighting_fault
+            - event_preview_pressure
+    private_info:
+      - text: Tomas Reed believes one more unstable cycle could force a full hall reset.
+        evidence:
+          event_ids:
+            - event_lighting_fault
+    relationships:
+      - target_id: persona_noa_bell
+        kind: warns
+        evidence:
+          relation_ids:
+            - relation_tomas_inspects_lights
+          event_ids:
+            - event_lighting_fault
+      - target_id: persona_iris_vale
+        kind: coordinates_with
+        evidence:
+          relation_ids:
+            - relation_iris_secures_entry
+          event_ids:
+            - event_entry_bottleneck
+
+  - persona_id: persona_mina_park
+    entity_id: entity_mina_park
+    public_role:
+      text: Volunteer coordinator carrying the printed opening checklist into the lobby flow.
+      evidence:
+        entity_ids:
+          - entity_mina_park
+          - entity_opening_checklist
+        relation_ids:
+          - relation_mina_controls_checklist
+    goals:
+      - text: Get the printed checklist to the front-of-house team before guests queue at the doors.
+        evidence:
+          event_ids:
+            - event_checklist_delay
+            - event_entry_bottleneck
+      - text: Keep volunteer instructions aligned with whatever hold posture security chooses.
+        evidence:
+          event_ids:
+            - event_checklist_delay
+            - event_entry_bottleneck
+    constraints:
+      - text: Depends on the print room and lobby routing to move the checklist copy.
+        evidence:
+          relation_ids:
+            - relation_mina_controls_checklist
+          event_ids:
+            - event_checklist_delay
+      - text: Has no authority to override curatorial pressure once the preview crowd is already assembling.
+        evidence:
+          event_ids:
+            - event_preview_pressure
+            - event_entry_bottleneck
+    known_facts:
+      - text: The current checklist copy is late enough to distort volunteer staging.
+        evidence:
+          event_ids:
+            - event_checklist_delay
+      - text: Security needs the checklist in hand before a hold can be explained cleanly at the museum entry.
+        evidence:
+          event_ids:
+            - event_checklist_delay
+            - event_entry_bottleneck
+    private_info:
+      - text: Mina Park prepared a backup checklist copy in case the print room misses the first handoff.
+        evidence:
+          relation_ids:
+            - relation_mina_controls_checklist
+          event_ids:
+            - event_checklist_delay
+    relationships:
+      - target_id: persona_iris_vale
+        kind: coordinates_with
+        evidence:
+          relation_ids:
+            - relation_iris_secures_entry
+            - relation_mina_controls_checklist
+          event_ids:
+            - event_checklist_delay
+      - target_id: persona_noa_bell
+        kind: briefs
+        evidence:
+          relation_ids:
+            - relation_noa_protects_preview
+            - relation_mina_controls_checklist
+          event_ids:
+            - event_preview_pressure

--- a/data/worlds/museum-night/corpus/docs/curatorial_memo.md
+++ b/data/worlds/museum-night/corpus/docs/curatorial_memo.md
@@ -1,0 +1,3 @@
+Curator Noa Bell wrote that the Twilight Preview must keep the preview opening on time if the team can do so without avoidable confusion at the museum entry.
+
+The memo says Noa Bell will accept a short hold only if the lighting evidence and the printed checklist point to the same operational risk.

--- a/data/worlds/museum-night/corpus/docs/facilities_log.md
+++ b/data/worlds/museum-night/corpus/docs/facilities_log.md
@@ -1,0 +1,3 @@
+Facilities technician Tomas Reed inspected the west hall lights and logged an unstable ballast inside the ballast rack before sunset.
+
+Tomas Reed warned that the west hall lights could fail before doors open unless the team slows the preview setup and confirms the spare ballast.

--- a/data/worlds/museum-night/corpus/docs/operations_board.md
+++ b/data/worlds/museum-night/corpus/docs/operations_board.md
@@ -1,0 +1,3 @@
+The operations board summary says the Twilight Preview guest list keeps pressure on the team to keep the preview on schedule even while facilities and security raise concerns.
+
+The same board notes connect the unstable ballast, the opening checklist, and the museum entry queue to one decision about whether the team should trigger a security hold.

--- a/data/worlds/museum-night/corpus/docs/security_round.md
+++ b/data/worlds/museum-night/corpus/docs/security_round.md
@@ -1,0 +1,3 @@
+Security lead Iris Vale walked the museum entry and recorded that the front steps will bottleneck quickly if guests arrive before a clean security hold can be explained.
+
+Iris Vale wrote that the queue at the museum entry stays manageable only when the volunteer handoff and the printed checklist reach the lobby doors on time.

--- a/data/worlds/museum-night/corpus/docs/volunteer_packet.md
+++ b/data/worlds/museum-night/corpus/docs/volunteer_packet.md
@@ -1,0 +1,3 @@
+Volunteer coordinator Mina Park noted that the opening checklist depends on a printed checklist copy leaving the print room before volunteers stage at the museum entry.
+
+Mina Park prepared a checklist copy backup because one late copy would distort the queue map and volunteer handoff at the front steps.

--- a/data/worlds/museum-night/corpus/manifest.yaml
+++ b/data/worlds/museum-night/corpus/manifest.yaml
@@ -1,0 +1,43 @@
+world_id: museum-night
+title: Museum Night Opening Review
+docs:
+  - document_id: doc_curatorial_memo
+    title: Curatorial Memo For The Twilight Preview
+    kind: memo
+    path: docs/curatorial_memo.md
+    created_at: "1912-10-04T16:10:00Z"
+    metadata:
+      author: noa_bell
+      channel: curatorial_office
+  - document_id: doc_facilities_log
+    title: West Hall Facilities Log
+    kind: facilities_log
+    path: docs/facilities_log.md
+    created_at: "1912-10-04T17:05:00Z"
+    metadata:
+      author: tomas_reed
+      channel: facilities_desk
+  - document_id: doc_volunteer_packet
+    title: Volunteer Packet Routing Note
+    kind: routing_note
+    path: docs/volunteer_packet.md
+    created_at: "1912-10-04T17:20:00Z"
+    metadata:
+      author: mina_park
+      channel: volunteer_room
+  - document_id: doc_security_round
+    title: Security Round At The Museum Entry
+    kind: round_report
+    path: docs/security_round.md
+    created_at: "1912-10-04T17:40:00Z"
+    metadata:
+      author: iris_vale
+      channel: security_office
+  - document_id: doc_operations_board
+    title: Operations Board Summary
+    kind: operations_note
+    path: docs/operations_board.md
+    created_at: "1912-10-04T17:55:00Z"
+    metadata:
+      author: night_manager
+      channel: operations_board

--- a/data/worlds/museum-night/scenarios/baseline.yaml
+++ b/data/worlds/museum-night/scenarios/baseline.yaml
@@ -1,0 +1,14 @@
+scenario_id: scenario_museum_night_baseline
+world_id: museum-night
+title: Baseline Twilight Preview Setup
+description: >
+  The baseline branch assumes the printed opening checklist reaches Mina Park on time
+  and the review team can decide on a safety hold without extra injected disruption.
+seed: 11
+turn_budget: 8
+branch_count: 1
+evaluation_questions:
+  - Who accumulates enough operational evidence to justify a safety hold first?
+  - Does the opening checklist surface before Iris Vale has to commit to the queue posture?
+  - Is the Twilight Preview paused before the entry queue becomes fragile?
+injections: []

--- a/data/worlds/museum-night/scenarios/checklist_delayed.yaml
+++ b/data/worlds/museum-night/scenarios/checklist_delayed.yaml
@@ -1,0 +1,24 @@
+scenario_id: scenario_museum_night_checklist_delayed
+world_id: museum-night
+title: Checklist Delay Pushes The Hold Decision Back
+description: >
+  The print room handoff slips, so Mina Park cannot publish the opening checklist on
+  the baseline turn and the hold decision arrives later.
+seed: 11
+turn_budget: 8
+branch_count: 1
+evaluation_questions:
+  - How much later does the printed checklist surface?
+  - Does the delayed checklist postpone the safety hold at the museum entry?
+  - Which action chain preserves the scheduled preview path longest?
+injections:
+  - injection_id: inj_checklist_delayed
+    kind: delay_document
+    target_id: doc_volunteer_packet
+    actor_id: persona_mina_park
+    params:
+      delay_turns: 2
+      cause: print_room_backlog
+    rationale: >
+      The print room releases the checklist copy two turns late, so the volunteer
+      coordinator cannot put the entry plan into circulation on the baseline turn.

--- a/docs/architecture/contracts.md
+++ b/docs/architecture/contracts.md
@@ -35,9 +35,20 @@ All IDs must be serializable, stable across files, and traceable in `artifacts/`
   - `inferred`
   - `speculative`
 
+## World Resolution Contract
+
+- The canonical demo world remains `fog-harbor-east-gate`.
+- Canonical demo inputs stay under `data/demo/`.
+- Canonical demo artifacts stay under `artifacts/demo/`.
+- Additional bounded worlds resolve through:
+  - `data/worlds/<world_id>/`
+  - `artifacts/worlds/<world_id>/`
+- World resolution is path-based and deterministic; it does not depend on world-specific Python constants baked into the runner.
+
 ## World Model Contract
 
-- Demo world modeling is driven by `data/demo/config/world_model.yaml`.
+- Canonical demo world modeling is driven by `data/demo/config/world_model.yaml`.
+- Additional worlds must provide `config/world_model.yaml` under their own world root.
 - `graph.json` is the durable world-model artifact and now contains:
   - `entities`
   - `relations`
@@ -60,6 +71,7 @@ All IDs must be serializable, stable across files, and traceable in `artifacts/`
 ## Scenario Contract
 
 - `scenario_id` names the full scenario package.
+- `world_id` must resolve to one bounded world root.
 - `branch_count` is part of the scenario execution contract.
   - `branch_count: 1` preserves the current single-branch behavior.
   - `branch_count > 1` requests deterministic multi-branch execution for one scenario package.
@@ -69,6 +81,21 @@ All IDs must be serializable, stable across files, and traceable in `artifacts/`
   - `delay_document`
   - `block_contact`
   - `resource_failure`
+
+## Simulation Rules Contract
+
+- Each world now provides `config/simulation_rules.yaml`.
+- `simulation_rules.yaml` is the deterministic runner contract for:
+  - `turn_sequence`
+  - `initial_state`
+  - `tracked_outcomes`
+  - supported injection effects
+  - explicit per-turn step rules
+- The runner remains bounded and deterministic:
+  - no free-form agent planning
+  - no LLM control loop
+  - no open-ended world simulation DSL
+- Fog Harbor keeps its existing behavior through world-local rules instead of runner hardcoding.
 
 ## Run Contract
 
@@ -141,11 +168,34 @@ artifacts/demo/
 │       └── compare.json
 ├── report/
 └── eval/
+
+artifacts/worlds/<world_id>/
+├── ingest/
+├── graph/
+├── personas/
+├── scenario/
+├── run/
+├── compare/
+├── report/
+└── eval/
 ```
 
 - Existing single-branch and Phase 44 matrix artifacts remain valid while Phase 45 implementation catches up to the new compare contract.
 
+## Eval Contract
+
+- `python -m backend.app.cli eval-demo` remains the canonical Fog Harbor regression command.
+- `python -m backend.app.cli eval-world --world <world_id>` runs the bounded world pipeline plus transfer eval for one world.
+- `python -m backend.app.cli eval-transfer` runs the dual-world transfer proof across the canonical demo and the current second world.
+- Transfer eval summaries must include:
+  - `world_id`
+  - `scenario_count`
+  - `checks_total`
+  - `checks_passed`
+  - `failed_checks`
+  - `artifact_paths`
+
 ## Platform Assumption
 
-The canonical command names remain `make setup|smoke|test|eval-demo|dev-api|dev-web`.  
+The canonical command names remain `make setup|smoke|test|eval-demo|eval-transfer|dev-api|dev-web`.
 Because GNU Make is absent in the current Windows environment, the repo also ships `make.ps1` and `make.cmd`.

--- a/docs/decisions/ADR-0005-two-world-transfer-contracts.md
+++ b/docs/decisions/ADR-0005-two-world-transfer-contracts.md
@@ -1,0 +1,68 @@
+# ADR-0005: Two-World Transfer Contracts
+
+## Status
+
+- Accepted
+
+## Context
+
+Phase 46 closed the workbench queue in a clean release stop-state, but the repository still proved only one thing end to end:
+
+- the canonical Fog Harbor demo works well
+
+That is necessary, but it is not yet enough to show minimal transferability. The next bounded step is not a larger UI or a heavier runtime. It is a second small fictional world that can reuse the same constrained, deterministic, evidence-backed pipeline.
+
+To make that credible, three contracts need to become explicit instead of remaining implicit:
+
+- how non-canonical worlds are resolved on disk
+- how the deterministic runner is configured without new world-specific Python constants
+- how transfer eval proves that two worlds can both pass the same integrity checks
+
+## Decision
+
+- Keep the canonical demo contract unchanged:
+  - `fog-harbor-east-gate` remains the canonical demo world
+  - canonical inputs stay in `data/demo/`
+  - canonical artifacts stay in `artifacts/demo/`
+- Introduce bounded world-path resolution for additional worlds:
+  - `data/worlds/<world_id>/`
+  - `artifacts/worlds/<world_id>/`
+- Ratify one new per-world runner config:
+  - `config/simulation_rules.yaml`
+- Freeze the purpose of `simulation_rules.yaml` to deterministic runner configuration only:
+  - turn ownership
+  - initial state
+  - tracked outcomes
+  - explicit step rules
+  - bounded injection effects
+- Do not introduce:
+  - free-form agent planning
+  - LLM-controlled simulation
+  - a complex open-ended simulation DSL
+- Keep external artifact contracts stable:
+  - `TurnAction` shape stays unchanged
+  - `RunTrace` shape stays unchanged
+  - compare artifact shape stays unchanged
+  - the canonical Fog Harbor compare path used by the workbench stays unchanged
+- Add two new CLI entrypoints:
+  - `python -m backend.app.cli eval-world --world <world_id>`
+  - `python -m backend.app.cli eval-transfer`
+- Freeze transfer eval semantics:
+  - `eval-demo` remains the canonical Fog Harbor regression command
+  - `eval-transfer` is the minimum portability proof and runs both Fog Harbor and the second bounded world
+  - transfer summaries must expose `world_id`, counts, failures, and artifact paths
+- Keep the frontend scope narrow in this round:
+  - no multi-world selector yet
+  - no new packet or handoff surfaces
+  - only metadata and doc drift fixes are allowed
+
+## Consequences
+
+- Mirror can now prove that the pipeline is not single-world-only without claiming open-world generality.
+- New bounded worlds can be added without hardcoding their turn sequence or state logic into the main runner.
+- The canonical Fog Harbor demo remains stable for the current workbench and README flow.
+- Future work can choose between:
+  - more bounded worlds
+  - a small frontend world selector
+  - a new successor queue
+  without first revisiting the core transfer contract.

--- a/docs/demo/fog-harbor-walkthrough.md
+++ b/docs/demo/fog-harbor-walkthrough.md
@@ -1,0 +1,154 @@
+# Fog Harbor Walkthrough
+
+This note explains the canonical Fog Harbor artifact flow for developers who are new to Mirror.
+
+## Artifact Flow
+
+Mirror's canonical demo follows the same bounded pipeline on every run:
+
+1. `corpus`
+2. `chunks`
+3. `graph`
+4. `personas`
+5. `scenarios`
+6. `runs`
+7. `report / claims`
+8. `eval`
+
+The canonical inputs live in `data/demo/`. The generated outputs live in `artifacts/demo/`.
+
+## Commands
+
+Backend setup:
+
+```bash
+make setup
+```
+
+```powershell
+./make.ps1 setup
+```
+
+Canonical validation:
+
+```bash
+make smoke
+make test
+make eval-demo
+```
+
+```powershell
+./make.ps1 smoke
+./make.ps1 test
+./make.ps1 eval-demo
+```
+
+Workbench:
+
+```bash
+make dev-api
+make dev-web
+```
+
+```powershell
+./make.ps1 dev-api
+./make.ps1 dev-web
+```
+
+## Key Files To Inspect
+
+Source data:
+
+- `data/demo/corpus/manifest.yaml`
+- `data/demo/config/world_model.yaml`
+- `data/demo/config/simulation_rules.yaml`
+- `data/demo/scenarios/*.yaml`
+
+Generated artifacts:
+
+- `artifacts/demo/ingest/documents.jsonl`
+- `artifacts/demo/ingest/chunks.jsonl`
+- `artifacts/demo/graph/graph.json`
+- `artifacts/demo/personas/personas.json`
+- `artifacts/demo/scenario/*.json`
+- `artifacts/demo/run/<scenario>/summary.json`
+- `artifacts/demo/run/<scenario>/run_trace.jsonl`
+- `artifacts/demo/compare/scenario_fog_harbor_phase44_matrix/compare.json`
+- `artifacts/demo/report/report.md`
+- `artifacts/demo/report/claims.json`
+- `artifacts/demo/eval/summary.json`
+
+## How To Read The Flow
+
+### Corpus -> Chunks
+
+`ingest` reads the bounded Fog Harbor documents and splits them into chunk-level evidence rows.
+
+Those chunk IDs become the durable `evidence_ids` that later world objects, personas, actions, and claims point back to.
+
+### Chunks -> Graph
+
+`build-graph` uses `data/demo/config/world_model.yaml` to derive:
+
+- entities
+- relations
+- events
+
+Every retained world object should carry `evidence_ids`.
+
+### Graph -> Personas
+
+`personas` builds field-level persona cards from the graph.
+
+Check `artifacts/demo/personas/personas.json` for:
+
+- aggregate persona `evidence_ids`
+- `field_provenance`
+
+If a persona field is populated but has no provenance, the pipeline should fail.
+
+### Scenarios -> Runs
+
+Scenario YAML files stay explicit and bounded. The canonical baseline is `baseline.yaml`, while injected branches such as `reporter_detained.yaml` or `harbor_comms_failure.yaml` change one disturbance at a time.
+
+Each run writes:
+
+- `summary.json`
+- `run_trace.jsonl`
+- `snapshots/turn-XX.json`
+
+### Runs -> Compare / Report / Claims
+
+Fog Harbor keeps a canonical matrix compare artifact at:
+
+- `artifacts/demo/compare/scenario_fog_harbor_phase44_matrix/compare.json`
+
+The main report is pair-scoped:
+
+- baseline
+- one focal intervention branch
+
+Claims live in `artifacts/demo/report/claims.json`.
+
+## How To Verify Claim Grounding
+
+Open `artifacts/demo/report/claims.json` and verify:
+
+- every claim has a `label`
+- every claim has non-empty `evidence_ids`
+- those `evidence_ids` resolve back to chunk IDs in `artifacts/demo/ingest/chunks.jsonl`
+
+This is the fastest manual check that the report is still evidence-backed rather than free-form narrative.
+
+## Baseline vs Intervention
+
+Read baseline and injected branches as a controlled comparison:
+
+- baseline: the bounded world with no extra injected disturbance
+- intervention: the same world plus one explicit disturbance
+
+The interesting question is not "what will the real world do?" It is:
+
+> Under the same corpus and deterministic rules, which outcome fields, actions, and claims change when one bounded disturbance is injected?
+
+That is the core Mirror reading model.

--- a/frontend/src/app/README.md
+++ b/frontend/src/app/README.md
@@ -1,4 +1,8 @@
-# Frontend Shell
+# Frontend Workbench
 
-Phase 0 intentionally defers the workbench UI.  
-This directory exists so later work can bind directly to `artifacts/demo/` without reshaping the repo.
+This app is the current Mirror review workbench.
+
+- It renders the canonical Fog Harbor artifact flow directly from `artifacts/demo/`.
+- The default reading path is compare -> evidence -> eval.
+- Packet-heavy review surfaces stay secondary to the core comparison path.
+- This round does not add a multi-world selector; additional worlds are validated through backend artifacts and transfer eval first.

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 
 export const metadata: Metadata = {
   title: "Mirror Workbench",
-  description: "Phase 5 review sign-off workbench for the Fog Harbor demo."
+  description: "Review workbench for constrained, evidence-backed scenario comparison in Mirror."
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/make.ps1
+++ b/make.ps1
@@ -19,6 +19,9 @@ switch ($Target) {
     "eval-demo" {
         python -m backend.app.cli eval-demo
     }
+    "eval-transfer" {
+        python -m backend.app.cli eval-transfer
+    }
     "dev-api" {
         python -m uvicorn backend.app.main:app --reload
     }


### PR DESCRIPTION
## Summary
- repair doc and metadata drift around the current review workbench and stop-state
- add a world-path resolver plus per-world `simulation_rules.yaml` so the deterministic pipeline is no longer hard-wired to one world
- add the fictional `museum-night` world and prove transferability with `eval-world` and `eval-transfer`

## Protected-Core Notes
- updates durable runner and report behavior through explicit world-local rules rather than new world-specific Python constants
- updates contracts in `docs/architecture/contracts.md`
- adds ADR `ADR-0005-two-world-transfer-contracts.md`
- keeps canonical Fog Harbor compare/workbench paths stable

## Testing
- python -m pytest backend/tests -q
- npm run build --prefix frontend
- ./make.ps1 smoke
- ./make.ps1 test
- ./make.ps1 eval-demo
- ./make.ps1 eval-transfer
- python -m backend.app.cli eval-world --world museum-night
- cmd /c make.cmd eval-transfer
