### PR TITLE
[codex] Rebuild frontend as bilingual editorial workbench

### DIFF
--- a/frontend/src/app/README.md
+++ b/frontend/src/app/README.md
@@ -1,8 +1,9 @@
 # Frontend Workbench
 
-This app is the current Mirror review workbench.
+This app is the current Mirror bilingual review workbench.
 
-- It renders the canonical Fog Harbor artifact flow directly from `artifacts/demo/`.
-- The default reading path is compare -> evidence -> eval.
-- Packet-heavy review surfaces stay secondary to the core comparison path.
-- This round does not add a multi-world selector; additional worlds are validated through backend artifacts and transfer eval first.
+- `/` is the briefing dashboard for the canonical Fog Harbor compare flow.
+- `/review` is the deep review workspace where scorecard, trace, claims, reference, and advanced operations are layered more clearly.
+- UI chrome supports `中文 / EN` language switching through the lightweight `mirror-lang` cookie.
+- Raw artifact bodies remain source-authentic; only the frontend shell and explanatory UI are localized.
+- Packet-heavy and legacy operational surfaces remain available, but they no longer define the homepage.

--- a/frontend/src/app/components/language-switch.tsx
+++ b/frontend/src/app/components/language-switch.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+
+import { MIRROR_LANG_COOKIE, type AppLocale } from "../lib/locale-shared";
+
+type LanguageSwitchProps = {
+  locale: AppLocale;
+};
+
+export function LanguageSwitch({ locale }: LanguageSwitchProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  function setLocale(nextLocale: AppLocale) {
+    if (nextLocale === locale) {
+      return;
+    }
+
+    document.cookie = `${MIRROR_LANG_COOKIE}=${nextLocale}; path=/; max-age=31536000; samesite=lax`;
+    startTransition(() => {
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="languageSwitch" aria-label="Language switch / 语言切换">
+      <button
+        type="button"
+        className={`languageButton${locale === "zh-CN" ? " languageButtonActive" : ""}`}
+        onClick={() => setLocale("zh-CN")}
+        aria-pressed={locale === "zh-CN"}
+        aria-label="切换到中文"
+        title="切换到中文"
+        disabled={isPending}
+      >
+        中文
+      </button>
+      <button
+        type="button"
+        className={`languageButton${locale === "en" ? " languageButtonActive" : ""}`}
+        onClick={() => setLocale("en")}
+        aria-pressed={locale === "en"}
+        aria-label="Switch to English"
+        title="Switch to English"
+        disabled={isPending}
+      >
+        EN
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/app/components/review-rubric-panel.tsx
+++ b/frontend/src/app/components/review-rubric-panel.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import type { AppLocale } from "../lib/locale-shared";
+import type { RubricRow } from "../lib/workbench-data";
+import { getCopy } from "../lib/copy";
+
+type ReviewRubricPanelProps = {
+  locale: AppLocale;
+  rubricRows: RubricRow[];
+  claimCount: number;
+  divergentTurnCount: number;
+  evalName: string;
+  evalStatus: string;
+};
+
+function scoreLabel(locale: AppLocale, value: number | null) {
+  if (value === null) {
+    return locale === "zh-CN" ? "未评分" : "Unscored";
+  }
+  return `${value}/5`;
+}
+
+export function ReviewRubricPanel({
+  locale,
+  rubricRows,
+  claimCount,
+  divergentTurnCount,
+  evalName,
+  evalStatus
+}: ReviewRubricPanelProps) {
+  const copy = getCopy(locale);
+  const [scores, setScores] = useState<Record<string, number | null>>(() =>
+    Object.fromEntries(rubricRows.map((row) => [row.dimension, null]))
+  );
+  const [notes, setNotes] = useState("");
+
+  const selectedScores = useMemo(
+    () => Object.values(scores).filter((value): value is number => value !== null),
+    [scores]
+  );
+  const filledCount = selectedScores.length;
+  const average =
+    selectedScores.length > 0
+      ? (selectedScores.reduce((sum, value) => sum + value, 0) / selectedScores.length).toFixed(1)
+      : "0.0";
+
+  const recommendation = useMemo(() => {
+    if (filledCount < rubricRows.length) {
+      return copy.rubric.recommendationIncomplete;
+    }
+    const minimum = Math.min(...selectedScores);
+    const numericAverage = Number(average);
+    if (numericAverage >= 4 && minimum >= 3) {
+      return copy.rubric.recommendationReady;
+    }
+    if (numericAverage >= 3 && minimum >= 2) {
+      return copy.rubric.recommendationFollowup;
+    }
+    return copy.rubric.recommendationHold;
+  }, [average, copy.rubric, filledCount, rubricRows.length, selectedScores]);
+
+  return (
+    <section className="rubricPanel panel panelAccent" id="scorecard">
+      <div className="panelHeader">
+        <p className="eyebrow">{copy.review.sectionNav.scorecard}</p>
+        <h2>{copy.rubric.title}</h2>
+        <p>{copy.rubric.helper}</p>
+      </div>
+
+      <div className="rubricSummaryGrid">
+        <article className="briefCard briefCardDark">
+          <span>{copy.rubric.dimensionsComplete}</span>
+          <strong>
+            {filledCount}/{rubricRows.length}
+          </strong>
+        </article>
+        <article className="briefCard">
+          <span>{copy.rubric.evidenceTracked}</span>
+          <strong>{claimCount}</strong>
+        </article>
+        <article className="briefCard">
+          <span>{copy.rubric.divergentTurns}</span>
+          <strong>{divergentTurnCount}</strong>
+        </article>
+        <article className="briefCard">
+          <span>{copy.rubric.evalPosture}</span>
+          <strong>
+            {evalName}: {evalStatus}
+          </strong>
+        </article>
+      </div>
+
+      <div className="rubricGrid">
+        {rubricRows.map((row) => (
+          <article key={row.dimension} className="rubricCard">
+            <div className="rubricCardHeader">
+              <div>
+                <h3>{row.dimension}</h3>
+                <p className="subtle">{scoreLabel(locale, scores[row.dimension])}</p>
+              </div>
+              <span className="pill">{copy.rubric.scoreLegend}</span>
+            </div>
+            <div className="scoreButtons">
+              {[1, 2, 3, 4, 5].map((value) => (
+                <button
+                  key={value}
+                  type="button"
+                  className={`scoreButton${scores[row.dimension] === value ? " scoreButtonActive" : ""}`}
+                  onClick={() => setScores((current) => ({ ...current, [row.dimension]: value }))}
+                >
+                  {value}
+                </button>
+              ))}
+            </div>
+            <div className="rubricAnchors">
+              <p>
+                <strong>1</strong> {row.one}
+              </p>
+              <p>
+                <strong>3</strong> {row.three}
+              </p>
+              <p>
+                <strong>5</strong> {row.five}
+              </p>
+            </div>
+          </article>
+        ))}
+      </div>
+
+      <div className="rubricNotes">
+        <label htmlFor="reviewer-notes">{copy.rubric.notesLabel}</label>
+        <textarea
+          id="reviewer-notes"
+          rows={5}
+          value={notes}
+          onChange={(event) => setNotes(event.target.value)}
+          placeholder={copy.rubric.notesPlaceholder}
+        />
+      </div>
+
+      <div className="rubricDecisionCard">
+        <div>
+          <p className="eyebrow">{copy.rubric.recommendationLabel}</p>
+          <h3>{recommendation}</h3>
+        </div>
+        <div className="claimEvidence">
+          <code>
+            {copy.rubric.averageLabel}: {average}
+          </code>
+          <a className="linkPill" href="#advanced-operations">
+            {copy.rubric.openLegacy}
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,15 +1,22 @@
 :root {
   color-scheme: light;
-  --bg: #f4efe6;
-  --bg-strong: #e6d9c6;
-  --panel: rgba(255, 251, 245, 0.82);
-  --panel-strong: rgba(73, 54, 34, 0.08);
-  --ink: #1e1a16;
-  --muted: #66584a;
-  --accent: #0f6b63;
-  --accent-strong: #0a4e49;
-  --border: rgba(30, 26, 22, 0.12);
-  --shadow: 0 24px 60px rgba(58, 40, 22, 0.14);
+  --bg: #f3eadc;
+  --bg-soft: #f8f2e8;
+  --ink: #17130f;
+  --muted: #675b4d;
+  --border: rgba(29, 24, 19, 0.12);
+  --panel: rgba(252, 248, 242, 0.9);
+  --panel-strong: rgba(255, 252, 247, 0.96);
+  --panel-dark: linear-gradient(145deg, #1c1a17, #272119);
+  --accent: #1e7268;
+  --accent-strong: #114d47;
+  --accent-soft: rgba(30, 114, 104, 0.1);
+  --warm: #9b6d3f;
+  --warm-soft: rgba(155, 109, 63, 0.1);
+  --shadow: 0 26px 64px rgba(58, 43, 28, 0.12);
+  --font-display: "Fraunces", "Noto Serif SC", "Songti SC", serif;
+  --font-ui: "IBM Plex Sans", "Noto Sans SC", "PingFang SC", "Microsoft YaHei", sans-serif;
+  --font-mono: "IBM Plex Mono", "JetBrains Mono", "Cascadia Code", monospace;
 }
 
 * {
@@ -21,132 +28,274 @@ body {
   margin: 0;
   min-height: 100%;
   background:
-    radial-gradient(circle at top left, rgba(15, 107, 99, 0.14), transparent 28%),
-    radial-gradient(circle at top right, rgba(191, 120, 72, 0.15), transparent 26%),
-    linear-gradient(180deg, var(--bg), #faf7f1);
+    radial-gradient(circle at top left, rgba(30, 114, 104, 0.14), transparent 24%),
+    radial-gradient(circle at top right, rgba(155, 109, 63, 0.12), transparent 28%),
+    linear-gradient(180deg, var(--bg), var(--bg-soft));
   color: var(--ink);
-  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  font-family: var(--font-ui);
 }
 
 body {
-  padding: 32px 20px 56px;
+  padding: 28px 18px 56px;
+  line-height: 1.6;
 }
 
-.shell {
-  width: min(1120px, 100%);
-  margin: 0 auto;
-  display: grid;
-  gap: 24px;
+a {
+  color: inherit;
 }
 
-.hero,
-.panel {
-  backdrop-filter: blur(10px);
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 28px;
-  box-shadow: var(--shadow);
-}
-
-.hero {
-  padding: 32px;
-}
-
-.panel {
-  padding: 28px;
-}
-
-.panelAccent {
-  background:
-    linear-gradient(135deg, rgba(15, 107, 99, 0.08), rgba(255, 255, 255, 0.82)),
-    var(--panel);
-}
-
-.eyebrow {
-  margin: 0 0 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-  font-size: 12px;
+code {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(30, 114, 104, 0.12);
   color: var(--accent-strong);
-  font-weight: 700;
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
 }
 
 h1,
 h2,
 h3 {
   margin: 0;
-  font-family: Georgia, "Times New Roman", serif;
+  font-family: var(--font-display);
+  letter-spacing: -0.02em;
 }
 
 h1 {
-  font-size: clamp(2.3rem, 5vw, 4.4rem);
-  line-height: 0.98;
-  max-width: 10ch;
+  font-size: clamp(2.6rem, 5vw, 4.9rem);
+  line-height: 0.95;
+  max-width: 10.5ch;
 }
 
 h2 {
-  font-size: clamp(1.5rem, 3vw, 2.3rem);
-  line-height: 1.05;
+  font-size: clamp(1.65rem, 3vw, 2.6rem);
+  line-height: 1.02;
 }
 
 h3 {
-  font-size: 1.15rem;
+  font-size: 1.16rem;
 }
 
-.lede,
-.panel p,
-.checklist li {
-  color: var(--muted);
-  line-height: 1.65;
-  font-size: 1rem;
+p {
+  margin: 0;
 }
 
-.lede {
-  margin: 18px 0 0;
-  max-width: 64ch;
+.workbenchPage {
+  width: min(1180px, 100%);
+  margin: 0 auto;
+  display: grid;
+  gap: 24px;
 }
 
-.heroMeta {
-  margin-top: 22px;
+.topBar {
   display: flex;
   flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.topBarBrand {
+  display: grid;
   gap: 10px;
 }
 
-.heroMeta span,
-code {
+.topBarLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.topBarLinks a,
+.topBarActive {
   display: inline-flex;
   align-items: center;
-  padding: 8px 12px;
+  padding: 9px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(30, 114, 104, 0.16);
+  background: rgba(255, 255, 255, 0.75);
+  color: var(--accent-strong);
+  font-size: 0.92rem;
+  text-decoration: none;
+}
+
+.topBarActive {
+  background: var(--accent);
+  color: #f6fbfa;
+  border-color: var(--accent-strong);
+}
+
+.languageSwitch {
+  display: inline-flex;
+  padding: 4px;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.72);
-  border: 1px solid rgba(15, 107, 99, 0.12);
-  color: var(--accent-strong);
-  font-size: 0.92rem;
+  border: 1px solid rgba(30, 114, 104, 0.12);
+  gap: 4px;
 }
 
-.linkPill {
-  display: inline-flex;
-  align-items: center;
-  padding: 8px 12px;
+.languageButton {
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-weight: 600;
+  padding: 8px 14px;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.78);
-  border: 1px solid rgba(15, 107, 99, 0.18);
-  color: var(--accent-strong);
-  font-size: 0.92rem;
-  text-decoration: none;
+  cursor: pointer;
 }
 
-.linkPill:hover,
-.jumpLink:hover {
-  border-color: rgba(15, 107, 99, 0.4);
-  color: var(--accent);
+.languageButtonActive {
+  background: #201b16;
+  color: #f6f1e7;
 }
 
-.jumpLink {
+.eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 11px;
   color: var(--accent-strong);
   font-weight: 700;
+}
+
+.lede,
+.sectionHeading p,
+.summaryList li,
+.storyboardTurn p,
+.claimSnapshotCard p,
+.miniCard p,
+.rubricAnchors p,
+.rubricNotes textarea,
+.subtle {
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.heroPanel,
+.dashboardSection,
+.reviewHero,
+.panel {
+  border-radius: 30px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  background: var(--panel);
+}
+
+.heroPanel,
+.reviewHero {
+  display: grid;
+  gap: 24px;
+  padding: 30px;
+}
+
+.heroPanel {
+  grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.9fr);
+  background:
+    linear-gradient(140deg, rgba(12, 44, 46, 0.95), rgba(31, 27, 21, 0.94)),
+    var(--panel-dark);
+  color: #f6f1e8;
+}
+
+.heroPanel .eyebrow,
+.heroPanel .lede,
+.heroPanel .briefCard span,
+.heroPanel .briefCard strong {
+  color: inherit;
+}
+
+.heroPanel .eyebrow {
+  color: rgba(231, 224, 211, 0.7);
+}
+
+.heroPanelCopy {
+  display: grid;
+  gap: 18px;
+}
+
+.heroPanelCopy .lede {
+  color: rgba(241, 234, 223, 0.8);
+  max-width: 62ch;
+}
+
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.heroAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 11px 16px;
+  border-radius: 999px;
   text-decoration: none;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.06);
+  color: #f8f2e8;
+  font-weight: 600;
+}
+
+.heroActionPrimary {
+  background: #f0dfc3;
+  color: #1f1812;
+  border-color: rgba(240, 223, 195, 0.45);
+}
+
+.briefSummaryGrid,
+.rubricSummaryGrid,
+.metricGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 14px;
+}
+
+.briefCard {
+  display: grid;
+  gap: 8px;
+  padding: 16px;
+  min-height: 108px;
+  border-radius: 22px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(245, 237, 226, 0.92));
+  border: 1px solid rgba(30, 114, 104, 0.12);
+}
+
+.briefCardDark {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.04));
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.briefCardWide {
+  grid-column: span 2;
+}
+
+.briefCard span {
+  font-size: 0.82rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.briefCard strong {
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+  line-height: 1.15;
+}
+
+.dashboardSection,
+.panel {
+  padding: 28px;
+}
+
+.panelAccent {
+  background:
+    linear-gradient(180deg, rgba(255, 252, 247, 0.98), rgba(244, 236, 224, 0.96)),
+    var(--panel);
 }
 
 .panelHeader {
@@ -155,102 +304,299 @@ code {
   margin-bottom: 18px;
 }
 
-.grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
-  gap: 16px;
+.dashboardSection[id],
+.rubricPanel[id] {
+  scroll-margin-top: 96px;
 }
 
-.pathGrid {
+.sectionHeading {
   display: grid;
+  gap: 8px;
+  margin-bottom: 18px;
+}
+
+.routeBoard,
+.interventionBoard,
+.storyboardGrid,
+.claimSnapshotGrid {
+  display: grid;
+  gap: 18px;
+}
+
+.routeBoard,
+.claimSnapshotGrid {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 16px;
 }
 
-.pathCard {
+.interventionBoard {
+  grid-template-columns: repeat(auto-fit, minmax(290px, 1fr));
+}
+
+.storyboardGrid {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.routeCard,
+.interventionCard,
+.storyboardCard,
+.claimSnapshotCard,
+.referenceCard,
+.rubricCard,
+.rubricDecisionCard,
+.dashboardCallout {
   display: grid;
-  gap: 12px;
-  padding: 18px;
-  border-radius: 22px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(230, 217, 198, 0.54));
-  border: 1px solid rgba(15, 107, 99, 0.14);
+  gap: 14px;
+  padding: 20px;
+  min-width: 0;
+  border-radius: 24px;
+  background: var(--panel-strong);
+  border: 1px solid var(--border);
 }
 
-.pathCard p {
-  margin: 0;
+.interventionCardReference {
+  background: linear-gradient(180deg, rgba(30, 114, 104, 0.12), rgba(255, 250, 243, 0.98));
 }
 
-.pathStep {
+.routeIndex {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: fit-content;
-  min-width: 44px;
-  padding: 6px 12px;
+  min-width: 48px;
+  padding: 7px 12px;
   border-radius: 999px;
-  background: rgba(15, 107, 99, 0.12);
+  background: var(--accent-soft);
   color: var(--accent-strong);
-  font-size: 0.84rem;
+  font-size: 0.82rem;
   font-weight: 700;
   letter-spacing: 0.08em;
 }
 
-.drawerLauncherGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 18px;
+.interventionCardMeta,
+.artifactChipRow,
+.deltaBadgeRow,
+.cardActions,
+.sectionSwitch,
+.claimEvidence {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
 }
 
-.comparisonOverviewGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 18px;
+.interventionCardMeta span {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent-strong);
+  font-weight: 700;
 }
 
-.scenarioGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 18px;
+.deltaBadge,
+.artifactChip,
+.pill,
+.linkPill,
+.sectionLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(30, 114, 104, 0.16);
+  background: rgba(255, 255, 255, 0.76);
+  color: var(--accent-strong);
+  font-size: 0.84rem;
+  text-decoration: none;
 }
 
-.reportGrid {
+.summaryList {
   display: grid;
-  grid-template-columns: 1.3fr 1fr;
-  gap: 18px;
+  gap: 10px;
+  margin: 0;
+  padding-left: 18px;
 }
 
-.card {
-  padding: 18px;
-  border-radius: 22px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(245, 238, 230, 0.94));
-  border: 1px solid var(--border);
+.storyboardRows {
   display: grid;
   gap: 12px;
 }
 
-.checklist {
-  margin: 0;
-  padding-left: 20px;
+.storyboardRow {
   display: grid;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 20px;
+  background: rgba(246, 239, 229, 0.82);
+  border: 1px solid rgba(30, 114, 104, 0.12);
+}
+
+.storyboardRowTop {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+}
+
+.storyboardColumns,
+.dashboardSplit,
+.reviewHeroMeta,
+.rubricGrid {
+  display: grid;
+  gap: 18px;
+}
+
+.storyboardColumns,
+.dashboardSplit {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.storyboardTurn {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(30, 114, 104, 0.08);
+}
+
+.storyboardTurn span,
+.rubricCardHeader .subtle {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent-strong);
+}
+
+.claimSnapshotCardExpanded,
+.referenceCard {
+  align-content: start;
+}
+
+.miniList,
+.subsectionBlock,
+.rubricNotes {
+  display: grid;
+  gap: 12px;
+}
+
+.miniCard {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid rgba(30, 114, 104, 0.1);
+}
+
+.reviewPage {
+  gap: 20px;
+}
+
+.reviewHero {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(246, 239, 229, 0.96)),
+    var(--panel);
+}
+
+.reviewHeroCopy,
+.reviewHeroMeta {
+  display: grid;
+  gap: 16px;
+}
+
+.reviewInterventionBoard {
+  align-items: start;
+}
+
+.sectionSwitch {
   gap: 10px;
 }
 
-.checklist.compact {
-  margin-top: 16px;
+.rubricPanel {
+  padding: 28px;
 }
 
-.artifactCard {
-  padding: 18px;
-  border-radius: 24px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(247, 240, 232, 0.96));
-  border: 1px solid var(--border);
+.rubricGrid {
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  margin-top: 8px;
+}
+
+.rubricCardHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.rubricAnchors {
   display: grid;
-  gap: 16px;
-  min-height: 100%;
+  gap: 8px;
 }
 
-.artifactCardWide {
-  min-width: 0;
+.rubricAnchors strong {
+  color: var(--ink);
+}
+
+.rubricNotes label {
+  font-weight: 700;
+}
+
+.rubricNotes textarea {
+  width: 100%;
+  border: 1px solid rgba(30, 114, 104, 0.16);
+  border-radius: 18px;
+  padding: 14px 16px;
+  min-height: 130px;
+  resize: vertical;
+  font: inherit;
+  background: rgba(255, 255, 255, 0.82);
+}
+
+.rubricDecisionCard {
+  margin-top: 18px;
+}
+
+.editorialDrawer {
+  border-radius: 24px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.72);
+  overflow: hidden;
+}
+
+.editorialDrawerSummary {
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+  padding: 18px 20px;
+}
+
+.editorialDrawerSummary::-webkit-details-marker {
+  display: none;
+}
+
+.editorialDrawerSummary div {
+  display: grid;
+  gap: 6px;
+}
+
+.editorialDrawerSummary span:last-child {
+  color: var(--muted);
+}
+
+.editorialDrawerBody {
+  padding: 0 18px 18px;
+}
+
+.editorialDrawerNote {
+  margin: 0 0 14px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  background: rgba(30, 114, 104, 0.08);
+  border: 1px solid rgba(30, 114, 104, 0.12);
+  color: var(--muted);
+  line-height: 1.65;
 }
 
 .drawerSection {
@@ -1207,15 +1553,51 @@ code {
   border: 1px solid var(--border);
 }
 
+@media (max-width: 1080px) {
+  .heroPanel {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboardSplit,
+  .storyboardColumns,
+  .reviewHeroMeta {
+    grid-template-columns: 1fr;
+  }
+
+  .briefCardWide {
+    grid-column: span 1;
+  }
+}
+
 @media (max-width: 720px) {
   body {
-    padding-inline: 14px;
+    padding: 18px 14px 42px;
+  }
+
+  .workbenchPage,
+  .reviewPage {
+    gap: 18px;
+  }
+
+  .topBar {
+    align-items: flex-start;
+  }
+
+  .topBarLinks {
+    width: 100%;
+  }
+
+  .languageSwitch {
+    align-self: flex-start;
   }
 
   .hero,
+  .heroPanel,
+  .reviewHero,
+  .dashboardSection,
   .panel {
     padding: 22px;
-    border-radius: 22px;
+    border-radius: 24px;
   }
 
   .heroMeta {
@@ -1223,11 +1605,30 @@ code {
     align-items: flex-start;
   }
 
+  h1 {
+    max-width: none;
+    font-size: clamp(2.2rem, 13vw, 3.3rem);
+  }
+
+  .briefSummaryGrid,
+  .rubricSummaryGrid,
+  .metricGrid,
+  .routeBoard,
+  .interventionBoard,
+  .storyboardGrid,
+  .claimSnapshotGrid,
   .reportGrid {
     grid-template-columns: 1fr;
   }
 
+  .storyboardColumns,
+  .dashboardSplit,
   .reviewColumns {
+    grid-template-columns: 1fr;
+  }
+
+  .reviewHeroMeta,
+  .rubricGrid {
     grid-template-columns: 1fr;
   }
 
@@ -1237,5 +1638,29 @@ code {
 
   .payloadPreviewGrid {
     grid-template-columns: 1fr;
+  }
+
+  .storyboardCard,
+  .storyboardRow,
+  .interventionCard,
+  .claimSnapshotCard,
+  .referenceCard,
+  .rubricCard,
+  .dashboardCallout {
+    padding: 18px;
+    border-radius: 20px;
+  }
+
+  .editorialDrawerSummary {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .editorialDrawerBody {
+    padding: 0 14px 14px;
+  }
+
+  .artifactPreCompact {
+    max-height: 320px;
   }
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,16 +1,43 @@
 import "./globals.css";
+
+import { Fraunces, IBM_Plex_Mono, IBM_Plex_Sans } from "next/font/google";
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
+import { getAppLocale } from "./lib/locale";
+
+const displayFont = Fraunces({
+  subsets: ["latin"],
+  variable: "--font-display",
+  weight: ["500", "600", "700"]
+});
+
+const uiFont = IBM_Plex_Sans({
+  subsets: ["latin"],
+  variable: "--font-ui",
+  weight: ["400", "500", "600", "700"]
+});
+
+const monoFont = IBM_Plex_Mono({
+  subsets: ["latin"],
+  variable: "--font-mono",
+  weight: ["400", "500", "600"]
+});
+
 export const metadata: Metadata = {
-  title: "Mirror Workbench",
-  description: "Review workbench for constrained, evidence-backed scenario comparison in Mirror."
+  title: "Mirror Workbench | Mirror 工作台",
+  description:
+    "Bilingual editorial workbench for constrained, evidence-backed scenario comparison in Mirror."
 };
 
-export default function RootLayout({ children }: { children: ReactNode }) {
+export default async function RootLayout({ children }: { children: ReactNode }) {
+  const locale = await getAppLocale();
+
   return (
-    <html lang="en">
-      <body>{children}</body>
+    <html lang={locale}>
+      <body className={`${displayFont.variable} ${uiFont.variable} ${monoFont.variable}`}>
+        {children}
+      </body>
     </html>
   );
 }

--- a/frontend/src/app/lib/copy.ts
+++ b/frontend/src/app/lib/copy.ts
@@ -1,0 +1,434 @@
+import type { AppLocale } from "./locale-shared";
+
+type Copy = {
+  brand: {
+    eyebrow: string;
+    worldLabel: string;
+    compareArtifactLabel: string;
+    sourceArtifactLabel: string;
+    dashboardLabel: string;
+    reviewLabel: string;
+    legacyLabel: string;
+  };
+  dashboard: {
+    title: string;
+    lede: string;
+    currentPair: string;
+    loadedBranches: string;
+    interventionCount: string;
+    jumpToReview: string;
+    jumpToReference: string;
+    routeEyebrow: string;
+    routeTitle: string;
+    routeSummary: string;
+    interventionEyebrow: string;
+    interventionTitle: string;
+    interventionSummary: string;
+    storyboardEyebrow: string;
+    storyboardTitle: string;
+    claimEyebrow: string;
+    claimTitle: string;
+    evalEyebrow: string;
+    evalTitle: string;
+    scorecardNote: string;
+    openReview: string;
+    openTrace: string;
+    openClaims: string;
+    openReference: string;
+  };
+  routeSteps: Array<{
+    step: string;
+    title: string;
+    summary: string;
+  }>;
+  metrics: {
+    scenarioBranches: string;
+    interventionBranches: string;
+    delayedLedger: string;
+    delayedEvacuation: string;
+    routeOnly: string;
+    knowledgeShift: string;
+    budgetExposed: string;
+    ledgerPublic: string;
+    evacuation: string;
+    divergentTurns: string;
+    evidenceLinkedClaims: string;
+    evalStatus: string;
+  };
+  review: {
+    title: string;
+    lede: string;
+    backToDashboard: string;
+    stripTitle: string;
+    sectionNav: {
+      scorecard: string;
+      traceClaims: string;
+      reference: string;
+      advanced: string;
+    };
+    scorecardTitle: string;
+    scorecardSummary: string;
+    traceTitle: string;
+    traceSummary: string;
+    claimsTitle: string;
+    claimsSummary: string;
+    referenceTitle: string;
+    referenceSummary: string;
+    advancedTitle: string;
+    advancedSummary: string;
+    legacyOperationsTitle: string;
+    legacyOperationsSummary: string;
+    legacyOperationsDisclosure: string;
+    rawReportTitle: string;
+    rawReportSummary: string;
+    documentTitle: string;
+    graphTitle: string;
+    scenariosTitle: string;
+    openSourceArtifact: string;
+    noDivergence: string;
+    noTarget: string;
+  };
+  rubric: {
+    title: string;
+    helper: string;
+    notesLabel: string;
+    notesPlaceholder: string;
+    dimensionsComplete: string;
+    evidenceTracked: string;
+    divergentTurns: string;
+    evalPosture: string;
+    recommendationLabel: string;
+    recommendationReady: string;
+    recommendationFollowup: string;
+    recommendationHold: string;
+    recommendationIncomplete: string;
+    openLegacy: string;
+    scoreLegend: string;
+    averageLabel: string;
+  };
+  common: {
+    referenceBranch: string;
+    routeOnlyDelta: string;
+    timingDrift: string;
+    knowledgeShift: string;
+    baseline: string;
+    candidate: string;
+    rawArtifact: string;
+    jumpToReview: string;
+    jumpToTrace: string;
+    jumpToClaims: string;
+    jumpToEvidence: string;
+    jumpToEval: string;
+  };
+};
+
+const englishCopy: Copy = {
+  brand: {
+    eyebrow: "Mirror Engine / Editorial Briefing Workbench",
+    worldLabel: "Current world",
+    compareArtifactLabel: "Compare artifact",
+    sourceArtifactLabel: "Source artifact",
+    dashboardLabel: "Dashboard",
+    reviewLabel: "Deep review",
+    legacyLabel: "Legacy operations"
+  },
+  dashboard: {
+    title: "Read the outcome first, then decide where deeper review is actually worth your attention.",
+    lede:
+      "This dashboard turns the canonical compare artifact into an editorial briefing: what changed, what only drifted in route, which evidence path matters, and when to open the heavier review workspace.",
+    currentPair: "Current report pair",
+    loadedBranches: "canonical scenario branches",
+    interventionCount: "intervention comparisons against baseline",
+    jumpToReview: "Open deep review",
+    jumpToReference: "Open reference surfaces",
+    routeEyebrow: "Default path",
+    routeTitle: "Move through compare, trace, evidence, and eval before opening heavier review machinery.",
+    routeSummary:
+      "The homepage now behaves like a briefing board, not a dump. It should tell you what changed, why it matters, and where to inspect next without forcing the whole workbench on first read.",
+    interventionEyebrow: "Intervention board",
+    interventionTitle: "Each intervention gets a strong summary card: impact first, drill-down second.",
+    interventionSummary:
+      "The cards below emphasize outcome shifts, route-only drift, and where to jump next instead of repeating full artifact payloads.",
+    storyboardEyebrow: "Trace storyboard",
+    storyboardTitle: "Preview only the turns that actually diverge.",
+    claimEyebrow: "Claims and eval",
+    claimTitle: "Keep the evidence-linked claims and integrity posture readable at a glance.",
+    evalEyebrow: "Review handoff",
+    evalTitle: "Use the dashboard to decide whether you should continue into deep review or stop at the current briefing.",
+    scorecardNote:
+      "The full review scorecard, routing logic, and historical heavy surfaces still exist, but they now live behind the deep review workspace.",
+    openReview: "Open review workspace",
+    openTrace: "Open trace",
+    openClaims: "Open claims",
+    openReference: "Open reference"
+  },
+  routeSteps: [
+    {
+      step: "01",
+      title: "Scan intervention impact",
+      summary: "See which branch changes the outcome and which only changes the route."
+    },
+    {
+      step: "02",
+      title: "Replay divergent turns",
+      summary: "Open the short storyboard before reading the full branch timeline."
+    },
+    {
+      step: "03",
+      title: "Check claims and evidence",
+      summary: "Confirm which claims are grounded and which turns or chunks they depend on."
+    },
+    {
+      step: "04",
+      title: "Confirm eval posture",
+      summary: "Use eval as the integrity gate before moving into deeper review."
+    }
+  ],
+  metrics: {
+    scenarioBranches: "Scenario branches",
+    interventionBranches: "Intervention branches",
+    delayedLedger: "Delayed ledger branches",
+    delayedEvacuation: "Delayed evacuation branches",
+    routeOnly: "Route-only branches",
+    knowledgeShift: "Knowledge-shift branches",
+    budgetExposed: "Budget exposed",
+    ledgerPublic: "Ledger public",
+    evacuation: "Evacuation",
+    divergentTurns: "Divergent turns",
+    evidenceLinkedClaims: "Evidence-linked claims",
+    evalStatus: "Eval posture"
+  },
+  review: {
+    title: "Deep review keeps the scorecard front and center, then lets trace, claims, reference, and advanced operations stack behind it.",
+    lede:
+      "This view is the operator workspace. Start with the scorecard, then move into trace and claims, consult references only when needed, and keep the legacy heavy tooling behind an explicit advanced boundary.",
+    backToDashboard: "Back to dashboard",
+    stripTitle: "Review strip",
+    sectionNav: {
+      scorecard: "Scorecard",
+      traceClaims: "Trace & Claims",
+      reference: "Reference",
+      advanced: "Advanced Operations"
+    },
+    scorecardTitle: "Score the branch before you get lost in tooling.",
+    scorecardSummary:
+      "The review scorecard is now the primary deep-review surface. It summarizes confidence, weak dimensions, and whether the current branch is ready for deeper escalation or still needs evidence cleanup.",
+    traceTitle: "Trace and claims",
+    traceSummary:
+      "Use these sections to connect divergent turns to the evidence-linked claims without reopening the entire raw branch history.",
+    claimsTitle: "Claim drill-down",
+    claimsSummary:
+      "Claims stay evidence-linked and traceable. Each card shows the supporting chunks and the related turn chain.",
+    referenceTitle: "Reference surfaces",
+    referenceSummary:
+      "These panels keep scenarios, graph context, documents, and the raw report reachable without letting them dominate the first read.",
+    advancedTitle: "Advanced operations",
+    advancedSummary:
+      "Heavy historical packet, delivery, and legacy operational surfaces remain available, but they are explicitly secondary to the review path.",
+    legacyOperationsTitle: "Legacy operations workspace",
+    legacyOperationsSummary:
+      "Use this only when you need the older packet-heavy review tooling. It remains available, but no longer defines the page.",
+    legacyOperationsDisclosure: "Open legacy operations",
+    rawReportTitle: "Raw report artifact",
+    rawReportSummary:
+      "This panel shows the original artifact content. The UI around it is bilingual, but the artifact body itself stays source-authentic.",
+    documentTitle: "Source documents",
+    graphTitle: "Graph snapshot",
+    scenariosTitle: "Scenario cards",
+    openSourceArtifact: "Open source artifact",
+    noDivergence: "No divergent turns are recorded for this branch.",
+    noTarget: "No explicit target"
+  },
+  rubric: {
+    title: "Review scorecard",
+    helper:
+      "Score the current branch across usefulness, credibility, explainability, and actionability before expanding heavier operations.",
+    notesLabel: "Reviewer notes",
+    notesPlaceholder: "Capture what still feels weak, what looks credible, and what should happen next.",
+    dimensionsComplete: "Dimensions scored",
+    evidenceTracked: "Evidence-linked claims",
+    divergentTurns: "Divergent turns",
+    evalPosture: "Eval posture",
+    recommendationLabel: "Recommendation",
+    recommendationReady:
+      "This branch reads as strong enough to continue with deeper review or controlled sign-off.",
+    recommendationFollowup:
+      "This branch is usable, but at least one dimension still needs focused follow-up before a strong handoff.",
+    recommendationHold:
+      "Hold the branch here and revise the weakest dimensions before escalating further.",
+    recommendationIncomplete: "Complete the scorecard before making a review recommendation.",
+    openLegacy: "Open legacy operations workspace",
+    scoreLegend: "Low confidence -> high confidence",
+    averageLabel: "Average"
+  },
+  common: {
+    referenceBranch: "Reference branch",
+    routeOnlyDelta: "Route-only delta",
+    timingDrift: "Timing drift",
+    knowledgeShift: "Knowledge shift",
+    baseline: "Baseline",
+    candidate: "Candidate",
+    rawArtifact: "Raw artifact",
+    jumpToReview: "Jump to review",
+    jumpToTrace: "Trace",
+    jumpToClaims: "Claims",
+    jumpToEvidence: "Evidence",
+    jumpToEval: "Eval"
+  }
+};
+
+const chineseCopy: Copy = {
+  brand: {
+    eyebrow: "Mirror Engine / 编辑部指挥台工作区",
+    worldLabel: "当前世界",
+    compareArtifactLabel: "Compare 产物",
+    sourceArtifactLabel: "原始产物",
+    dashboardLabel: "总览台",
+    reviewLabel: "深度审阅",
+    legacyLabel: "历史操作面"
+  },
+  dashboard: {
+    title: "先读结果，再判断哪里值得继续深挖。",
+    lede:
+      "这个首页把 canonical compare artifact 组织成一块编辑部 briefing board：哪条干预改变了结果，哪条只是改变了路径，证据链该从哪里看起，以及什么时候才值得打开更重的审阅工作区。",
+    currentPair: "当前报告对比",
+    loadedBranches: "canonical 场景分支",
+    interventionCount: "相对 baseline 的干预对比",
+    jumpToReview: "进入深度审阅",
+    jumpToReference: "打开参考面板",
+    routeEyebrow: "默认路径",
+    routeTitle: "先走 compare、trace、evidence、eval，再决定是否进入更重的审阅机制。",
+    routeSummary:
+      "首页现在应该像一块 briefing board，而不是一页 dump。它先告诉你发生了什么、为什么重要、下一步该看哪里。",
+    interventionEyebrow: "干预摘要板",
+    interventionTitle: "每条 intervention 都先给出强摘要卡，再给 drill-down。",
+    interventionSummary:
+      "下面的卡片优先强调结果变化、纯路径漂移，以及下一步查看入口，而不是重复整块 artifact 内容。",
+    storyboardEyebrow: "Trace 分镜",
+    storyboardTitle: "只预览真正发生分歧的 turn。",
+    claimEyebrow: "Claims 与 Eval",
+    claimTitle: "让 evidence-linked claims 和完整性状态可以一眼扫读。",
+    evalEyebrow: "审阅交接",
+    evalTitle: "用首页先判断是否需要继续进入深度审阅，而不是默认把整套重型工具全部打开。",
+    scorecardNote:
+      "完整的 review scorecard、routing 逻辑和历史重型 surface 依然保留，但它们现在统一收进深度审阅工作区。",
+    openReview: "进入审阅工作区",
+    openTrace: "查看 trace",
+    openClaims: "查看 claims",
+    openReference: "查看参考"
+  },
+  routeSteps: [
+    {
+      step: "01",
+      title: "扫描干预影响",
+      summary: "先看哪条分支真正改变了结果，哪条只是改变了路线。"
+    },
+    {
+      step: "02",
+      title: "回放分歧 turn",
+      summary: "先看短分镜，再决定是否需要打开完整分支时间线。"
+    },
+    {
+      step: "03",
+      title: "核对 claims 与证据",
+      summary: "确认哪些 claim 是被证据支撑的，以及它们依赖哪些 turn 或 chunk。"
+    },
+    {
+      step: "04",
+      title: "确认 eval 状态",
+      summary: "把 eval 当作完整性门槛，再决定是否继续更深的审阅。"
+    }
+  ],
+  metrics: {
+    scenarioBranches: "场景分支数",
+    interventionBranches: "干预分支数",
+    delayedLedger: "账本延后分支",
+    delayedEvacuation: "疏散延后分支",
+    routeOnly: "纯路径变化分支",
+    knowledgeShift: "知识扩散变化分支",
+    budgetExposed: "预算曝光",
+    ledgerPublic: "账本公开",
+    evacuation: "疏散触发",
+    divergentTurns: "分歧 turns",
+    evidenceLinkedClaims: "证据关联 claims",
+    evalStatus: "Eval 状态"
+  },
+  review: {
+    title: "深度审阅把 scorecard 放在最前面，trace、claims、reference 和 advanced operations 都退到它之后。",
+    lede:
+      "这里是操作员工作区。先完成 scorecard，再看 trace 与 claims；只有在需要时才进入 reference，并把历史重型 tooling 放在明确的 advanced 边界之后。",
+    backToDashboard: "返回总览台",
+    stripTitle: "审阅摘要条",
+    sectionNav: {
+      scorecard: "评分卡",
+      traceClaims: "Trace 与 Claims",
+      reference: "参考面板",
+      advanced: "高级操作"
+    },
+    scorecardTitle: "先给当前分支打分，再决定是否值得掉进重型工具。",
+    scorecardSummary:
+      "评分卡现在是深度审阅的主入口。它先总结可信度、薄弱维度，以及当前分支是否值得继续升级审阅，还是先补证据。",
+    traceTitle: "Trace 与 Claims",
+    traceSummary:
+      "用这里把分歧 turns 与 evidence-linked claims 连起来，而不是一上来就重新打开整条原始 branch 历史。",
+    claimsTitle: "Claim drill-down",
+    claimsSummary:
+      "Claims 继续保持 evidence-linked 和可追踪。每张卡片都展示支撑它的 chunks 和相关 turns。",
+    referenceTitle: "参考面板",
+    referenceSummary:
+      "这些面板让 scenarios、graph、documents 和原始 report 都可达，但不会再主导首读体验。",
+    advancedTitle: "高级操作",
+    advancedSummary:
+      "历史上的 packet、delivery 和重型操作 surface 继续保留，但它们明确退居为次级路径。",
+    legacyOperationsTitle: "历史操作工作区",
+    legacyOperationsSummary:
+      "只有当你确实需要旧的 packet-heavy review tooling 时才打开这里。它仍然可用，但不再定义整个页面。",
+    legacyOperationsDisclosure: "打开历史操作面",
+    rawReportTitle: "原始报告产物",
+    rawReportSummary:
+      "这个面板展示原始 artifact 内容。外围 UI 是双语的，但 artifact 正文本体保持源内容原样。",
+    documentTitle: "源文档",
+    graphTitle: "图谱快照",
+    scenariosTitle: "场景卡片",
+    openSourceArtifact: "打开原始产物",
+    noDivergence: "这个分支没有记录到分歧 turn。",
+    noTarget: "没有显式 target"
+  },
+  rubric: {
+    title: "审阅评分卡",
+    helper:
+      "在展开更重的操作面之前，先从 usefulness、credibility、explainability 和 actionability 四个维度为当前分支打分。",
+    notesLabel: "审阅备注",
+    notesPlaceholder: "记录哪里还薄弱、哪里已经可信，以及下一步应该怎么推进。",
+    dimensionsComplete: "已评分维度",
+    evidenceTracked: "证据关联 claims",
+    divergentTurns: "分歧 turns",
+    evalPosture: "Eval 状态",
+    recommendationLabel: "当前建议",
+    recommendationReady: "这个分支已经足够稳，可以继续进入更深审阅或受控 sign-off。",
+    recommendationFollowup: "这个分支可以继续，但至少还有一个维度需要补强后再做强交接。",
+    recommendationHold: "先停在这里，补齐最弱维度后再继续升级。",
+    recommendationIncomplete: "先完成评分卡，再给出审阅建议。",
+    openLegacy: "打开历史操作工作区",
+    scoreLegend: "低信心 -> 高信心",
+    averageLabel: "平均分"
+  },
+  common: {
+    referenceBranch: "参考分支",
+    routeOnlyDelta: "仅路径变化",
+    timingDrift: "时间漂移",
+    knowledgeShift: "知识扩散变化",
+    baseline: "Baseline",
+    candidate: "Candidate",
+    rawArtifact: "原始产物",
+    jumpToReview: "跳到审阅",
+    jumpToTrace: "Trace",
+    jumpToClaims: "Claims",
+    jumpToEvidence: "证据",
+    jumpToEval: "Eval"
+  }
+};
+
+export function getCopy(locale: AppLocale): Copy {
+  return locale === "zh-CN" ? chineseCopy : englishCopy;
+}

--- a/frontend/src/app/lib/locale-shared.ts
+++ b/frontend/src/app/lib/locale-shared.ts
@@ -1,0 +1,17 @@
+export const MIRROR_LANG_COOKIE = "mirror-lang";
+export type AppLocale = "en" | "zh-CN";
+
+export function normalizeLocale(value: string | undefined | null): AppLocale | null {
+  if (!value) {
+    return null;
+  }
+
+  const lowered = value.toLowerCase();
+  if (lowered === "en") {
+    return "en";
+  }
+  if (lowered === "zh-cn" || lowered.startsWith("zh")) {
+    return "zh-CN";
+  }
+  return null;
+}

--- a/frontend/src/app/lib/locale.ts
+++ b/frontend/src/app/lib/locale.ts
@@ -1,0 +1,19 @@
+import { cookies, headers } from "next/headers";
+
+import { normalizeLocale, type AppLocale } from "./locale-shared";
+
+export async function getAppLocale(): Promise<AppLocale> {
+  const cookieStore = await cookies();
+  const cookieLocale = normalizeLocale(cookieStore.get("mirror-lang")?.value);
+  if (cookieLocale) {
+    return cookieLocale;
+  }
+
+  const headerStore = await headers();
+  const accepted = headerStore.get("accept-language");
+  return normalizeLocale(accepted) ?? "en";
+}
+
+export function isChineseLocale(locale: AppLocale) {
+  return locale === "zh-CN";
+}

--- a/frontend/src/app/lib/presenters.ts
+++ b/frontend/src/app/lib/presenters.ts
@@ -1,0 +1,136 @@
+import type { ComparisonOverview, CompareOutcomeDelta } from "./workbench-data";
+import type { AppLocale } from "./locale-shared";
+
+function formatTurnLabel(locale: AppLocale, turn: number | null | undefined) {
+  if (typeof turn !== "number") {
+    return locale === "zh-CN" ? "未触发" : "Not reached";
+  }
+  return `T${turn}`;
+}
+
+export function formatDeltaLabel(locale: AppLocale, delta: number | null) {
+  if (delta === null) {
+    return locale === "zh-CN" ? "n/a" : "n/a";
+  }
+  if (delta === 0) {
+    return locale === "zh-CN" ? "0 回合" : "0 turns";
+  }
+  const prefix = delta > 0 ? "+" : "-";
+  return locale === "zh-CN"
+    ? `${prefix}${Math.abs(delta)} 回合`
+    : `${prefix}${Math.abs(delta)} turn${Math.abs(delta) === 1 ? "" : "s"}`;
+}
+
+function summarizeTurnOutcome(
+  locale: AppLocale,
+  label: string,
+  outcome: CompareOutcomeDelta | undefined
+) {
+  if (!outcome) {
+    return locale === "zh-CN"
+      ? `${label} 未在 compare 产物中记录。`
+      : `${label} is not recorded in the compare artifact.`;
+  }
+
+  const referenceTurn = typeof outcome.reference === "number" ? outcome.reference : undefined;
+  const candidateTurn = typeof outcome.candidate === "number" ? outcome.candidate : undefined;
+
+  if (referenceTurn === undefined && candidateTurn === undefined) {
+    return locale === "zh-CN"
+      ? `${label} 在两个分支中都没有发生。`
+      : `${label} is not reached in either branch.`;
+  }
+
+  if (referenceTurn !== undefined && candidateTurn === undefined) {
+    return locale === "zh-CN"
+      ? `${label} 在这个分支中没有发生。`
+      : `${label} never lands in this branch.`;
+  }
+
+  if (referenceTurn === undefined && candidateTurn !== undefined) {
+    return locale === "zh-CN"
+      ? `${label} 只在这个分支里于 ${formatTurnLabel(locale, candidateTurn)} 出现。`
+      : `${label} appears only in this branch at ${formatTurnLabel(locale, candidateTurn)}.`;
+  }
+
+  const resolvedReferenceTurn = referenceTurn as number;
+  const resolvedCandidateTurn = candidateTurn as number;
+  const delta =
+    typeof outcome.delta === "number" ? outcome.delta : resolvedCandidateTurn - resolvedReferenceTurn;
+
+  if (delta > 0) {
+    return locale === "zh-CN"
+      ? `${label} 延后 ${delta} 回合，到 ${formatTurnLabel(locale, resolvedCandidateTurn)}。`
+      : `${label} slips by ${delta} turn${delta === 1 ? "" : "s"} to ${formatTurnLabel(locale, resolvedCandidateTurn)}.`;
+  }
+
+  if (delta < 0) {
+    return locale === "zh-CN"
+      ? `${label} 提前 ${Math.abs(delta)} 回合，到 ${formatTurnLabel(locale, resolvedCandidateTurn)}。`
+      : `${label} lands ${Math.abs(delta)} turn${Math.abs(delta) === 1 ? "" : "s"} earlier at ${formatTurnLabel(locale, resolvedCandidateTurn)}.`;
+  }
+
+  return locale === "zh-CN"
+    ? `${label} 与 baseline 保持同一时间点 ${formatTurnLabel(locale, resolvedCandidateTurn)}。`
+    : `${label} stays on the baseline timing at ${formatTurnLabel(locale, resolvedCandidateTurn)}.`;
+}
+
+export function summarizeRiskShift(locale: AppLocale, outcome: CompareOutcomeDelta | undefined) {
+  if (!outcome) {
+    return locale === "zh-CN"
+      ? "compare 产物没有记录这条分支的风险扩散变化。"
+      : "The compare artifact does not record any risk-awareness delta for this branch.";
+  }
+
+  const referenceActors = Array.isArray(outcome.reference)
+    ? outcome.reference.filter((item): item is string => typeof item === "string")
+    : [];
+  const candidateActors = Array.isArray(outcome.candidate)
+    ? outcome.candidate.filter((item): item is string => typeof item === "string")
+    : [];
+
+  const removed = referenceActors.filter((actorId) => !candidateActors.includes(actorId));
+  const added = candidateActors.filter((actorId) => !referenceActors.includes(actorId));
+
+  if (removed.length === 0 && added.length === 0) {
+    return locale === "zh-CN"
+      ? "风险认知到达的 actor 集合与 baseline 一致。"
+      : "Risk awareness reaches the same actor set as baseline.";
+  }
+
+  if (removed.length > 0 && added.length === 0) {
+    return locale === "zh-CN"
+      ? `风险认知不再到达 ${removed.join(", ")}。`
+      : `Risk awareness no longer reaches ${removed.join(", ")} in this branch.`;
+  }
+
+  if (added.length > 0 && removed.length === 0) {
+    return locale === "zh-CN"
+      ? `风险认知扩展到了 ${added.join(", ")}。`
+      : `Risk awareness expands to ${added.join(", ")} in this branch.`;
+  }
+
+  return locale === "zh-CN"
+    ? `风险认知路径发生改道：移除 ${removed.join(", ")}，新增 ${added.join(", ")}。`
+    : `Risk awareness reroutes: removed ${removed.join(", ")}; added ${added.join(", ")}.`;
+}
+
+export function buildOverviewLines(locale: AppLocale, overview: ComparisonOverview) {
+  return [
+    summarizeTurnOutcome(locale, locale === "zh-CN" ? "预算曝光" : "Budget exposure", overview.delta.outcome_deltas.budget_exposed_turn),
+    summarizeTurnOutcome(locale, locale === "zh-CN" ? "账本公开" : "Ledger publication", overview.delta.outcome_deltas.ledger_public_turn),
+    summarizeTurnOutcome(locale, locale === "zh-CN" ? "疏散触发" : "Evacuation", overview.delta.outcome_deltas.evacuation_turn),
+    summarizeRiskShift(locale, overview.delta.outcome_deltas.risk_known_by)
+  ];
+}
+
+export function friendlyWorldName(locale: AppLocale, worldId: string | undefined) {
+  if (worldId === "fog-harbor-east-gate") {
+    return locale === "zh-CN" ? "雾港东闸危机" : "Fog Harbor East Gate";
+  }
+  return worldId ?? (locale === "zh-CN" ? "未知世界" : "Unknown world");
+}
+
+export function formatTurn(locale: AppLocale, turn: number | null | undefined) {
+  return formatTurnLabel(locale, turn);
+}

--- a/frontend/src/app/lib/workbench-data.ts
+++ b/frontend/src/app/lib/workbench-data.ts
@@ -1,0 +1,551 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const repoRoot = path.resolve(process.cwd(), "..");
+export const compareArtifactPath = "artifacts/demo/compare/scenario_fog_harbor_phase44_matrix/compare.json";
+
+export type Claim = {
+  claim_id: string;
+  text: string;
+  label: string;
+  evidence_ids: string[];
+  related_turn_ids: string[];
+  confidence_note: string;
+};
+
+export type EvalSummary = {
+  eval_name: string;
+  world_id?: string;
+  status: string;
+  metrics: Record<string, number>;
+  failures: string[];
+  notes: string[];
+};
+
+export type DocumentRow = {
+  document_id: string;
+  title: string;
+  kind: string;
+  metadata?: Record<string, string>;
+};
+
+export type ChunkRow = {
+  chunk_id: string;
+  document_id: string;
+  text: string;
+  char_start: number;
+  char_end: number;
+  source_id: string;
+};
+
+export type GraphEntity = {
+  entity_id: string;
+  name: string;
+  type: string;
+  evidence_ids: string[];
+};
+
+export type GraphRelation = {
+  relation_id: string;
+  source_entity_id: string;
+  relation_type: string;
+  target_entity_id: string;
+  evidence_ids: string[];
+};
+
+export type GraphEvent = {
+  event_id: string;
+  name: string;
+  kind: string;
+  participant_entity_ids: string[];
+  evidence_ids: string[];
+};
+
+export type GraphPayload = {
+  world_id?: string;
+  entities: GraphEntity[];
+  relations: GraphRelation[];
+  events: GraphEvent[];
+  stats: Record<string, number>;
+};
+
+export type ScenarioPayload = {
+  scenario_id: string;
+  world_id?: string;
+  title: string;
+  description: string;
+  branch_count: number;
+  turn_budget: number;
+  injections: Array<{
+    injection_id: string;
+    kind: string;
+    target_id: string;
+    actor_id: string;
+  }>;
+};
+
+export type TurnAction = {
+  turn_id: string;
+  run_id: string;
+  turn_index: number;
+  actor_id: string;
+  action_type: string;
+  target_id: string | null;
+  rationale: string;
+  evidence_ids: string[];
+  state_patch: Record<string, unknown>;
+};
+
+export type SnapshotPayload = {
+  turn_index: number;
+  state: Record<string, unknown>;
+};
+
+export type RunSummary = {
+  run_id: string;
+  scenario_id: string;
+  seed: number;
+  turn_budget: number;
+  executed_turns: number;
+  ledger_public_turn?: number;
+  budget_exposed_turn?: number;
+  evacuation_turn?: number;
+  final_state: Record<string, unknown>;
+  action_count: number;
+  action_types: string[];
+  notes: string[];
+};
+
+export type CompareBranch = {
+  branch_id: string;
+  label: string;
+  run_id: string;
+  is_reference: boolean;
+  summary_path: string;
+  trace_path: string;
+  snapshot_dir: string;
+};
+
+export type CompareOutcomeDelta = {
+  reference: unknown;
+  candidate: unknown;
+  delta: unknown;
+};
+
+export type CompareTurnDelta = {
+  turn_index: number;
+  reference_turn_id: string | null;
+  candidate_turn_id: string | null;
+};
+
+export type CompareBranchDelta = {
+  branch_id: string;
+  divergent_turn_count: number;
+  divergent_turns: CompareTurnDelta[];
+  outcome_deltas: Record<string, CompareOutcomeDelta>;
+};
+
+export type CompareArtifact = {
+  compare_id: string;
+  scenario_id: string;
+  seed: number;
+  branch_count: number;
+  reference_branch_id: string;
+  branches: CompareBranch[];
+  reference_deltas: CompareBranchDelta[];
+};
+
+export type RubricRow = {
+  dimension: string;
+  one: string;
+  three: string;
+  five: string;
+};
+
+export type RunPayload = {
+  key: string;
+  label: string;
+  branch: CompareBranch;
+  scenario: ScenarioPayload;
+  summary: RunSummary;
+  actions: TurnAction[];
+  snapshots: SnapshotPayload[];
+};
+
+export type TurnEntry = {
+  scenarioKey: string;
+  scenarioTitle: string;
+  scenarioDescription: string;
+  turn: TurnAction;
+  snapshot: SnapshotPayload | null;
+};
+
+export type ComparisonRow = {
+  turnIndex: number;
+  reference: TurnEntry | null;
+  candidate: TurnEntry | null;
+};
+
+export type ComparisonOverview = {
+  run: RunPayload;
+  delta: CompareBranchDelta;
+  rows: ComparisonRow[];
+  divergentTurnCount: number;
+  budgetExposureDelta: number | null;
+  ledgerDelta: number | null;
+  evacuationDelta: number | null;
+  routeOnly: boolean;
+  knowledgeShift: boolean;
+  summaryLines: string[];
+};
+
+export type ClaimDrilldown = {
+  claim: Claim;
+  evidenceChunks: Array<{
+    chunk: ChunkRow;
+    document: DocumentRow | null;
+  }>;
+  relatedTurns: TurnEntry[];
+};
+
+export type WorkbenchData = {
+  report: string;
+  claims: Claim[];
+  evalSummary: EvalSummary;
+  rubric: string;
+  rubricRows: RubricRow[];
+  documents: DocumentRow[];
+  chunks: ChunkRow[];
+  graph: GraphPayload;
+  compareArtifact: CompareArtifact;
+  runs: RunPayload[];
+  baselineRun: RunPayload;
+  comparisonRuns: RunPayload[];
+  comparisonOverviews: ComparisonOverview[];
+  reportComparison: ComparisonOverview | null;
+  reportComparisonRun: RunPayload;
+  routeOnlyCount: number;
+  delayedEvacuationCount: number;
+  delayedLedgerCount: number;
+  knowledgeShiftCount: number;
+  totalDivergentTurnCount: number;
+  claimDrilldowns: ClaimDrilldown[];
+};
+
+async function readText(relativePath: string) {
+  return readFile(path.join(repoRoot, relativePath), "utf-8");
+}
+
+async function readJson<T>(relativePath: string) {
+  return JSON.parse(await readText(relativePath)) as T;
+}
+
+async function readJsonl<T>(relativePath: string) {
+  return (await readText(relativePath))
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as T);
+}
+
+function parseRubricRows(rubric: string): RubricRow[] {
+  const rows = rubric
+    .split("\n")
+    .filter((line) => line.startsWith("|"))
+    .slice(2)
+    .map((line) => line.split("|").map((cell) => cell.trim()).filter(Boolean))
+    .filter((cells) => cells.length >= 4)
+    .map(([dimension, one, three, five]) => ({ dimension, one, three, five }));
+
+  if (rows.length > 0) {
+    return rows;
+  }
+
+  return [
+    {
+      dimension: "Usefulness",
+      one: "Adds no new understanding",
+      three: "Some useful contrast",
+      five: "Clearly clarifies branch differences"
+    },
+    {
+      dimension: "Credibility",
+      one: "Reads like guesswork",
+      three: "Partly grounded",
+      five: "Evidence boundaries are clear"
+    },
+    {
+      dimension: "Explainability",
+      one: "Hard to trace",
+      three: "Mostly understandable",
+      five: "Easy to replay from trace"
+    },
+    {
+      dimension: "Actionability",
+      one: "No next step is obvious",
+      three: "Some follow-up hints",
+      five: "Clear next engineering/product step"
+    }
+  ];
+}
+
+function runKeyFromSummaryPath(summaryPath: string) {
+  return path.basename(path.dirname(summaryPath));
+}
+
+async function loadSnapshots(snapshotDir: string, turnBudget: number) {
+  return Promise.all(
+    Array.from({ length: turnBudget }, (_, index) =>
+      readJson<SnapshotPayload>(
+        `artifacts/demo/${snapshotDir}/turn-${String(index + 1).padStart(2, "0")}.json`
+      )
+    )
+  );
+}
+
+async function loadRunPayload(branch: CompareBranch): Promise<RunPayload> {
+  const key = runKeyFromSummaryPath(branch.summary_path);
+  const scenario = await readJson<ScenarioPayload>(`artifacts/demo/scenario/${key}.json`);
+  const [summary, actions, snapshots] = await Promise.all([
+    readJson<RunSummary>(`artifacts/demo/${branch.summary_path}`),
+    readJsonl<TurnAction>(`artifacts/demo/${branch.trace_path}`),
+    loadSnapshots(branch.snapshot_dir, scenario.turn_budget)
+  ]);
+
+  return {
+    key,
+    label: branch.label,
+    branch,
+    scenario,
+    summary,
+    actions,
+    snapshots
+  };
+}
+
+function buildTurnEntries(run: RunPayload): TurnEntry[] {
+  return run.actions.map((turn, index) => ({
+    scenarioKey: run.key,
+    scenarioTitle: run.scenario.title,
+    scenarioDescription: run.scenario.description,
+    turn,
+    snapshot: run.snapshots[index] ?? null
+  }));
+}
+
+function valuesMatch(left: unknown, right: unknown) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function numericOutcomeDelta(outcomes: Record<string, CompareOutcomeDelta>, key: string) {
+  const delta = outcomes[key]?.delta;
+  return typeof delta === "number" ? delta : null;
+}
+
+function stringArray(value: unknown) {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function outcomeChanged(outcome: CompareOutcomeDelta | undefined) {
+  if (!outcome) {
+    return false;
+  }
+
+  if (typeof outcome.delta === "number") {
+    return outcome.delta !== 0;
+  }
+
+  return !valuesMatch(outcome.reference, outcome.candidate);
+}
+
+function describeTurnOutcome(label: string, outcome: CompareOutcomeDelta | undefined) {
+  if (!outcome) {
+    return `${label} is not recorded in the compare artifact.`;
+  }
+
+  const referenceTurn = typeof outcome.reference === "number" ? outcome.reference : undefined;
+  const candidateTurn = typeof outcome.candidate === "number" ? outcome.candidate : undefined;
+
+  if (referenceTurn === undefined && candidateTurn === undefined) {
+    return `${label} is not reached in either branch.`;
+  }
+
+  if (referenceTurn !== undefined && candidateTurn === undefined) {
+    return `${label} never lands in this branch.`;
+  }
+
+  if (referenceTurn === undefined && candidateTurn !== undefined) {
+    return `${label} appears only in this branch at T${candidateTurn}.`;
+  }
+
+  const resolvedReferenceTurn = referenceTurn as number;
+  const resolvedCandidateTurn = candidateTurn as number;
+  const delta =
+    typeof outcome.delta === "number" ? outcome.delta : resolvedCandidateTurn - resolvedReferenceTurn;
+
+  if (delta > 0) {
+    return `${label} slips by ${delta} turn${delta === 1 ? "" : "s"} to T${resolvedCandidateTurn}.`;
+  }
+
+  if (delta < 0) {
+    return `${label} lands ${Math.abs(delta)} turn${Math.abs(delta) === 1 ? "" : "s"} earlier at T${resolvedCandidateTurn}.`;
+  }
+
+  return `${label} stays on the baseline timing at T${resolvedCandidateTurn}.`;
+}
+
+function describeRiskKnownBy(outcome: CompareOutcomeDelta | undefined) {
+  if (!outcome) {
+    return "The compare artifact does not record any risk-awareness delta for this branch.";
+  }
+
+  const referenceActors = stringArray(outcome.reference);
+  const candidateActors = stringArray(outcome.candidate);
+  const removedActors = referenceActors.filter((actorId) => !candidateActors.includes(actorId));
+  const addedActors = candidateActors.filter((actorId) => !referenceActors.includes(actorId));
+
+  if (removedActors.length === 0 && addedActors.length === 0) {
+    return "Risk awareness reaches the same actor set as baseline.";
+  }
+
+  if (removedActors.length > 0 && addedActors.length === 0) {
+    return `Risk awareness no longer reaches ${removedActors.join(", ")} in this branch.`;
+  }
+
+  if (addedActors.length > 0 && removedActors.length === 0) {
+    return `Risk awareness expands to ${addedActors.join(", ")} in this branch.`;
+  }
+
+  return `Risk awareness reroutes: removed ${removedActors.join(", ")}; added ${addedActors.join(", ")}.`;
+}
+
+function buildComparisonOverview(
+  run: RunPayload,
+  delta: CompareBranchDelta,
+  turnsById: Map<string, TurnEntry>
+): ComparisonOverview {
+  const rows = delta.divergent_turns.map((turnDelta) => ({
+    turnIndex: turnDelta.turn_index,
+    reference: turnDelta.reference_turn_id ? turnsById.get(turnDelta.reference_turn_id) ?? null : null,
+    candidate: turnDelta.candidate_turn_id ? turnsById.get(turnDelta.candidate_turn_id) ?? null : null
+  }));
+  const budgetExposureDelta = numericOutcomeDelta(delta.outcome_deltas, "budget_exposed_turn");
+  const ledgerDelta = numericOutcomeDelta(delta.outcome_deltas, "ledger_public_turn");
+  const evacuationDelta = numericOutcomeDelta(delta.outcome_deltas, "evacuation_turn");
+  const routeOnly = [budgetExposureDelta, ledgerDelta, evacuationDelta].every(
+    (value) => value === 0 || value === null
+  );
+  const knowledgeShift = outcomeChanged(delta.outcome_deltas.risk_known_by);
+
+  return {
+    run,
+    delta,
+    rows,
+    divergentTurnCount: delta.divergent_turn_count,
+    budgetExposureDelta,
+    ledgerDelta,
+    evacuationDelta,
+    routeOnly,
+    knowledgeShift,
+    summaryLines: [
+      describeTurnOutcome("Budget exposure", delta.outcome_deltas.budget_exposed_turn),
+      describeTurnOutcome("Ledger publication", delta.outcome_deltas.ledger_public_turn),
+      describeTurnOutcome("Evacuation", delta.outcome_deltas.evacuation_turn),
+      describeRiskKnownBy(delta.outcome_deltas.risk_known_by)
+    ]
+  };
+}
+
+export async function loadWorkbenchData(): Promise<WorkbenchData> {
+  const [report, claims, evalSummary, rubric, documents, chunks, graph, compareArtifact] = await Promise.all([
+    readText("artifacts/demo/report/report.md"),
+    readJson<Claim[]>("artifacts/demo/report/claims.json"),
+    readJson<EvalSummary>("artifacts/demo/eval/summary.json"),
+    readText("docs/rubrics/human-review.md"),
+    readJsonl<DocumentRow>("artifacts/demo/ingest/documents.jsonl"),
+    readJsonl<ChunkRow>("artifacts/demo/ingest/chunks.jsonl"),
+    readJson<GraphPayload>("artifacts/demo/graph/graph.json"),
+    readJson<CompareArtifact>(compareArtifactPath)
+  ]);
+
+  const runs = await Promise.all(compareArtifact.branches.map((branch) => loadRunPayload(branch)));
+  const runsByKey = new Map(runs.map((run) => [run.key, run]));
+  const runsByBranchId = new Map(runs.map((run) => [run.branch.branch_id, run]));
+  const baselineRun = runsByBranchId.get(compareArtifact.reference_branch_id) ?? runs[0];
+
+  if (!baselineRun) {
+    throw new Error("Expected at least one canonical demo run.");
+  }
+
+  const comparisonRuns = runs.filter((run) => run.key !== baselineRun.key);
+  const reportComparisonRun = runsByKey.get("reporter_detained") ?? comparisonRuns[0] ?? baselineRun;
+  const allTurns = runs.flatMap(buildTurnEntries);
+  const turnsById = new Map(allTurns.map((entry) => [entry.turn.turn_id, entry]));
+  const documentsById = new Map(documents.map((document) => [document.document_id, document]));
+  const chunksById = new Map(chunks.map((chunk) => [chunk.chunk_id, chunk]));
+
+  const comparisonOverviews = comparisonRuns
+    .map((run) => {
+      const delta = compareArtifact.reference_deltas.find(
+        (branchDelta) => branchDelta.branch_id === run.branch.branch_id
+      );
+      if (!delta) {
+        return null;
+      }
+      return buildComparisonOverview(run, delta, turnsById);
+    })
+    .filter((overview): overview is ComparisonOverview => Boolean(overview));
+
+  const reportComparison =
+    comparisonOverviews.find((overview) => overview.run.key === reportComparisonRun.key) ?? null;
+
+  const claimDrilldowns = claims.map((claim) => {
+    const relatedTurns = claim.related_turn_ids
+      .filter((value): value is string => Boolean(value))
+      .map((turnId) => turnsById.get(turnId))
+      .filter((entry): entry is TurnEntry => Boolean(entry));
+
+    const evidenceChunks = claim.evidence_ids
+      .map((chunkId) => chunksById.get(chunkId))
+      .filter((chunk): chunk is ChunkRow => Boolean(chunk))
+      .map((chunk) => ({
+        chunk,
+        document: documentsById.get(chunk.document_id) ?? null
+      }));
+
+    return {
+      claim,
+      evidenceChunks,
+      relatedTurns
+    };
+  });
+
+  return {
+    report,
+    claims,
+    evalSummary,
+    rubric,
+    rubricRows: parseRubricRows(rubric),
+    documents,
+    chunks,
+    graph,
+    compareArtifact,
+    runs,
+    baselineRun,
+    comparisonRuns,
+    comparisonOverviews,
+    reportComparison,
+    reportComparisonRun,
+    routeOnlyCount: comparisonOverviews.filter((overview) => overview.routeOnly).length,
+    delayedEvacuationCount: comparisonOverviews.filter(
+      (overview) => (overview.evacuationDelta ?? 0) > 0
+    ).length,
+    delayedLedgerCount: comparisonOverviews.filter((overview) => (overview.ledgerDelta ?? 0) > 0)
+      .length,
+    knowledgeShiftCount: comparisonOverviews.filter((overview) => overview.knowledgeShift).length,
+    totalDivergentTurnCount: comparisonOverviews.reduce(
+      (sum, overview) => sum + overview.divergentTurnCount,
+      0
+    ),
+    claimDrilldowns
+  };
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,1486 +1,293 @@
-import { readFile } from "node:fs/promises";
-import path from "node:path";
-import { ReviewScorecard } from "./review-scorecard";
+import Link from "next/link";
+import type { Metadata } from "next";
 
-const repoRoot = path.resolve(process.cwd(), "..");
-const compareArtifactPath = "artifacts/demo/compare/scenario_fog_harbor_phase44_matrix/compare.json";
+import { LanguageSwitch } from "./components/language-switch";
+import { getCopy } from "./lib/copy";
+import { getAppLocale } from "./lib/locale";
+import {
+  buildOverviewLines,
+  formatDeltaLabel,
+  formatTurn,
+  friendlyWorldName
+} from "./lib/presenters";
+import { loadWorkbenchData } from "./lib/workbench-data";
 
-const sections = [
-  {
-    title: "Corpus",
-    copy: "Source documents and chunks remain the bounded truth layer behind every later comparison, claim, and review step.",
-    path: "artifacts/demo/ingest"
-  },
-  {
-    title: "World Model",
-    copy: "Graph entities, relations, events, and personas keep evidence-bearing context queryable after the matrix branches diverge.",
-    path: "artifacts/demo/graph and artifacts/demo/personas"
-  },
-  {
-    title: "Scenario Matrix",
-    copy: "Canonical baseline and intervention scenarios stay normalized, explicit, and discoverable from the same artifact directory.",
-    path: "artifacts/demo/scenario"
-  },
-  {
-    title: "Run Matrix",
-    copy: "Deterministic traces and snapshots now load as a four-branch comparison surface instead of a single intervention lane.",
-    path: "artifacts/demo/run"
-  },
-  {
-    title: "Compare To Review",
-    copy: "The default operator path now starts from outcome deltas, then drops into trace, claim and evidence, and eval summary.",
-    path: "artifacts/demo/report, run, and eval"
-  }
-];
-
-type Claim = {
-  claim_id: string;
-  text: string;
-  label: string;
-  evidence_ids: string[];
-  related_turn_ids: string[];
-  confidence_note: string;
-};
-
-type EvalSummary = {
-  eval_name: string;
-  status: string;
-  metrics: Record<string, number>;
-  failures: string[];
-  notes: string[];
-};
-
-type DocumentRow = {
-  document_id: string;
-  title: string;
-  kind: string;
-  metadata?: Record<string, string>;
-};
-
-type ChunkRow = {
-  chunk_id: string;
-  document_id: string;
-  text: string;
-  char_start: number;
-  char_end: number;
-  source_id: string;
-};
-
-type GraphEntity = {
-  entity_id: string;
-  name: string;
-  type: string;
-  evidence_ids: string[];
-};
-
-type GraphRelation = {
-  relation_id: string;
-  source_entity_id: string;
-  relation_type: string;
-  target_entity_id: string;
-  evidence_ids: string[];
-};
-
-type GraphEvent = {
-  event_id: string;
-  name: string;
-  kind: string;
-  participant_entity_ids: string[];
-  evidence_ids: string[];
-};
-
-type GraphPayload = {
-  entities: GraphEntity[];
-  relations: GraphRelation[];
-  events: GraphEvent[];
-  stats: Record<string, number>;
-};
-
-type ScenarioPayload = {
-  scenario_id: string;
-  title: string;
-  description: string;
-  branch_count: number;
-  turn_budget: number;
-  injections: Array<{
-    injection_id: string;
-    kind: string;
-    target_id: string;
-    actor_id: string;
-  }>;
-};
-
-type TurnAction = {
-  turn_id: string;
-  run_id: string;
-  turn_index: number;
-  actor_id: string;
-  action_type: string;
-  target_id: string | null;
-  rationale: string;
-  evidence_ids: string[];
-  state_patch: Record<string, unknown>;
-};
-
-type SnapshotPayload = {
-  turn_index: number;
-  state: Record<string, unknown>;
-};
-
-type RunSummary = {
-  run_id: string;
-  scenario_id: string;
-  seed: number;
-  turn_budget: number;
-  executed_turns: number;
-  ledger_public_turn?: number;
-  budget_exposed_turn?: number;
-  evacuation_turn?: number;
-  final_state: Record<string, unknown>;
-  action_count: number;
-  action_types: string[];
-  notes: string[];
-};
-
-type CompareBranch = {
-  branch_id: string;
-  label: string;
-  run_id: string;
-  is_reference: boolean;
-  summary_path: string;
-  trace_path: string;
-  snapshot_dir: string;
-};
-
-type CompareOutcomeDelta = {
-  reference: unknown;
-  candidate: unknown;
-  delta: unknown;
-};
-
-type CompareTurnDelta = {
-  turn_index: number;
-  reference_turn_id: string | null;
-  candidate_turn_id: string | null;
-};
-
-type CompareBranchDelta = {
-  branch_id: string;
-  divergent_turn_count: number;
-  divergent_turns: CompareTurnDelta[];
-  outcome_deltas: Record<string, CompareOutcomeDelta>;
-};
-
-type CompareArtifact = {
-  compare_id: string;
-  scenario_id: string;
-  seed: number;
-  branch_count: number;
-  reference_branch_id: string;
-  branches: CompareBranch[];
-  reference_deltas: CompareBranchDelta[];
-};
-
-type ScenarioKey = string;
-
-type RubricRow = {
-  dimension: string;
-  one: string;
-  three: string;
-  five: string;
-};
-
-type RunPayload = {
-  key: ScenarioKey;
-  label: string;
-  branch: CompareBranch;
-  scenario: ScenarioPayload;
-  summary: RunSummary;
-  actions: TurnAction[];
-  snapshots: SnapshotPayload[];
-};
-
-type TurnEntry = {
-  scenarioKey: ScenarioKey;
-  scenarioTitle: string;
-  scenarioDescription: string;
-  turn: TurnAction;
-  snapshot: SnapshotPayload | null;
-};
-
-async function readText(relativePath: string) {
-  return readFile(path.join(repoRoot, relativePath), "utf-8");
-}
-
-async function readJson<T>(relativePath: string) {
-  return JSON.parse(await readText(relativePath)) as T;
-}
-
-async function readJsonl<T>(relativePath: string) {
-  return (await readText(relativePath))
-    .split("\n")
-    .filter(Boolean)
-    .map((line) => JSON.parse(line) as T);
-}
-
-function runKeyFromSummaryPath(summaryPath: string) {
-  return path.basename(path.dirname(summaryPath));
-}
-
-async function loadSnapshots(snapshotDir: string, turnBudget: number) {
-  return Promise.all(
-    Array.from({ length: turnBudget }, (_, index) =>
-      readJson<SnapshotPayload>(
-        `artifacts/demo/${snapshotDir}/turn-${String(index + 1).padStart(2, "0")}.json`
-      )
-    )
-  );
-}
-
-async function loadRunPayload(branch: CompareBranch): Promise<RunPayload> {
-  const key = runKeyFromSummaryPath(branch.summary_path);
-  const scenario = await readJson<ScenarioPayload>(`artifacts/demo/scenario/${key}.json`);
-  const [summary, actions, snapshots] = await Promise.all([
-    readJson<RunSummary>(`artifacts/demo/${branch.summary_path}`),
-    readJsonl<TurnAction>(`artifacts/demo/${branch.trace_path}`),
-    loadSnapshots(branch.snapshot_dir, scenario.turn_budget)
-  ]);
-
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getAppLocale();
   return {
-    key,
-    label: branch.label,
-    branch,
-    scenario,
-    summary,
-    actions,
-    snapshots
-  };
-}
-
-async function loadWorkbenchData() {
-  const [
-    report,
-    claims,
-    evalSummary,
-    rubric,
-    documents,
-    chunks,
-    graph,
-    compareArtifact
-  ] = await Promise.all([
-    readText("artifacts/demo/report/report.md"),
-    readJson<Claim[]>("artifacts/demo/report/claims.json"),
-    readJson<EvalSummary>("artifacts/demo/eval/summary.json"),
-    readText("docs/rubrics/human-review.md"),
-    readJsonl<DocumentRow>("artifacts/demo/ingest/documents.jsonl"),
-    readJsonl<ChunkRow>("artifacts/demo/ingest/chunks.jsonl"),
-    readJson<GraphPayload>("artifacts/demo/graph/graph.json"),
-    readJson<CompareArtifact>(compareArtifactPath)
-  ]);
-
-  const runs = await Promise.all(compareArtifact.branches.map((branch) => loadRunPayload(branch)));
-
-  const runsByKey = new Map(runs.map((run) => [run.key, run]));
-  const runsByBranchId = new Map(runs.map((run) => [run.branch.branch_id, run]));
-  const baselineRun = runsByBranchId.get(compareArtifact.reference_branch_id) ?? runs[0];
-
-  if (!baselineRun) {
-    throw new Error("Expected at least one canonical demo run.");
-  }
-
-  const comparisonRuns = runs.filter((run) => run.key !== baselineRun.key);
-  const reportComparisonRun = runsByKey.get("reporter_detained") ?? comparisonRuns[0] ?? baselineRun;
-
-  return {
-    report,
-    claims,
-    evalSummary,
-    rubric,
-    documents,
-    chunks,
-    graph,
-    compareArtifact,
-    runs,
-    runsByKey,
-    baselineRun,
-    comparisonRuns,
-    reportComparisonRun
-  };
-}
-
-function formatValue(value: unknown) {
-  if (typeof value === "string") {
-    return value;
-  }
-  return JSON.stringify(value) ?? "undefined";
-}
-
-function formatTurnLabel(turn: number | null | undefined) {
-  return typeof turn === "number" ? `T${turn}` : "not reached";
-}
-
-function formatDeltaLabel(delta: number | null) {
-  if (delta === null) {
-    return "n/a";
-  }
-  if (delta === 0) {
-    return "0 turns";
-  }
-  const prefix = delta > 0 ? "+" : "-";
-  return `${prefix}${Math.abs(delta)} turn${Math.abs(delta) === 1 ? "" : "s"}`;
-}
-
-function buildTurnEntries(run: RunPayload): TurnEntry[] {
-  return run.actions.map((turn, index) => ({
-    scenarioKey: run.key,
-    scenarioTitle: run.scenario.title,
-    scenarioDescription: run.scenario.description,
-    turn,
-    snapshot: run.snapshots[index] ?? null
-  }));
-}
-
-function stateHighlights(state: Record<string, unknown> | undefined) {
-  if (!state) {
-    return [];
-  }
-
-  const keys = [
-    "festival_status",
-    "budget_exposed",
-    "ledger_public",
-    "budget_exposed_turn",
-    "ledger_public_turn",
-    "evacuation_requested",
-    "evacuation_triggered",
-    "evacuation_turn",
-    "public_pressure",
-    "command_post",
-    "mayor_alerted",
-    "communications_status"
-  ];
-
-  return keys.flatMap((key) => {
-    const value = state[key];
-    if (value === null || value === undefined || value === false) {
-      return [];
-    }
-    return [`${key}=${formatValue(value)}`];
-  });
-}
-
-function parseRubricRows(rubric: string): RubricRow[] {
-  const rows = rubric
-    .split("\n")
-    .filter((line) => line.startsWith("|"))
-    .slice(2)
-    .map((line) => line.split("|").map((cell) => cell.trim()).filter(Boolean))
-    .filter((cells) => cells.length >= 4)
-    .map(([dimension, one, three, five]) => ({ dimension, one, three, five }));
-
-  if (rows.length > 0) {
-    return rows;
-  }
-
-  return [
-    {
-      dimension: "Usefulness",
-      one: "Adds no new understanding",
-      three: "Some useful contrast",
-      five: "Clearly clarifies branch differences"
-    },
-    {
-      dimension: "Credibility",
-      one: "Reads like guesswork",
-      three: "Partly grounded",
-      five: "Evidence boundaries are clear"
-    },
-    {
-      dimension: "Explainability",
-      one: "Hard to trace",
-      three: "Mostly understandable",
-      five: "Easy to replay from trace"
-    },
-    {
-      dimension: "Actionability",
-      one: "No next step is obvious",
-      three: "Some follow-up hints",
-      five: "Clear next engineering/product step"
-    }
-  ];
-}
-
-type ComparisonRow = {
-  turnIndex: number;
-  reference: TurnEntry | null;
-  candidate: TurnEntry | null;
-};
-
-type ComparisonOverview = {
-  run: RunPayload;
-  delta: CompareBranchDelta;
-  rows: ComparisonRow[];
-  divergentTurnCount: number;
-  budgetExposureDelta: number | null;
-  ledgerDelta: number | null;
-  evacuationDelta: number | null;
-  routeOnly: boolean;
-  knowledgeShift: boolean;
-  summaryLines: string[];
-};
-
-function valuesMatch(left: unknown, right: unknown) {
-  return JSON.stringify(left) === JSON.stringify(right);
-}
-
-function numericOutcomeDelta(outcomes: Record<string, CompareOutcomeDelta>, key: string) {
-  const delta = outcomes[key]?.delta;
-  return typeof delta === "number" ? delta : null;
-}
-
-function stringArray(value: unknown) {
-  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
-}
-
-function outcomeChanged(outcome: CompareOutcomeDelta | undefined) {
-  if (!outcome) {
-    return false;
-  }
-
-  if (typeof outcome.delta === "number") {
-    return outcome.delta !== 0;
-  }
-
-  return !valuesMatch(outcome.reference, outcome.candidate);
-}
-
-function describeTurnOutcome(label: string, outcome: CompareOutcomeDelta | undefined) {
-  if (!outcome) {
-    return `${label} is not recorded in the compare artifact.`;
-  }
-
-  const referenceTurn = typeof outcome.reference === "number" ? outcome.reference : undefined;
-  const candidateTurn = typeof outcome.candidate === "number" ? outcome.candidate : undefined;
-
-  if (referenceTurn === undefined && candidateTurn === undefined) {
-    return `${label} is not reached in either branch.`;
-  }
-
-  if (referenceTurn !== undefined && candidateTurn === undefined) {
-    return `${label} never lands in this branch.`;
-  }
-
-  if (referenceTurn === undefined && candidateTurn !== undefined) {
-    return `${label} appears only in this branch at ${formatTurnLabel(candidateTurn)}.`;
-  }
-
-  const resolvedReferenceTurn = referenceTurn as number;
-  const resolvedCandidateTurn = candidateTurn as number;
-  const delta =
-    typeof outcome.delta === "number" ? outcome.delta : resolvedCandidateTurn - resolvedReferenceTurn;
-
-  if (delta > 0) {
-    return `${label} slips by ${delta} turn${delta === 1 ? "" : "s"} to ${formatTurnLabel(resolvedCandidateTurn)}.`;
-  }
-
-  if (delta < 0) {
-    return `${label} lands ${Math.abs(delta)} turn${Math.abs(delta) === 1 ? "" : "s"} earlier at ${formatTurnLabel(resolvedCandidateTurn)}.`;
-  }
-
-  return `${label} stays on the baseline timing at ${formatTurnLabel(resolvedCandidateTurn)}.`;
-}
-
-function describeRiskKnownBy(outcome: CompareOutcomeDelta | undefined) {
-  if (!outcome) {
-    return "The compare artifact does not record any risk-awareness delta for this branch.";
-  }
-
-  const referenceActors = stringArray(outcome.reference);
-  const candidateActors = stringArray(outcome.candidate);
-  const removedActors = referenceActors.filter((actorId) => !candidateActors.includes(actorId));
-  const addedActors = candidateActors.filter((actorId) => !referenceActors.includes(actorId));
-
-  if (removedActors.length === 0 && addedActors.length === 0) {
-    return "Risk awareness reaches the same actor set as baseline.";
-  }
-
-  if (removedActors.length > 0 && addedActors.length === 0) {
-    return `Risk awareness no longer reaches ${removedActors.join(", ")} in this branch.`;
-  }
-
-  if (addedActors.length > 0 && removedActors.length === 0) {
-    return `Risk awareness expands to ${addedActors.join(", ")} in this branch.`;
-  }
-
-  return `Risk awareness reroutes: removed ${removedActors.join(", ")}; added ${addedActors.join(", ")}.`;
-}
-
-function buildComparisonOverview(
-  run: RunPayload,
-  delta: CompareBranchDelta,
-  turnsById: Map<string, TurnEntry>
-): ComparisonOverview {
-  const rows = delta.divergent_turns.map((turnDelta) => ({
-    turnIndex: turnDelta.turn_index,
-    reference: turnDelta.reference_turn_id ? turnsById.get(turnDelta.reference_turn_id) ?? null : null,
-    candidate: turnDelta.candidate_turn_id ? turnsById.get(turnDelta.candidate_turn_id) ?? null : null
-  }));
-  const budgetExposureDelta = numericOutcomeDelta(delta.outcome_deltas, "budget_exposed_turn");
-  const ledgerDelta = numericOutcomeDelta(delta.outcome_deltas, "ledger_public_turn");
-  const evacuationDelta = numericOutcomeDelta(delta.outcome_deltas, "evacuation_turn");
-  const routeOnly = [budgetExposureDelta, ledgerDelta, evacuationDelta].every(
-    (value) => value === 0 || value === null
-  );
-  const knowledgeShift = outcomeChanged(delta.outcome_deltas.risk_known_by);
-
-  return {
-    run,
-    delta,
-    rows,
-    divergentTurnCount: delta.divergent_turn_count,
-    budgetExposureDelta,
-    ledgerDelta,
-    evacuationDelta,
-    routeOnly,
-    knowledgeShift,
-    summaryLines: [
-      describeTurnOutcome("Budget exposure", delta.outcome_deltas.budget_exposed_turn),
-      describeTurnOutcome("Ledger publication", delta.outcome_deltas.ledger_public_turn),
-      describeTurnOutcome("Evacuation", delta.outcome_deltas.evacuation_turn),
-      describeRiskKnownBy(delta.outcome_deltas.risk_known_by)
-    ]
+    title: locale === "zh-CN" ? "Mirror 工作台总览" : "Mirror Briefing Dashboard",
+    description:
+      locale === "zh-CN"
+        ? "Mirror 的双语编辑部指挥台首页，优先展示 compare、evidence 与 eval。"
+        : "Bilingual editorial briefing dashboard for Mirror's compare, evidence, and eval flow."
   };
 }
 
 export default async function Page() {
-  const {
-    report,
-    claims,
-    evalSummary,
-    rubric,
-    documents,
-    chunks,
-    graph,
-    compareArtifact,
-    runs,
-    runsByKey,
-    baselineRun,
-    comparisonRuns,
-    reportComparisonRun
-  } = await loadWorkbenchData();
-
-  const rubricRows = parseRubricRows(rubric);
-  const documentsById = new Map(documents.map((document) => [document.document_id, document]));
-  const chunksById = new Map(chunks.map((chunk) => [chunk.chunk_id, chunk]));
-  const allTurns = runs.flatMap(buildTurnEntries);
-  const turnsById = new Map(allTurns.map((entry) => [entry.turn.turn_id, entry]));
-  const claimIdsByTurnId = new Map<string, string[]>();
-
-  for (const claim of claims) {
-    for (const turnId of claim.related_turn_ids.filter((value): value is string => Boolean(value))) {
-      const ids = claimIdsByTurnId.get(turnId) ?? [];
-      ids.push(claim.claim_id);
-      claimIdsByTurnId.set(turnId, ids);
-    }
-  }
-
-  const claimDrilldowns = claims.map((claim) => {
-    const evidenceIdSet = new Set(claim.evidence_ids);
-    const evidenceChunks = claim.evidence_ids
-      .map((chunkId) => chunksById.get(chunkId))
-      .filter((chunk): chunk is ChunkRow => Boolean(chunk))
-      .map((chunk) => ({
-        chunk,
-        document: documentsById.get(chunk.document_id) ?? null
-      }));
-
-    const graphContext = {
-      entities: graph.entities.filter((entity) => entity.evidence_ids.some((evidenceId) => evidenceIdSet.has(evidenceId))),
-      relations: graph.relations.filter((relation) => relation.evidence_ids.some((evidenceId) => evidenceIdSet.has(evidenceId))),
-      events: graph.events.filter((event) => event.evidence_ids.some((evidenceId) => evidenceIdSet.has(evidenceId)))
-    };
-
-    const relatedTurns = claim.related_turn_ids
-      .filter((value): value is string => Boolean(value))
-      .map((turnId) => turnsById.get(turnId))
-      .filter((entry): entry is TurnEntry => Boolean(entry));
-
-    const scenarioContext = Array.from(new Set(relatedTurns.map((entry) => entry.scenarioKey)))
-      .map((scenarioKey) => runsByKey.get(scenarioKey))
-      .filter((run): run is RunPayload => Boolean(run));
-
-    return {
-      claim,
-      evidenceChunks,
-      graphContext,
-      relatedTurns,
-      scenarioContext
-    };
-  });
-
-  const comparisonOverviews = comparisonRuns
-    .map((run) => {
-      const delta = compareArtifact.reference_deltas.find(
-        (branchDelta) => branchDelta.branch_id === run.branch.branch_id
-      );
-
-      if (!delta) {
-        return null;
-      }
-
-      return buildComparisonOverview(run, delta, turnsById);
-    })
-    .filter((overview): overview is ComparisonOverview => Boolean(overview));
-  const reportComparison =
-    comparisonOverviews.find((overview) => overview.run.key === reportComparisonRun.key) ?? null;
-  const routeOnlyCount = comparisonOverviews.filter((overview) => overview.routeOnly).length;
-  const delayedEvacuationCount = comparisonOverviews.filter(
-    (overview) => (overview.evacuationDelta ?? 0) > 0
-  ).length;
-  const delayedLedgerCount = comparisonOverviews.filter(
-    (overview) => (overview.ledgerDelta ?? 0) > 0
-  ).length;
-  const knowledgeShiftCount = comparisonOverviews.filter(
-    (overview) => overview.knowledgeShift
-  ).length;
-  const reviewDrawerDivergentTurns = reportComparison?.divergentTurnCount ?? 0;
-  const totalDivergentTurnCount = comparisonOverviews.reduce(
-    (sum, overview) => sum + overview.divergentTurnCount,
-    0
-  );
-  const operatorPathSteps = [
-    {
-      step: "01",
-      title: "Compare branches",
-      target: "#compare-overview",
-      summary: "Start from durable compare deltas so you can see which intervention changes the overall outcome shape.",
-      meta: `${comparisonRuns.length} intervention branches`
-    },
-    {
-      step: "02",
-      title: "Replay divergent trace",
-      target: "#trace-diff",
-      summary: "Open only the divergent turns named by the compare artifact instead of scanning full branch timelines first.",
-      meta: `${totalDivergentTurnCount} divergent turns mapped`
-    },
-    {
-      step: "03",
-      title: "Check claim and evidence",
-      target: "#report-claims",
-      summary: "Verify the canonical report pair, then drop into evidence excerpts, graph context, and linked turns when needed.",
-      meta: `${claims.length} evidence-linked claims`
-    },
-    {
-      step: "04",
-      title: "Confirm eval posture",
-      target: "#eval-summary",
-      summary: "Finish the default pass with machine eval posture before opening packet-heavy review and handoff tooling.",
-      meta: `${evalSummary.eval_name}: ${evalSummary.status}`
-    }
-  ];
+  const locale = await getAppLocale();
+  const copy = getCopy(locale);
+  const data = await loadWorkbenchData();
+  const worldName = friendlyWorldName(locale, data.graph.world_id);
+  const keyClaims = data.claims.slice(0, 3);
+  const topMetrics = Object.entries(data.evalSummary.metrics).slice(0, 4);
 
   return (
-    <main className="shell">
-      <section className="hero">
-        <p className="eyebrow">Mirror Engine / Phase 46 Focused Compare Workbench</p>
-        <h1>Start with compare, then trace, claim and evidence, and eval.</h1>
-        <p className="lede">
-          The default operator path now stays intentionally narrow: compare the branches, replay
-          only the divergent trace, inspect the linked claim and evidence chain, and confirm the
-          eval posture before opening heavier review or packet surfaces.
-        </p>
-        <div className="heroMeta">
-          <span>Current demo: Fog Harbor East Gate</span>
-          <span>{compareArtifact.branch_count} canonical scenario branches loaded</span>
-          <span>{comparisonRuns.length} intervention comparisons against baseline</span>
-          <span>compare artifact: {compareArtifact.compare_id}</span>
-          <span>
-            Current report pair: baseline vs {reportComparisonRun.scenario.title}
-          </span>
-          <span>
-            {evalSummary.eval_name}: {evalSummary.status}
-          </span>
+    <main className="workbenchPage">
+      <header className="topBar">
+        <div className="topBarBrand">
+          <p className="eyebrow">{copy.brand.eyebrow}</p>
+          <div className="topBarLinks">
+            <span className="topBarActive">{copy.brand.dashboardLabel}</span>
+            <Link href="/review">{copy.brand.reviewLabel}</Link>
+          </div>
+        </div>
+        <LanguageSwitch locale={locale} />
+      </header>
+
+      <section className="heroPanel">
+        <div className="heroPanelCopy">
+          <p className="eyebrow">{copy.dashboard.interventionEyebrow}</p>
+          <h1>{copy.dashboard.title}</h1>
+          <p className="lede">{copy.dashboard.lede}</p>
+          <div className="heroActions">
+            <Link className="heroAction heroActionPrimary" href="/review">
+              {copy.dashboard.jumpToReview}
+            </Link>
+            <Link className="heroAction" href="/review#reference">
+              {copy.dashboard.jumpToReference}
+            </Link>
+          </div>
+        </div>
+        <div className="briefSummaryGrid">
+          <article className="briefCard briefCardDark">
+            <span>{copy.brand.worldLabel}</span>
+            <strong>{worldName}</strong>
+          </article>
+          <article className="briefCard">
+            <span>{copy.metrics.scenarioBranches}</span>
+            <strong>{data.compareArtifact.branch_count}</strong>
+          </article>
+          <article className="briefCard">
+            <span>{copy.metrics.interventionBranches}</span>
+            <strong>{data.comparisonRuns.length}</strong>
+          </article>
+          <article className="briefCard">
+            <span>{copy.metrics.evalStatus}</span>
+            <strong>
+              {data.evalSummary.eval_name}: {data.evalSummary.status}
+            </strong>
+          </article>
+          <article className="briefCard briefCardWide">
+            <span>{copy.dashboard.currentPair}</span>
+            <strong>
+              {data.baselineRun.scenario.title} ↔ {data.reportComparisonRun.scenario.title}
+            </strong>
+          </article>
+          <article className="briefCard briefCardWide">
+            <span>{copy.brand.compareArtifactLabel}</span>
+            <code>{data.compareArtifact.compare_id}</code>
+          </article>
         </div>
       </section>
 
-      <section className="panel">
-        <div className="panelHeader">
-          <p className="eyebrow">Default Operator Path</p>
-          <h2>Use the focused compare path first, then open advanced review and reference surfaces only when needed.</h2>
+      <section className="dashboardSection">
+        <div className="sectionHeading">
+          <p className="eyebrow">{copy.dashboard.routeEyebrow}</p>
+          <h2>{copy.dashboard.routeTitle}</h2>
+          <p>{copy.dashboard.routeSummary}</p>
         </div>
-        <div className="pathGrid">
-          {operatorPathSteps.map((step) => (
-            <article key={step.step} className="pathCard">
-              <span className="pathStep">{step.step}</span>
+        <div className="routeBoard">
+          {copy.routeSteps.map((step) => (
+            <article key={step.step} className="routeCard">
+              <span className="routeIndex">{step.step}</span>
               <h3>{step.title}</h3>
               <p>{step.summary}</p>
-              <div className="claimEvidence">
-                <code>{step.meta}</code>
-                <a className="linkPill" href={step.target}>
-                  Open step
-                </a>
-              </div>
             </article>
           ))}
         </div>
-        <ul className="checklist">
-          <li>The compare artifact remains the first read, and focused divergent trace is now treated as the next default step rather than a later deep-dive.</li>
-          <li>Claim/evidence review and eval stay in the primary path; review-scorecard and packet-heavy surfaces remain available afterward as advanced tooling.</li>
-          <li>Scenario, world-model, and corpus artifacts remain in-repo as reference surfaces, but they no longer compete with the core compare path for first attention.</li>
-        </ul>
       </section>
 
-      <section className="panel panelAccent" id="compare-overview">
-        <div className="panelHeader">
-          <p className="eyebrow">Counterfactual Overview</p>
-          <h2>See which intervention changes the outcome, which only changes the route, and where to inspect next.</h2>
+      <section className="dashboardSection">
+        <div className="sectionHeading">
+          <p className="eyebrow">{copy.dashboard.interventionEyebrow}</p>
+          <h2>{copy.dashboard.interventionTitle}</h2>
+          <p>{copy.dashboard.interventionSummary}</p>
         </div>
-        <div className="metricGrid">
-          <div className="metricCard">
-            <span>scenario branches</span>
-            <strong>{compareArtifact.branch_count}</strong>
-          </div>
-          <div className="metricCard">
-            <span>intervention branches</span>
-            <strong>{comparisonRuns.length}</strong>
-          </div>
-          <div className="metricCard">
-            <span>delayed ledger branches</span>
-            <strong>{delayedLedgerCount}</strong>
-          </div>
-          <div className="metricCard">
-            <span>delayed evacuation branches</span>
-            <strong>{delayedEvacuationCount}</strong>
-          </div>
-          <div className="metricCard">
-            <span>route-only branches</span>
-            <strong>{routeOnlyCount}</strong>
-          </div>
-          <div className="metricCard">
-            <span>knowledge-shift branches</span>
-            <strong>{knowledgeShiftCount}</strong>
-          </div>
-        </div>
-        <div className="comparisonOverviewGrid">
-          <article className="artifactCard">
-            <div className="artifactMeta">
-              <span>reference</span>
-              <code>{compareArtifactPath}</code>
-              <code>artifacts/demo/{baselineRun.branch.summary_path}</code>
+        <div className="interventionBoard">
+          <article className="interventionCard interventionCardReference">
+            <div className="interventionCardMeta">
+              <span>{copy.common.referenceBranch}</span>
+              <code>{data.baselineRun.scenario.scenario_id}</code>
             </div>
-            <div className="claimHeader">
-              <strong>{baselineRun.scenario.title}</strong>
-              <span className="pill">reference branch</span>
+            <h3>{data.baselineRun.scenario.title}</h3>
+            <p>{data.baselineRun.scenario.description}</p>
+            <div className="deltaBadgeRow">
+              <span className="deltaBadge">{copy.metrics.budgetExposed}: {formatTurn(locale, data.baselineRun.summary.budget_exposed_turn)}</span>
+              <span className="deltaBadge">{copy.metrics.ledgerPublic}: {formatTurn(locale, data.baselineRun.summary.ledger_public_turn)}</span>
+              <span className="deltaBadge">{copy.metrics.evacuation}: {formatTurn(locale, data.baselineRun.summary.evacuation_turn)}</span>
             </div>
-            <p>{baselineRun.scenario.description}</p>
-            <div className="claimEvidence">
-              <code>{baselineRun.branch.branch_id}</code>
-              <code>{baselineRun.scenario.scenario_id}</code>
-              <code>turn_budget={baselineRun.scenario.turn_budget}</code>
-              <code>seed={compareArtifact.seed}</code>
-            </div>
-            <div className="metricGrid">
-              <div className="metricCard">
-                <span>budget exposed</span>
-                <strong>{formatTurnLabel(baselineRun.summary.budget_exposed_turn)}</strong>
-              </div>
-              <div className="metricCard">
-                <span>ledger public</span>
-                <strong>{formatTurnLabel(baselineRun.summary.ledger_public_turn)}</strong>
-              </div>
-              <div className="metricCard">
-                <span>evacuation</span>
-                <strong>{formatTurnLabel(baselineRun.summary.evacuation_turn)}</strong>
-              </div>
-            </div>
-            <ul className="checklist compact">
-              <li>The compare contract anchors every delta against this reference branch.</li>
-              <li>Budget exposure lands at {formatTurnLabel(baselineRun.summary.budget_exposed_turn)}.</li>
-              <li>Ledger publication becomes public at {formatTurnLabel(baselineRun.summary.ledger_public_turn)}.</li>
-              <li>Evacuation triggers at {formatTurnLabel(baselineRun.summary.evacuation_turn)}.</li>
-            </ul>
-            <div className="claimEvidence">
-              <a className="linkPill" href="#reference-surfaces-drawer">
-                Reference surfaces
-              </a>
-              <a className="linkPill" href="#trace-diff">
-                Trace compare
-              </a>
-              <a className="linkPill" href="#eval-summary">
-                Eval summary
-              </a>
+            <div className="artifactChipRow">
+              <span className="artifactChip">{copy.brand.sourceArtifactLabel}</span>
+              <code>artifacts/demo/{data.baselineRun.branch.summary_path}</code>
             </div>
           </article>
 
-          {comparisonOverviews.map((overview) => (
-            <article key={overview.run.key} className="artifactCard">
-              <div className="artifactMeta">
-                <span>{overview.run.label}</span>
-                <code>{compareArtifactPath}</code>
-                <code>artifacts/demo/{overview.run.branch.summary_path}</code>
+          {data.comparisonOverviews.map((overview) => {
+            const summaryLines = buildOverviewLines(locale, overview).slice(0, 3);
+            return (
+              <article key={overview.run.key} className="interventionCard">
+                <div className="interventionCardMeta">
+                  <span>{overview.run.label}</span>
+                  <code>{overview.run.scenario.scenario_id}</code>
+                </div>
+                <h3>{overview.run.scenario.title}</h3>
+                <p>{overview.run.scenario.description}</p>
+                <div className="deltaBadgeRow">
+                  <span className="deltaBadge">
+                    {copy.metrics.budgetExposed}: {formatDeltaLabel(locale, overview.budgetExposureDelta)}
+                  </span>
+                  <span className="deltaBadge">
+                    {copy.metrics.ledgerPublic}: {formatDeltaLabel(locale, overview.ledgerDelta)}
+                  </span>
+                  <span className="deltaBadge">
+                    {copy.metrics.evacuation}: {formatDeltaLabel(locale, overview.evacuationDelta)}
+                  </span>
+                  <span className="deltaBadge">
+                    {copy.metrics.divergentTurns}: {overview.divergentTurnCount}
+                  </span>
+                  <span className="deltaBadge">
+                    {overview.routeOnly ? copy.common.routeOnlyDelta : copy.common.timingDrift}
+                  </span>
+                  {overview.knowledgeShift ? (
+                    <span className="deltaBadge">{copy.common.knowledgeShift}</span>
+                  ) : null}
+                </div>
+                <ul className="summaryList">
+                  {summaryLines.map((line) => (
+                    <li key={line}>{line}</li>
+                  ))}
+                </ul>
+                <div className="cardActions">
+                  <Link className="linkPill" href={`/review#trace-${overview.run.key}`}>
+                    {copy.dashboard.openTrace}
+                  </Link>
+                  <Link className="linkPill" href="/review#claims">
+                    {copy.dashboard.openClaims}
+                  </Link>
+                  <Link className="linkPill" href="/review#reference">
+                    {copy.dashboard.openReference}
+                  </Link>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="dashboardSection">
+        <div className="sectionHeading">
+          <p className="eyebrow">{copy.dashboard.storyboardEyebrow}</p>
+          <h2>{copy.dashboard.storyboardTitle}</h2>
+        </div>
+        <div className="storyboardGrid">
+          {data.comparisonOverviews.map((overview) => (
+            <article key={overview.run.key} className="storyboardCard">
+              <div className="interventionCardMeta">
+                <span>{overview.run.scenario.title}</span>
+                <code>{overview.divergentTurnCount} {copy.metrics.divergentTurns.toLowerCase()}</code>
               </div>
-              <div className="claimHeader">
-                <strong>{overview.run.scenario.title}</strong>
-                <span className="pill">{overview.divergentTurnCount} divergent turns</span>
-              </div>
-              <p>{overview.run.scenario.description}</p>
-              <div className="claimEvidence">
-                <code>{overview.run.branch.branch_id}</code>
-                <code>{overview.run.scenario.scenario_id}</code>
-                <code>budget delta {formatDeltaLabel(overview.budgetExposureDelta)}</code>
-                <code>ledger delta {formatDeltaLabel(overview.ledgerDelta)}</code>
-                <code>evacuation delta {formatDeltaLabel(overview.evacuationDelta)}</code>
-              </div>
-              <div className="claimEvidence">
-                {overview.run.scenario.injections.map((injection) => (
-                  <code key={injection.injection_id}>{injection.kind}</code>
+              <div className="storyboardRows">
+                {overview.rows.slice(0, 2).map((row) => (
+                  <article key={`${overview.run.key}-${row.turnIndex}`} className="storyboardRow">
+                    <div className="storyboardRowTop">
+                      <strong>T{row.turnIndex}</strong>
+                      <span className="pill">{copy.common.rawArtifact}</span>
+                    </div>
+                    <div className="storyboardColumns">
+                      <div className="storyboardTurn">
+                        <span>{copy.common.baseline}</span>
+                        {row.reference ? (
+                          <>
+                            <strong>{row.reference.turn.action_type}</strong>
+                            <p>{row.reference.turn.rationale}</p>
+                          </>
+                        ) : (
+                          <p>{copy.review.noDivergence}</p>
+                        )}
+                      </div>
+                      <div className="storyboardTurn">
+                        <span>{copy.common.candidate}</span>
+                        {row.candidate ? (
+                          <>
+                            <strong>{row.candidate.turn.action_type}</strong>
+                            <p>{row.candidate.turn.rationale}</p>
+                          </>
+                        ) : (
+                          <p>{copy.review.noDivergence}</p>
+                        )}
+                      </div>
+                    </div>
+                  </article>
                 ))}
-                <span className="pill">{overview.routeOnly ? "route-only delta" : "timing drift"}</span>
-                {overview.knowledgeShift ? <span className="pill">knowledge shift</span> : null}
-              </div>
-              <div className="metricGrid">
-                <div className="metricCard">
-                  <span>budget exposed</span>
-                  <strong>{formatTurnLabel(overview.run.summary.budget_exposed_turn)}</strong>
-                </div>
-                <div className="metricCard">
-                  <span>ledger public</span>
-                  <strong>{formatTurnLabel(overview.run.summary.ledger_public_turn)}</strong>
-                </div>
-                <div className="metricCard">
-                  <span>evacuation</span>
-                  <strong>{formatTurnLabel(overview.run.summary.evacuation_turn)}</strong>
-                </div>
-              </div>
-              <ul className="checklist compact">
-                {overview.summaryLines.map((line) => (
-                  <li key={line}>{line}</li>
-                ))}
-              </ul>
-              {overview.run.summary.notes.length > 1 ? (
-                <p className="subtle">{overview.run.summary.notes.slice(1).join(" ")}</p>
-              ) : null}
-              <div className="claimEvidence">
-                <a className="linkPill" href={`#compare-${overview.run.key}`}>
-                  Trace diff
-                </a>
-                <a className="linkPill" href="#report-claims">
-                  Claim and evidence
-                </a>
-                <a className="linkPill" href="#eval-summary">
-                  Eval summary
-                </a>
               </div>
             </article>
           ))}
         </div>
       </section>
 
-      <section className="panel" id="trace-diff">
-        <div className="panelHeader">
-          <p className="eyebrow">Focused Trace Diff</p>
-          <h2>Replay only the divergent turns named by the compare artifact, then jump straight into claims, evidence, or eval.</h2>
-        </div>
-        <div className="detailList">
-          {comparisonOverviews.map((overview) => (
-            <article key={overview.run.key} id={`compare-${overview.run.key}`} className="artifactCard">
-              <div className="artifactMeta">
-                <span>compare</span>
-                <code>{compareArtifactPath}</code>
-                <code>artifacts/demo/{overview.run.branch.trace_path}</code>
-              </div>
-              <div className="claimHeader">
-                <strong>{baselineRun.scenario.title} vs {overview.run.scenario.title}</strong>
-                <span className="pill">{overview.divergentTurnCount} divergent turns</span>
-              </div>
-              <p>{overview.summaryLines.join(" ")}</p>
-              <div className="claimEvidence">
-                <a className="linkPill" href="#report-claims">
-                  Jump to claims
-                </a>
-                <a className="linkPill" href="#claim-drilldowns">
-                  Jump to drill-down
-                </a>
-                <a className="linkPill" href="#eval-summary">
-                  Jump to eval
-                </a>
-              </div>
-              {overview.rows.length > 0 ? (
-                <div className="timelineRows">
-                  {overview.rows.map(({ turnIndex, reference, candidate }) => (
-                    <article
-                      key={`${overview.run.key}-turn-${turnIndex}`}
-                      className="timelineRow timelineRowDivergent"
-                    >
-                      <div className="claimHeader">
-                        <strong>Turn {turnIndex}</strong>
-                        <span className="pill">branch divergence</span>
-                      </div>
-                      <div className="timelineCards">
-                        {[reference, candidate].map((entry, index) => (
-                          <section
-                            key={index === 0 ? `${overview.run.key}-baseline` : `${overview.run.key}-candidate`}
-                            id={entry ? `turn-${entry.turn.turn_id}` : undefined}
-                            className={`timelineCard${entry ? "" : " timelineCardEmpty"}`}
-                          >
-                            {entry ? (
-                              <>
-                                <div className="artifactMeta">
-                                  <span>{index === 0 ? "baseline" : "candidate"}</span>
-                                  <code>{entry.turn.turn_id}</code>
-                                </div>
-                                <div className="claimHeader">
-                                  <strong>{entry.turn.action_type}</strong>
-                                  <span className="pill">{entry.turn.actor_id}</span>
-                                </div>
-                                <p>{entry.turn.rationale}</p>
-                                <div className="claimEvidence">
-                                  <code>{entry.scenarioTitle}</code>
-                                  {entry.turn.target_id ? <code>{entry.turn.target_id}</code> : null}
-                                  {claimIdsByTurnId.get(entry.turn.turn_id)?.map((claimId) => (
-                                    <a key={claimId} className="linkPill" href={`#drill-${claimId}`}>
-                                      {claimId}
-                                    </a>
-                                  ))}
-                                </div>
-                                <div className="claimEvidence">
-                                  {entry.turn.evidence_ids.map((evidenceId) => (
-                                    <a key={evidenceId} className="linkPill" href={`#chunk-${evidenceId}`}>
-                                      {evidenceId}
-                                    </a>
-                                  ))}
-                                </div>
-                                <div className="timelineState">
-                                  {Object.keys(entry.turn.state_patch).length > 0 ? (
-                                    Object.entries(entry.turn.state_patch).map(([key, value]) => (
-                                      <code key={key}>
-                                        {key}={formatValue(value)}
-                                      </code>
-                                    ))
-                                  ) : (
-                                    <span className="subtle">no state patch</span>
-                                  )}
-                                </div>
-                                <div className="timelineState">
-                                  {stateHighlights(entry.snapshot?.state).length > 0 ? (
-                                    stateHighlights(entry.snapshot?.state).map((highlight) => (
-                                      <code key={highlight}>{highlight}</code>
-                                    ))
-                                  ) : (
-                                    <span className="subtle">no highlighted snapshot state</span>
-                                  )}
-                                </div>
-                              </>
-                            ) : (
-                              <span className="subtle">No turn recorded for this branch.</span>
-                            )}
-                          </section>
-                        ))}
-                      </div>
-                    </article>
+      <div className="dashboardSplit">
+        <section className="dashboardSection">
+          <div className="sectionHeading">
+            <p className="eyebrow">{copy.dashboard.claimEyebrow}</p>
+            <h2>{copy.dashboard.claimTitle}</h2>
+          </div>
+          <div className="claimSnapshotGrid">
+            {keyClaims.map((claim) => (
+              <article key={claim.claim_id} className="claimSnapshotCard">
+                <div className="interventionCardMeta">
+                  <span>{claim.claim_id}</span>
+                  <span className="pill">{claim.label}</span>
+                </div>
+                <p>{claim.text}</p>
+                <div className="artifactChipRow">
+                  {claim.evidence_ids.slice(0, 3).map((evidenceId) => (
+                    <code key={evidenceId}>{evidenceId}</code>
                   ))}
                 </div>
-              ) : (
-                <p className="subtle">This branch has no divergent turns recorded in the compare artifact.</p>
-              )}
-            </article>
-          ))}
-        </div>
-      </section>
+              </article>
+            ))}
+          </div>
+        </section>
 
-      <section className="panel" id="report-claims">
-        <div className="panelHeader">
-          <p className="eyebrow">Report Pair</p>
-          <h2>Current report artifacts remain explicit about the canonical baseline vs reporter-detained comparison.</h2>
-        </div>
-        <div className="reportGrid">
-          <article className="artifactCard artifactCardWide">
-            <div className="artifactMeta">
-              <span>artifact</span>
-              <code>artifacts/demo/report/report.md</code>
-            </div>
-            <div className="claimEvidence">
-              <code>baseline</code>
-              <code>{reportComparisonRun.key}</code>
-              <a className="linkPill" href={`#compare-${reportComparisonRun.key}`}>
-                Open canonical trace diff
-              </a>
-            </div>
-            <p>
-              The report layer is still generated from the baseline vs reporter-detained pair, which
-              keeps the current claim and evidence contract honest while the new matrix overview
-              broadens the top-level comparison surface.
+        <section className="dashboardSection">
+          <div className="sectionHeading">
+            <p className="eyebrow">{copy.dashboard.evalEyebrow}</p>
+            <h2>{copy.dashboard.evalTitle}</h2>
+            <p>{copy.dashboard.scorecardNote}</p>
+          </div>
+          <div className="briefSummaryGrid">
+            {topMetrics.map(([key, value]) => (
+              <article key={key} className="briefCard">
+                <span>{key}</span>
+                <strong>{value}</strong>
+              </article>
+            ))}
+          </div>
+          <div className="dashboardCallout">
+            <p className="subtle">
+              {data.evalSummary.eval_name}: {data.evalSummary.status}
             </p>
-            <pre className="artifactPre">{report}</pre>
-          </article>
-          <article className="artifactCard">
-            <div className="artifactMeta">
-              <span>artifact</span>
-              <code>artifacts/demo/report/claims.json</code>
+            <div className="cardActions">
+              <Link className="heroAction heroActionPrimary" href="/review">
+                {copy.dashboard.openReview}
+              </Link>
+              <Link className="heroAction" href="/review#advanced-operations">
+                {copy.rubric.openLegacy}
+              </Link>
             </div>
-            <div className="claimList">
-              {claims.map((claim) => (
-                <article key={claim.claim_id} className="claimCard">
-                  <div className="claimHeader">
-                    <strong>{claim.claim_id}</strong>
-                    <span className="pill">{claim.label}</span>
-                  </div>
-                  <p>{claim.text}</p>
-                  <div className="claimEvidence">
-                    {claim.evidence_ids.map((evidenceId) => (
-                      <a key={evidenceId} className="linkPill" href={`#chunk-${evidenceId}`}>
-                        {evidenceId}
-                      </a>
-                    ))}
-                  </div>
-                  <div className="claimEvidence">
-                    {claim.related_turn_ids.filter(Boolean).map((turnId) => (
-                      <a key={turnId} className="linkPill" href={`#turn-${turnId}`}>
-                        {turnId}
-                      </a>
-                    ))}
-                  </div>
-                  <a className="jumpLink" href={`#drill-${claim.claim_id}`}>
-                    Open review drill-down
-                  </a>
-                  <p className="claimNote">{claim.confidence_note}</p>
-                </article>
-              ))}
-            </div>
-          </article>
-        </div>
-      </section>
-
-      <section className="panel" id="claim-drilldowns">
-        <div className="panelHeader">
-          <p className="eyebrow">Claim Drill-Down</p>
-          <h2>Move from each claim into supporting evidence, graph context, and the specific branch turns behind it.</h2>
-        </div>
-        <div className="drilldownGrid">
-          {claimDrilldowns.map(({ claim, evidenceChunks, graphContext, relatedTurns, scenarioContext }) => (
-            <article key={claim.claim_id} id={`drill-${claim.claim_id}`} className="drilldownCard">
-              <div className="claimHeader">
-                <strong>{claim.claim_id}</strong>
-                <span className="pill">{claim.label}</span>
-              </div>
-              <p>{claim.text}</p>
-
-              <div className="detailStack">
-                <section className="detailBlock">
-                  <h3>Evidence excerpts</h3>
-                  <div className="detailList">
-                    {evidenceChunks.map(({ chunk, document }) => (
-                      <article key={chunk.chunk_id} id={`chunk-${chunk.chunk_id}`} className="evidenceBlock">
-                        <div className="claimHeader">
-                          <strong>{document?.title ?? chunk.document_id}</strong>
-                          <span className="pill">{document?.kind ?? "chunk"}</span>
-                        </div>
-                        <div className="claimEvidence">
-                          <code>{chunk.chunk_id}</code>
-                          <code>{chunk.document_id}</code>
-                        </div>
-                        <p>{chunk.text}</p>
-                      </article>
-                    ))}
-                  </div>
-                </section>
-
-                <section className="detailBlock">
-                  <h3>Scenario context</h3>
-                  <div className="detailList">
-                    {scenarioContext.map((run) => (
-                      <article key={run.scenario.scenario_id} className="docCard">
-                        <div className="claimHeader">
-                          <strong>{run.scenario.title}</strong>
-                          <span className="pill">{run.label}</span>
-                        </div>
-                        <p>{run.scenario.description}</p>
-                        <div className="claimEvidence">
-                          <code>{run.scenario.scenario_id}</code>
-                          <code>turn_budget={run.scenario.turn_budget}</code>
-                          <code>injections={run.scenario.injections.length}</code>
-                        </div>
-                      </article>
-                    ))}
-                  </div>
-                </section>
-
-                <section className="detailBlock">
-                  <h3>Graph context</h3>
-                  <div className="objectColumns">
-                    <div>
-                      <h3>Entities</h3>
-                      <ul className="objectList">
-                        {graphContext.entities.length > 0 ? (
-                          graphContext.entities.map((entity) => (
-                            <li key={entity.entity_id}>
-                              <strong>{entity.name}</strong>
-                              <code>{entity.entity_id}</code>
-                            </li>
-                          ))
-                        ) : (
-                          <li className="objectListEmpty">No entity evidence overlap.</li>
-                        )}
-                      </ul>
-                    </div>
-                    <div>
-                      <h3>Relations</h3>
-                      <ul className="objectList">
-                        {graphContext.relations.length > 0 ? (
-                          graphContext.relations.map((relation) => (
-                            <li key={relation.relation_id}>
-                              <strong>{relation.relation_type}</strong>
-                              <code>{relation.relation_id}</code>
-                            </li>
-                          ))
-                        ) : (
-                          <li className="objectListEmpty">No relation evidence overlap.</li>
-                        )}
-                      </ul>
-                    </div>
-                    <div>
-                      <h3>Events</h3>
-                      <ul className="objectList">
-                        {graphContext.events.length > 0 ? (
-                          graphContext.events.map((event) => (
-                            <li key={event.event_id}>
-                              <strong>{event.name}</strong>
-                              <code>{event.event_id}</code>
-                            </li>
-                          ))
-                        ) : (
-                          <li className="objectListEmpty">No event evidence overlap.</li>
-                        )}
-                      </ul>
-                    </div>
-                  </div>
-                </section>
-
-                <section className="detailBlock">
-                  <h3>Related turns</h3>
-                  <div className="detailList">
-                    {relatedTurns.map((entry) => (
-                      <article key={entry.turn.turn_id} className="traceItem">
-                        <div className="claimHeader">
-                          <strong>{entry.turn.turn_id}</strong>
-                          <span className="pill">{entry.scenarioTitle}</span>
-                        </div>
-                        <div className="claimEvidence">
-                          <a className="linkPill" href={`#turn-${entry.turn.turn_id}`}>
-                            jump to timeline
-                          </a>
-                          <code>{entry.turn.action_type}</code>
-                          {entry.turn.target_id ? <code>{entry.turn.target_id}</code> : null}
-                        </div>
-                        <p>{entry.turn.rationale}</p>
-                      </article>
-                    ))}
-                  </div>
-                </section>
-              </div>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className="panel" id="eval-summary">
-        <div className="panelHeader">
-          <p className="eyebrow">Eval And Review</p>
-          <h2>Finish the default path with the matrix-level eval posture before opening advanced review tooling.</h2>
-        </div>
-        <div className="reportGrid">
-          <article className="artifactCard">
-            <div className="artifactMeta">
-              <span>artifact</span>
-              <code>artifacts/demo/eval/summary.json</code>
-            </div>
-            <div className="metricGrid">
-              {Object.entries(evalSummary.metrics).map(([key, value]) => (
-                <div key={key} className="metricCard">
-                  <span>{key}</span>
-                  <strong>{value}</strong>
-                </div>
-              ))}
-            </div>
-            <div className="statusRow">
-              <span className="pill">{evalSummary.status}</span>
-              <span>{evalSummary.eval_name}</span>
-            </div>
-            {evalSummary.notes.length > 0 ? (
-              <ul className="checklist compact">
-                {evalSummary.notes.map((note) => (
-                  <li key={note}>{note}</li>
-                ))}
-              </ul>
-            ) : null}
-          </article>
-
-          <article className="artifactCard">
-            <div className="artifactMeta">
-              <span>artifact</span>
-              <code>docs/rubrics/human-review.md</code>
-            </div>
-            <pre className="artifactPre artifactPreCompact">{rubric}</pre>
-          </article>
-        </div>
-      </section>
-
-      <section className="panel panelAccent" id="advanced-review">
-        <div className="panelHeader">
-          <p className="eyebrow">Advanced Review</p>
-          <h2>Scorecards, packet tooling, and reference layers stay available behind explicit advanced-navigation drawers.</h2>
-        </div>
-        <div className="drawerLauncherGrid">
-          <article className="artifactCard">
-            <div className="artifactMeta">
-              <span>after default path</span>
-              <code>review-scorecard and delivery surfaces</code>
-            </div>
-            <p>
-              Once compare, divergent trace, claim/evidence, and eval are clear, the advanced
-              review surfaces below remain available for scoring, handoff packaging, and delivery
-              planning without dominating the first-read experience.
-            </p>
-            <div className="claimEvidence">
-              <code>{claims.length} claims in scope</code>
-              <code>{reviewDrawerDivergentTurns} canonical divergent turns</code>
-              <a className="linkPill" href="#review-scorecard-drawer">
-                Open review drawer
-              </a>
-            </div>
-          </article>
-
-          <article className="artifactCard">
-            <div className="artifactMeta">
-              <span>reference surfaces</span>
-              <code>scenario, world, and corpus remain available below</code>
-            </div>
-            <ul className="checklist compact">
-              <li>Keep the default path narrow when you only need to understand branch differences and evidence posture.</li>
-              <li>Open the advanced review surfaces when you are ready to score the branch or assemble a handoff packet.</li>
-              <li>Drop into scenario, world-model, or corpus references only when the core compare path still leaves a question unresolved.</li>
-            </ul>
-            <div className="claimEvidence">
-              <code>{sections.length} reference surfaces</code>
-              <a className="linkPill" href="#reference-surfaces-drawer">
-                Open reference drawer
-              </a>
-            </div>
-          </article>
-        </div>
-      </section>
-
-      <details className="drawerSection" id="review-scorecard-drawer">
-        <summary className="drawerSummary">
-          <div className="drawerSummaryContent">
-            <strong>Advanced review drawer</strong>
-            <span>Open the scorecard, packet tooling, and handoff surfaces only after the default compare path is clear.</span>
           </div>
-          <div className="drawerSummaryMeta">
-            <span className="drawerChip">secondary surface</span>
-            <span className="drawerChip">{claims.length} claims</span>
-            <span className="drawerChip">{reviewDrawerDivergentTurns} divergent turns</span>
-          </div>
-        </summary>
-        <div className="drawerBody">
-          <p className="drawerLead">
-            Use this drawer when you are ready to score the branch, package a handoff, or work through the
-            packet-heavy export and delivery tooling that intentionally sits behind the default operator path.
-          </p>
-          <ReviewScorecard
-            rubricRows={rubricRows}
-            claimCount={claims.length}
-            divergentTurnCount={reviewDrawerDivergentTurns}
-            evalName={evalSummary.eval_name}
-            evalStatus={evalSummary.status}
-            claimPackets={claims.map((claim) => ({
-              claimId: claim.claim_id,
-              text: claim.text,
-              relatedTurnIds: claim.related_turn_ids.filter(Boolean)
-            }))}
-            divergentTurns={(reportComparison?.rows ?? [])
-              .map(({ turnIndex, reference, candidate }) => ({
-                turnIndex,
-                baselineTurnId: reference?.turn.turn_id ?? null,
-                baselineAction: reference?.turn.action_type ?? null,
-                interventionTurnId: candidate?.turn.turn_id ?? null,
-                interventionAction: candidate?.turn.action_type ?? null
-              }))}
-          />
-        </div>
-      </details>
-
-      <details className="drawerSection" id="reference-surfaces-drawer">
-        <summary className="drawerSummary">
-          <div className="drawerSummaryContent">
-            <strong>Reference surfaces drawer</strong>
-            <span>Open scenario, world-model, and corpus references when the focused compare path still leaves a question unresolved.</span>
-          </div>
-          <div className="drawerSummaryMeta">
-            <span className="drawerChip">supporting artifacts</span>
-            <span className="drawerChip">{sections.length} sections</span>
-            <span className="drawerChip">{documents.length} documents</span>
-          </div>
-        </summary>
-        <div className="drawerBody drawerBodyStack">
-          <section className="panel" id="reference-map">
-            <div className="panelHeader">
-              <p className="eyebrow">Reference Map</p>
-              <h2>These supporting artifact surfaces stay available behind the default operator path.</h2>
-            </div>
-            <div className="grid">
-              {sections.map((section) => (
-                <article key={section.title} className="card">
-                  <h3>{section.title}</h3>
-                  <p>{section.copy}</p>
-                  <code>{section.path}</code>
-                </article>
-              ))}
-            </div>
-          </section>
-
-          <section className="panel" id="scenario-matrix">
-            <div className="panelHeader">
-              <p className="eyebrow">Scenario Matrix</p>
-              <h2>All canonical scenario artifacts stay visible, normalized, and branch-comparable.</h2>
-            </div>
-            <div className="scenarioGrid">
-              {runs.map((run) => (
-                <article key={run.key} className="artifactCard">
-                  <div className="artifactMeta">
-                    <span>{run.label}</span>
-                    <code>artifacts/demo/scenario/{run.key}.json</code>
-                  </div>
-                  <div className="claimHeader">
-                    <strong>{run.scenario.title}</strong>
-                    <span className="pill">{run.scenario.scenario_id}</span>
-                  </div>
-                  <p>{run.scenario.description}</p>
-                  <div className="claimEvidence">
-                    <code>turn_budget={run.scenario.turn_budget}</code>
-                    <code>branch_count={run.scenario.branch_count}</code>
-                    <code>injections={run.scenario.injections.length}</code>
-                  </div>
-                  <pre className="artifactPre artifactPreCompact">
-                    {JSON.stringify(run.scenario, null, 2)}
-                  </pre>
-                </article>
-              ))}
-            </div>
-          </section>
-
-          <section className="panel" id="world-model">
-            <div className="panelHeader">
-              <p className="eyebrow">World Model</p>
-              <h2>Graph objects stay visible as structured, evidence-bearing records.</h2>
-            </div>
-            <div className="reportGrid">
-              <article className="artifactCard">
-                <div className="artifactMeta">
-                  <span>artifact</span>
-                  <code>artifacts/demo/graph/graph.json</code>
-                </div>
-                <div className="metricGrid">
-                  {Object.entries(graph.stats).map(([key, value]) => (
-                    <div key={key} className="metricCard">
-                      <span>{key}</span>
-                      <strong>{value}</strong>
-                    </div>
-                  ))}
-                </div>
-                <div className="objectColumns">
-                  <div>
-                    <h3>Entities</h3>
-                    <ul className="objectList">
-                      {graph.entities.slice(0, 4).map((entity) => (
-                        <li key={entity.entity_id}>
-                          <strong>{entity.name}</strong>
-                          <code>{entity.entity_id}</code>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                  <div>
-                    <h3>Relations</h3>
-                    <ul className="objectList">
-                      {graph.relations.slice(0, 4).map((relation) => (
-                        <li key={relation.relation_id}>
-                          <strong>{relation.relation_type}</strong>
-                          <code>{relation.relation_id}</code>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                  <div>
-                    <h3>Events</h3>
-                    <ul className="objectList">
-                      {graph.events.slice(0, 4).map((event) => (
-                        <li key={event.event_id}>
-                          <strong>{event.name}</strong>
-                          <code>{event.event_id}</code>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                </div>
-              </article>
-
-              <article className="artifactCard">
-                <div className="artifactMeta">
-                  <span>traceability</span>
-                  <code>entities / relations / events</code>
-                </div>
-                <p>
-                  This view still avoids a heavy graph dependency, but the new claim drill-down now
-                  cross-links evidence-bearing graph records when a claim shares their `evidence_ids`.
-                </p>
-              </article>
-            </div>
-          </section>
-
-          <section className="panel" id="corpus-reference">
-            <div className="panelHeader">
-              <p className="eyebrow">Corpus</p>
-              <h2>Canonical source documents remain directly inspectable.</h2>
-            </div>
-            <div className="reportGrid">
-              <article className="artifactCard">
-                <div className="artifactMeta">
-                  <span>artifact</span>
-                  <code>artifacts/demo/ingest/documents.jsonl</code>
-                </div>
-                <div className="docList">
-                  {documents.map((document) => (
-                    <article key={document.document_id} className="docCard">
-                      <div className="claimHeader">
-                        <strong>{document.title}</strong>
-                        <span className="pill">{document.kind}</span>
-                      </div>
-                      <div className="claimEvidence">
-                        <code>{document.document_id}</code>
-                        {document.metadata?.author ? <code>{document.metadata.author}</code> : null}
-                        {document.metadata?.channel ? <code>{document.metadata.channel}</code> : null}
-                      </div>
-                    </article>
-                  ))}
-                </div>
-              </article>
-
-              <article className="artifactCard">
-                <div className="artifactMeta">
-                  <span>summary</span>
-                  <code>{documents.length} documents</code>
-                </div>
-                <p>
-                  The source-document layer remains fully visible, so reviewers can verify evidence
-                  chains without treating the simulation or report layer as a black box.
-                </p>
-              </article>
-            </div>
-          </section>
-        </div>
-      </details>
-
+        </section>
+      </div>
     </main>
   );
 }

--- a/frontend/src/app/review/page.tsx
+++ b/frontend/src/app/review/page.tsx
@@ -1,0 +1,331 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+import { LanguageSwitch } from "../components/language-switch";
+import { ReviewRubricPanel } from "../components/review-rubric-panel";
+import { ReviewScorecard } from "../review-scorecard";
+import { getCopy } from "../lib/copy";
+import { getAppLocale } from "../lib/locale";
+import {
+  buildOverviewLines,
+  formatTurn,
+  friendlyWorldName
+} from "../lib/presenters";
+import { loadWorkbenchData } from "../lib/workbench-data";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getAppLocale();
+  return {
+    title: locale === "zh-CN" ? "Mirror 深度审阅工作区" : "Mirror Deep Review Workspace",
+    description:
+      locale === "zh-CN"
+        ? "Mirror 的双语深度审阅页，围绕 scorecard、trace、claims 和参考面板组织。"
+        : "Bilingual deep review workspace for scorecard, trace, claims, and reference inspection in Mirror."
+  };
+}
+
+export default async function ReviewPage() {
+  const locale = await getAppLocale();
+  const copy = getCopy(locale);
+  const data = await loadWorkbenchData();
+  const worldName = friendlyWorldName(locale, data.graph.world_id);
+  const divergentTurns =
+    data.reportComparison?.rows.map(({ turnIndex, reference, candidate }) => ({
+      turnIndex,
+      baselineTurnId: reference?.turn.turn_id ?? null,
+      baselineAction: reference?.turn.action_type ?? null,
+      interventionTurnId: candidate?.turn.turn_id ?? null,
+      interventionAction: candidate?.turn.action_type ?? null
+    })) ?? [];
+
+  return (
+    <main className="workbenchPage reviewPage">
+      <header className="topBar">
+        <div className="topBarBrand">
+          <p className="eyebrow">{copy.brand.eyebrow}</p>
+          <div className="topBarLinks">
+            <Link href="/">{copy.brand.dashboardLabel}</Link>
+            <span className="topBarActive">{copy.brand.reviewLabel}</span>
+          </div>
+        </div>
+        <LanguageSwitch locale={locale} />
+      </header>
+
+      <section className="reviewHero">
+        <div className="reviewHeroCopy">
+          <p className="eyebrow">{copy.review.stripTitle}</p>
+          <h1>{copy.review.title}</h1>
+          <p className="lede">{copy.review.lede}</p>
+        </div>
+        <div className="reviewHeroMeta">
+          <article className="briefCard briefCardDark">
+            <span>{copy.brand.worldLabel}</span>
+            <strong>{worldName}</strong>
+          </article>
+          <article className="briefCard">
+            <span>{copy.metrics.interventionBranches}</span>
+            <strong>{data.comparisonRuns.length}</strong>
+          </article>
+          <article className="briefCard">
+            <span>{copy.metrics.evidenceLinkedClaims}</span>
+            <strong>{data.claims.length}</strong>
+          </article>
+          <article className="briefCard">
+            <span>{copy.metrics.evalStatus}</span>
+            <strong>
+              {data.evalSummary.eval_name}: {data.evalSummary.status}
+            </strong>
+          </article>
+        </div>
+        <div className="sectionSwitch">
+          <Link className="sectionLink" href="/">
+            {copy.review.backToDashboard}
+          </Link>
+          <a className="sectionLink" href="#scorecard">
+            {copy.review.sectionNav.scorecard}
+          </a>
+          <a className="sectionLink" href="#trace-claims">
+            {copy.review.sectionNav.traceClaims}
+          </a>
+          <a className="sectionLink" href="#reference">
+            {copy.review.sectionNav.reference}
+          </a>
+          <a className="sectionLink" href="#advanced-operations">
+            {copy.review.sectionNav.advanced}
+          </a>
+        </div>
+      </section>
+
+      <ReviewRubricPanel
+        locale={locale}
+        rubricRows={data.rubricRows}
+        claimCount={data.claims.length}
+        divergentTurnCount={data.totalDivergentTurnCount}
+        evalName={data.evalSummary.eval_name}
+        evalStatus={data.evalSummary.status}
+      />
+
+      <section className="dashboardSection" id="trace-claims">
+        <div className="sectionHeading">
+          <p className="eyebrow">{copy.review.sectionNav.traceClaims}</p>
+          <h2>{copy.review.traceTitle}</h2>
+          <p>{copy.review.traceSummary}</p>
+        </div>
+        <div className="interventionBoard reviewInterventionBoard">
+          {data.comparisonOverviews.map((overview) => {
+            const lines = buildOverviewLines(locale, overview);
+            return (
+              <article key={overview.run.key} id={`trace-${overview.run.key}`} className="interventionCard">
+                <div className="interventionCardMeta">
+                  <span>{overview.run.scenario.title}</span>
+                  <code>{overview.run.scenario.scenario_id}</code>
+                </div>
+                <h3>{overview.run.label}</h3>
+                <ul className="summaryList">
+                  {lines.map((line) => (
+                    <li key={line}>{line}</li>
+                  ))}
+                </ul>
+                {overview.rows.length > 0 ? (
+                  <div className="storyboardRows">
+                    {overview.rows.slice(0, 3).map((row) => (
+                      <article key={`${overview.run.key}-${row.turnIndex}`} className="storyboardRow">
+                        <div className="storyboardRowTop">
+                          <strong>T{row.turnIndex}</strong>
+                          <span className="pill">{overview.run.branch.branch_id}</span>
+                        </div>
+                        <div className="storyboardColumns">
+                          <div className="storyboardTurn">
+                            <span>{copy.common.baseline}</span>
+                            {row.reference ? (
+                              <>
+                                <strong>{row.reference.turn.action_type}</strong>
+                                <p>{row.reference.turn.rationale}</p>
+                              </>
+                            ) : (
+                              <p>{copy.review.noDivergence}</p>
+                            )}
+                          </div>
+                          <div className="storyboardTurn">
+                            <span>{copy.common.candidate}</span>
+                            {row.candidate ? (
+                              <>
+                                <strong>{row.candidate.turn.action_type}</strong>
+                                <p>{row.candidate.turn.rationale}</p>
+                              </>
+                            ) : (
+                              <p>{copy.review.noDivergence}</p>
+                            )}
+                          </div>
+                        </div>
+                      </article>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="subtle">{copy.review.noDivergence}</p>
+                )}
+              </article>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="dashboardSection" id="claims">
+        <div className="sectionHeading">
+          <p className="eyebrow">{copy.review.claimsTitle}</p>
+          <h2>{copy.review.claimsSummary}</h2>
+        </div>
+        <div className="claimSnapshotGrid">
+          {data.claimDrilldowns.map(({ claim, evidenceChunks, relatedTurns }) => (
+            <article key={claim.claim_id} className="claimSnapshotCard claimSnapshotCardExpanded">
+              <div className="interventionCardMeta">
+                <span>{claim.claim_id}</span>
+                <span className="pill">{claim.label}</span>
+              </div>
+              <p>{claim.text}</p>
+              <div className="claimEvidence">
+                {claim.evidence_ids.map((evidenceId) => (
+                  <code key={evidenceId}>{evidenceId}</code>
+                ))}
+              </div>
+              <div className="subsectionBlock">
+                <h3>{copy.common.jumpToEvidence}</h3>
+                <div className="miniList">
+                  {evidenceChunks.map(({ chunk, document }) => (
+                    <article key={chunk.chunk_id} className="miniCard">
+                      <strong>{document?.title ?? chunk.document_id}</strong>
+                      <p>{chunk.text}</p>
+                    </article>
+                  ))}
+                </div>
+              </div>
+              <div className="subsectionBlock">
+                <h3>{copy.common.jumpToTrace}</h3>
+                <div className="miniList">
+                  {relatedTurns.map((entry) => (
+                    <article key={entry.turn.turn_id} className="miniCard">
+                      <strong>{entry.turn.turn_id}</strong>
+                      <p>{entry.turn.rationale}</p>
+                    </article>
+                  ))}
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="dashboardSection" id="reference">
+        <div className="sectionHeading">
+          <p className="eyebrow">{copy.review.sectionNav.reference}</p>
+          <h2>{copy.review.referenceTitle}</h2>
+          <p>{copy.review.referenceSummary}</p>
+        </div>
+        <div className="dashboardSplit">
+          <article className="referenceCard">
+            <div className="interventionCardMeta">
+              <span>{copy.review.rawReportTitle}</span>
+              <code>artifacts/demo/report/report.md</code>
+            </div>
+            <p>{copy.review.rawReportSummary}</p>
+            <pre className="artifactPre artifactPreCompact">{data.report}</pre>
+          </article>
+
+          <article className="referenceCard">
+            <div className="interventionCardMeta">
+              <span>{copy.review.graphTitle}</span>
+              <code>artifacts/demo/graph/graph.json</code>
+            </div>
+            <div className="briefSummaryGrid">
+              {Object.entries(data.graph.stats).map(([key, value]) => (
+                <article key={key} className="briefCard">
+                  <span>{key}</span>
+                  <strong>{value}</strong>
+                </article>
+              ))}
+            </div>
+          </article>
+        </div>
+
+        <div className="dashboardSplit">
+          <article className="referenceCard">
+            <div className="interventionCardMeta">
+              <span>{copy.review.scenariosTitle}</span>
+              <code>artifacts/demo/scenario</code>
+            </div>
+            <div className="miniList">
+              {data.runs.map((run) => (
+                <article key={run.key} className="miniCard">
+                  <strong>{run.scenario.title}</strong>
+                  <p>{run.scenario.description}</p>
+                  <div className="claimEvidence">
+                    <code>{run.scenario.scenario_id}</code>
+                    <code>branch_count={run.scenario.branch_count}</code>
+                    <code>turn_budget={run.scenario.turn_budget}</code>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </article>
+
+          <article className="referenceCard">
+            <div className="interventionCardMeta">
+              <span>{copy.review.documentTitle}</span>
+              <code>artifacts/demo/ingest/documents.jsonl</code>
+            </div>
+            <div className="miniList">
+              {data.documents.map((document) => (
+                <article key={document.document_id} className="miniCard">
+                  <strong>{document.title}</strong>
+                  <div className="claimEvidence">
+                    <code>{document.document_id}</code>
+                    <code>{document.kind}</code>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section className="dashboardSection" id="advanced-operations">
+        <div className="sectionHeading">
+          <p className="eyebrow">{copy.review.sectionNav.advanced}</p>
+          <h2>{copy.review.advancedTitle}</h2>
+          <p>{copy.review.advancedSummary}</p>
+        </div>
+        <details className="editorialDrawer">
+          <summary className="editorialDrawerSummary">
+            <div>
+              <strong>{copy.review.legacyOperationsTitle}</strong>
+              <span>{copy.review.legacyOperationsSummary}</span>
+            </div>
+            <span className="pill">{copy.review.legacyOperationsDisclosure}</span>
+          </summary>
+          <div className="editorialDrawerBody">
+            <p className="editorialDrawerNote">
+              {locale === "zh-CN"
+                ? "下方面板为了兼容旧工作流暂时保留英文文案。当前推荐的双语审阅路径仍以上面的 scorecard、trace、claims 和 reference 为主。"
+                : "The panel below remains English-first for compatibility with the older workflow. The primary bilingual review path stays in the scorecard, trace, claims, and reference sections above."}
+            </p>
+            <div lang="en">
+              <ReviewScorecard
+                rubricRows={data.rubricRows}
+                claimCount={data.claims.length}
+                divergentTurnCount={data.reportComparison?.divergentTurnCount ?? 0}
+                evalName={data.evalSummary.eval_name}
+                evalStatus={data.evalSummary.status}
+                claimPackets={data.claims.map((claim) => ({
+                  claimId: claim.claim_id,
+                  text: claim.text,
+                  relatedTurnIds: claim.related_turn_ids.filter(Boolean)
+                }))}
+                divergentTurns={divergentTurns}
+              />
+            </div>
+          </div>
+        </details>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- rebuild the homepage into an editorial-style bilingual briefing dashboard
- add a dedicated `/review` deep-review workspace with clearer section hierarchy
- introduce lightweight `mirror-lang` cookie-based language switching without changing backend APIs or artifact contracts

## Validation
- npm run build --prefix frontend
- ./make.ps1 smoke
- ./make.ps1 test
- ./make.ps1 eval-demo
- python -m backend.app.cli classify-lane --files frontend/src/app/README.md frontend/src/app/globals.css frontend/src/app/layout.tsx frontend/src/app/page.tsx frontend/src/app/components/language-switch.tsx frontend/src/app/components/review-rubric-panel.tsx frontend/src/app/lib/locale.ts frontend/src/app/lib/locale-shared.ts frontend/src/app/lib/copy.ts frontend/src/app/lib/presenters.ts frontend/src/app/lib/workbench-data.ts frontend/src/app/review/page.tsx