### PR TITLE
[codex] Polish zh UI and reduce raw artifact exposure

### DIFF
--- a/frontend/src/app/components/review-rubric-panel.tsx
+++ b/frontend/src/app/components/review-rubric-panel.tsx
@@ -5,6 +5,10 @@ import { useMemo, useState } from "react";
 import type { AppLocale } from "../lib/locale-shared";
 import type { RubricRow } from "../lib/workbench-data";
 import { getCopy } from "../lib/copy";
+import {
+  formatEvalPosture,
+  localizeRubricRow
+} from "../lib/presenters";
 
 type ReviewRubricPanelProps = {
   locale: AppLocale;
@@ -86,18 +90,18 @@ export function ReviewRubricPanel({
         </article>
         <article className="briefCard">
           <span>{copy.rubric.evalPosture}</span>
-          <strong>
-            {evalName}: {evalStatus}
-          </strong>
+          <strong>{formatEvalPosture(locale, evalName, evalStatus)}</strong>
         </article>
       </div>
 
       <div className="rubricGrid">
-        {rubricRows.map((row) => (
+        {rubricRows.map((row) => {
+          const localizedRow = localizeRubricRow(locale, row);
+          return (
           <article key={row.dimension} className="rubricCard">
             <div className="rubricCardHeader">
               <div>
-                <h3>{row.dimension}</h3>
+                <h3>{localizedRow.dimension}</h3>
                 <p className="subtle">{scoreLabel(locale, scores[row.dimension])}</p>
               </div>
               <span className="pill">{copy.rubric.scoreLegend}</span>
@@ -116,17 +120,17 @@ export function ReviewRubricPanel({
             </div>
             <div className="rubricAnchors">
               <p>
-                <strong>1</strong> {row.one}
+                <strong>1</strong> {localizedRow.one}
               </p>
               <p>
-                <strong>3</strong> {row.three}
+                <strong>3</strong> {localizedRow.three}
               </p>
               <p>
-                <strong>5</strong> {row.five}
+                <strong>5</strong> {localizedRow.five}
               </p>
             </div>
           </article>
-        ))}
+        )})}
       </div>
 
       <div className="rubricNotes">

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -176,6 +176,11 @@ p {
   line-height: 1.65;
 }
 
+.lede,
+.sectionHeading p {
+  font-size: 0.98rem;
+}
+
 .heroPanel,
 .dashboardSection,
 .reviewHero,
@@ -247,6 +252,25 @@ p {
   border-color: rgba(240, 223, 195, 0.45);
 }
 
+.surfaceAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 11px 16px;
+  border-radius: 999px;
+  text-decoration: none;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.08);
+  color: #f7f1e7;
+  font-weight: 600;
+}
+
+.surfaceActionPrimary {
+  background: #f0dfc3;
+  color: #1f1812;
+  border-color: rgba(240, 223, 195, 0.45);
+}
+
 .briefSummaryGrid,
 .rubricSummaryGrid,
 .metricGrid {
@@ -266,8 +290,14 @@ p {
 }
 
 .briefCardDark {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.04));
-  border-color: rgba(255, 255, 255, 0.12);
+  background: linear-gradient(145deg, rgba(22, 36, 34, 0.96), rgba(34, 28, 21, 0.94));
+  border-color: rgba(17, 77, 71, 0.3);
+  color: #fff7eb;
+}
+
+.briefCardDark span,
+.briefCardDark strong {
+  color: inherit;
 }
 
 .briefCardWide {
@@ -351,6 +381,16 @@ p {
   border-radius: 24px;
   background: var(--panel-strong);
   border: 1px solid var(--border);
+}
+
+.routeCard h3,
+.interventionCard h3,
+.storyboardCard h3,
+.claimSnapshotCard h3,
+.referenceCard h3,
+.rubricCard h3 {
+  font-size: 1.24rem;
+  line-height: 1.18;
 }
 
 .interventionCardReference {
@@ -458,6 +498,12 @@ p {
   border: 1px solid rgba(30, 114, 104, 0.08);
 }
 
+.storyboardTurn strong,
+.miniCard strong {
+  font-size: 1rem;
+  line-height: 1.35;
+}
+
 .storyboardTurn span,
 .rubricCardHeader .subtle {
   font-size: 0.8rem;
@@ -485,6 +531,16 @@ p {
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.78);
   border: 1px solid rgba(30, 114, 104, 0.1);
+}
+
+.dashboardCallout {
+  background: linear-gradient(145deg, rgba(20, 30, 28, 0.96), rgba(34, 27, 21, 0.94));
+  border-color: rgba(17, 77, 71, 0.28);
+  color: #fff8ef;
+}
+
+.dashboardCallout .subtle {
+  color: rgba(245, 237, 225, 0.78);
 }
 
 .reviewPage {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -655,6 +655,31 @@ p {
   line-height: 1.65;
 }
 
+.inlineDetails {
+  border-radius: 18px;
+  border: 1px solid rgba(30, 114, 104, 0.12);
+  background: rgba(255, 255, 255, 0.7);
+  overflow: hidden;
+}
+
+.inlineDetailsSummary {
+  list-style: none;
+  cursor: pointer;
+  padding: 14px 16px;
+  font-weight: 700;
+  color: var(--accent-strong);
+}
+
+.inlineDetailsSummary::-webkit-details-marker {
+  display: none;
+}
+
+.inlineDetailsBody {
+  display: grid;
+  gap: 14px;
+  padding: 0 16px 16px;
+}
+
 .drawerSection {
   backdrop-filter: blur(10px);
   background: var(--panel);

--- a/frontend/src/app/lib/copy.ts
+++ b/frontend/src/app/lib/copy.ts
@@ -281,7 +281,7 @@ const chineseCopy: Copy = {
   brand: {
     eyebrow: "Mirror Engine / 编辑部指挥台工作区",
     worldLabel: "当前世界",
-    compareArtifactLabel: "Compare 产物",
+    compareArtifactLabel: "对比产物",
     sourceArtifactLabel: "原始产物",
     dashboardLabel: "总览台",
     reviewLabel: "深度审阅",
@@ -290,31 +290,31 @@ const chineseCopy: Copy = {
   dashboard: {
     title: "先读结果，再判断哪里值得继续深挖。",
     lede:
-      "这个首页把 canonical compare artifact 组织成一块编辑部 briefing board：哪条干预改变了结果，哪条只是改变了路径，证据链该从哪里看起，以及什么时候才值得打开更重的审阅工作区。",
+      "这个首页把标准对比产物整理成一块编辑部简报板：哪条干预改变了结果，哪条只是改变了路径，证据链该从哪里看起，以及什么时候才值得打开更重的审阅工作区。",
     currentPair: "当前报告对比",
-    loadedBranches: "canonical 场景分支",
-    interventionCount: "相对 baseline 的干预对比",
+    loadedBranches: "标准场景分支",
+    interventionCount: "相对基线的干预对比",
     jumpToReview: "进入深度审阅",
     jumpToReference: "打开参考面板",
     routeEyebrow: "默认路径",
-    routeTitle: "先走 compare、trace、evidence、eval，再决定是否进入更重的审阅机制。",
+    routeTitle: "先看对比、轨迹、证据与评测，再决定是否进入更重的审阅流程。",
     routeSummary:
-      "首页现在应该像一块 briefing board，而不是一页 dump。它先告诉你发生了什么、为什么重要、下一步该看哪里。",
+      "首页现在应该像一块简报板，而不是一页信息倾倒。它先告诉你发生了什么、为什么重要、下一步该看哪里。",
     interventionEyebrow: "干预摘要板",
-    interventionTitle: "每条 intervention 都先给出强摘要卡，再给 drill-down。",
+    interventionTitle: "每条干预都先给出强摘要卡，再给出深入查看入口。",
     interventionSummary:
-      "下面的卡片优先强调结果变化、纯路径漂移，以及下一步查看入口，而不是重复整块 artifact 内容。",
-    storyboardEyebrow: "Trace 分镜",
-    storyboardTitle: "只预览真正发生分歧的 turn。",
-    claimEyebrow: "Claims 与 Eval",
-    claimTitle: "让 evidence-linked claims 和完整性状态可以一眼扫读。",
+      "下面的卡片优先强调结果变化、纯路径漂移，以及下一步查看入口，而不是重复整块原始产物内容。",
+    storyboardEyebrow: "轨迹分镜",
+    storyboardTitle: "只预览真正发生分歧的回合。",
+    claimEyebrow: "论点与评测",
+    claimTitle: "让证据关联的论点与完整性状态可以一眼扫读。",
     evalEyebrow: "审阅交接",
     evalTitle: "用首页先判断是否需要继续进入深度审阅，而不是默认把整套重型工具全部打开。",
     scorecardNote:
-      "完整的 review scorecard、routing 逻辑和历史重型 surface 依然保留，但它们现在统一收进深度审阅工作区。",
+      "完整的审阅评分卡、路由逻辑和历史重型操作面依然保留，但它们现在统一收进深度审阅工作区。",
     openReview: "进入审阅工作区",
-    openTrace: "查看 trace",
-    openClaims: "查看 claims",
+    openTrace: "查看轨迹",
+    openClaims: "查看论点",
     openReference: "查看参考"
   },
   routeSteps: [
@@ -325,18 +325,18 @@ const chineseCopy: Copy = {
     },
     {
       step: "02",
-      title: "回放分歧 turn",
+      title: "回放分歧回合",
       summary: "先看短分镜，再决定是否需要打开完整分支时间线。"
     },
     {
       step: "03",
-      title: "核对 claims 与证据",
-      summary: "确认哪些 claim 是被证据支撑的，以及它们依赖哪些 turn 或 chunk。"
+      title: "核对论点与证据",
+      summary: "确认哪些论点是被证据支撑的，以及它们依赖哪些回合或文本块。"
     },
     {
       step: "04",
-      title: "确认 eval 状态",
-      summary: "把 eval 当作完整性门槛，再决定是否继续更深的审阅。"
+      title: "确认评测状态",
+      summary: "把评测当作完整性门槛，再决定是否继续更深的审阅。"
     }
   ],
   metrics: {
@@ -349,63 +349,63 @@ const chineseCopy: Copy = {
     budgetExposed: "预算曝光",
     ledgerPublic: "账本公开",
     evacuation: "疏散触发",
-    divergentTurns: "分歧 turns",
-    evidenceLinkedClaims: "证据关联 claims",
-    evalStatus: "Eval 状态"
+    divergentTurns: "分歧回合",
+    evidenceLinkedClaims: "证据关联论点",
+    evalStatus: "评测状态"
   },
   review: {
-    title: "深度审阅把 scorecard 放在最前面，trace、claims、reference 和 advanced operations 都退到它之后。",
+    title: "深度审阅把评分卡放在最前面，轨迹、论点、参考面板和高级操作都退到它之后。",
     lede:
-      "这里是操作员工作区。先完成 scorecard，再看 trace 与 claims；只有在需要时才进入 reference，并把历史重型 tooling 放在明确的 advanced 边界之后。",
+      "这里是操作员工作区。先完成评分卡，再看轨迹与论点；只有在需要时才进入参考面板，并把历史重型工具收在明确的高级边界之后。",
     backToDashboard: "返回总览台",
     stripTitle: "审阅摘要条",
     sectionNav: {
       scorecard: "评分卡",
-      traceClaims: "Trace 与 Claims",
+      traceClaims: "轨迹与论点",
       reference: "参考面板",
       advanced: "高级操作"
     },
     scorecardTitle: "先给当前分支打分，再决定是否值得掉进重型工具。",
     scorecardSummary:
       "评分卡现在是深度审阅的主入口。它先总结可信度、薄弱维度，以及当前分支是否值得继续升级审阅，还是先补证据。",
-    traceTitle: "Trace 与 Claims",
+    traceTitle: "轨迹与论点",
     traceSummary:
-      "用这里把分歧 turns 与 evidence-linked claims 连起来，而不是一上来就重新打开整条原始 branch 历史。",
-    claimsTitle: "Claim drill-down",
+      "用这里把分歧回合与证据关联论点连起来，而不是一上来就重新打开整条原始分支历史。",
+    claimsTitle: "论点下钻",
     claimsSummary:
-      "Claims 继续保持 evidence-linked 和可追踪。每张卡片都展示支撑它的 chunks 和相关 turns。",
+      "论点继续保持证据关联和可追踪。每张卡片都展示支撑它的文本块和相关回合。",
     referenceTitle: "参考面板",
     referenceSummary:
-      "这些面板让 scenarios、graph、documents 和原始 report 都可达，但不会再主导首读体验。",
+      "这些面板让场景、图谱、文档和原始报告都可触达，但不再主导首读体验。",
     advancedTitle: "高级操作",
     advancedSummary:
-      "历史上的 packet、delivery 和重型操作 surface 继续保留，但它们明确退居为次级路径。",
+      "历史上的数据包、交付和重型操作面继续保留，但它们明确退居为次级路径。",
     legacyOperationsTitle: "历史操作工作区",
     legacyOperationsSummary:
-      "只有当你确实需要旧的 packet-heavy review tooling 时才打开这里。它仍然可用，但不再定义整个页面。",
+      "只有当你确实需要旧的重型审阅工具时才打开这里。它仍然可用，但不再定义整个页面。",
     legacyOperationsDisclosure: "打开历史操作面",
     rawReportTitle: "原始报告产物",
     rawReportSummary:
-      "这个面板展示原始 artifact 内容。外围 UI 是双语的，但 artifact 正文本体保持源内容原样。",
+      "这个面板展示原始产物内容。外围界面是双语的，但产物正文保持源内容原样。",
     documentTitle: "源文档",
     graphTitle: "图谱快照",
     scenariosTitle: "场景卡片",
     openSourceArtifact: "打开原始产物",
-    noDivergence: "这个分支没有记录到分歧 turn。",
-    noTarget: "没有显式 target"
+    noDivergence: "这个分支没有记录到分歧回合。",
+    noTarget: "没有明确目标"
   },
   rubric: {
     title: "审阅评分卡",
     helper:
-      "在展开更重的操作面之前，先从 usefulness、credibility、explainability 和 actionability 四个维度为当前分支打分。",
+      "在展开更重的操作面之前，先从有用性、可信度、可解释性和可行动性四个维度为当前分支打分。",
     notesLabel: "审阅备注",
     notesPlaceholder: "记录哪里还薄弱、哪里已经可信，以及下一步应该怎么推进。",
     dimensionsComplete: "已评分维度",
-    evidenceTracked: "证据关联 claims",
-    divergentTurns: "分歧 turns",
-    evalPosture: "Eval 状态",
+    evidenceTracked: "证据关联论点",
+    divergentTurns: "分歧回合",
+    evalPosture: "评测状态",
     recommendationLabel: "当前建议",
-    recommendationReady: "这个分支已经足够稳，可以继续进入更深审阅或受控 sign-off。",
+    recommendationReady: "这个分支已经足够稳，可以继续进入更深审阅或受控结论确认。",
     recommendationFollowup: "这个分支可以继续，但至少还有一个维度需要补强后再做强交接。",
     recommendationHold: "先停在这里，补齐最弱维度后再继续升级。",
     recommendationIncomplete: "先完成评分卡，再给出审阅建议。",
@@ -418,14 +418,14 @@ const chineseCopy: Copy = {
     routeOnlyDelta: "仅路径变化",
     timingDrift: "时间漂移",
     knowledgeShift: "知识扩散变化",
-    baseline: "Baseline",
-    candidate: "Candidate",
+    baseline: "基线",
+    candidate: "候选分支",
     rawArtifact: "原始产物",
     jumpToReview: "跳到审阅",
-    jumpToTrace: "Trace",
-    jumpToClaims: "Claims",
+    jumpToTrace: "轨迹",
+    jumpToClaims: "论点",
     jumpToEvidence: "证据",
-    jumpToEval: "Eval"
+    jumpToEval: "评测"
   }
 };
 

--- a/frontend/src/app/lib/presenters.ts
+++ b/frontend/src/app/lib/presenters.ts
@@ -1,24 +1,147 @@
-import type { ComparisonOverview, CompareOutcomeDelta } from "./workbench-data";
+import type {
+  ComparisonOverview,
+  CompareOutcomeDelta,
+  RubricRow
+} from "./workbench-data";
 import type { AppLocale } from "./locale-shared";
+
+type LocalizedRubricRow = {
+  dimension: string;
+  one: string;
+  three: string;
+  five: string;
+};
+
+const scenarioTitlesZh: Record<string, string> = {
+  baseline: "东闸门基线响应",
+  harbor_comms_failure: "港口通信故障导致预警转发延迟",
+  mayor_signal_blocked: "潮汐预警期间市长信号受阻",
+  reporter_detained: "记者发布前被拖延"
+};
+
+const scenarioDescriptionsZh: Record<string, string> = {
+  baseline:
+    "基线分支假设档案账本副本按时流转，除了语料中已经描述的危机之外，不再额外注入通信扰动。",
+  harbor_comms_failure:
+    "海水干扰使港口无线电在早期预警窗口离线，导致潮汐警报和维护账本副本的首次公开机会都被推迟。",
+  mayor_signal_blocked:
+    "陈宇在第一次预警尝试中无法联系赵科，因此副市长错过了直接的潮汐升级信号，即便账本仍按计划公开。",
+  reporter_detained:
+    "运送账本的记者被中途拦阻，因此维护记录副本进入公众决策链路的时间晚于基线。"
+};
+
+const evalNamesZh: Record<string, string> = {
+  fog_harbor_phase44_matrix: "雾港场景矩阵评测"
+};
+
+const evalStatusesZh: Record<string, string> = {
+  pass: "通过",
+  fail: "失败",
+  error: "错误",
+  pending: "进行中",
+  running: "运行中",
+  blocked: "阻塞"
+};
+
+const evalMetricLabelsZh: Record<string, string> = {
+  checks_total: "检查总数",
+  checks_passed: "通过检查",
+  scenario_count: "场景数",
+  event_count: "事件数",
+  baseline_evacuation_turn: "基线疏散回合",
+  harbor_comms_failure_evacuation_turn: "通信故障分支疏散回合",
+  mayor_signal_blocked_evacuation_turn: "信号受阻分支疏散回合",
+  reporter_detained_evacuation_turn: "记者受阻分支疏散回合",
+  baseline_ledger_public_turn: "基线账本公开回合",
+  harbor_comms_failure_ledger_public_turn: "通信故障分支账本公开回合",
+  mayor_signal_blocked_ledger_public_turn: "信号受阻分支账本公开回合",
+  reporter_detained_ledger_public_turn: "记者受阻分支账本公开回合"
+};
+
+const graphStatLabelsZh: Record<string, string> = {
+  entity_count: "实体数",
+  relation_count: "关系数",
+  event_count: "事件数",
+  chunk_count: "文本块数"
+};
+
+const claimLabelsZh: Record<string, string> = {
+  evidence_backed: "证据支撑"
+};
+
+const documentKindLabelsZh: Record<string, string> = {
+  bulletin: "公告",
+  dispatch_notes: "调度记录",
+  inspection_report: "检查报告",
+  ledger_copy: "账本副本",
+  minutes: "会议纪要",
+  vessel_log: "船只日志"
+};
+
+const actionTypeLabelsZh: Record<string, string> = {
+  delay: "延迟",
+  evacuate: "疏散",
+  hide: "隐藏",
+  inform: "通报",
+  inspect: "检查",
+  move: "转移",
+  publish: "公开",
+  request: "请求"
+};
+
+const rubricDimensionLabelsZh: Record<string, string> = {
+  Usefulness: "有用性",
+  Credibility: "可信度",
+  Explainability: "可解释性",
+  Actionability: "可行动性"
+};
+
+const rubricAnchorLabelsZh: Record<string, string> = {
+  "Adds no new understanding": "没有带来新的理解",
+  "Some useful contrast": "提供了一些有用对比",
+  "Clearly clarifies branch differences": "能够清楚说明分支差异",
+  "Reads like guesswork": "读起来像猜测",
+  "Partly grounded": "部分有依据",
+  "Evidence boundaries are clear": "证据边界清晰",
+  "Hard to trace": "难以追踪复盘",
+  "Mostly understandable": "大体可以理解",
+  "Easy to replay from trace": "可以轻松从轨迹重放",
+  "No next step is obvious": "看不出下一步",
+  "Some follow-up hints": "给出了一些后续提示",
+  "Clear next engineering/product step": "明确指向下一步工程或产品动作"
+};
+
+function normalizeScenarioKey(scenarioId: string | undefined) {
+  if (!scenarioId) {
+    return "";
+  }
+  return scenarioId.startsWith("scenario_") ? scenarioId.slice("scenario_".length) : scenarioId;
+}
 
 function formatTurnLabel(locale: AppLocale, turn: number | null | undefined) {
   if (typeof turn !== "number") {
-    return locale === "zh-CN" ? "未触发" : "Not reached";
+    return locale === "zh-CN" ? "未触达" : "Not reached";
   }
   return `T${turn}`;
 }
 
-export function formatDeltaLabel(locale: AppLocale, delta: number | null) {
-  if (delta === null) {
-    return locale === "zh-CN" ? "n/a" : "n/a";
+function formatCountSuffix(locale: AppLocale, value: number, singular: string, plural: string) {
+  if (locale === "zh-CN") {
+    return `${value} 回合`;
   }
-  if (delta === 0) {
-    return locale === "zh-CN" ? "0 回合" : "0 turns";
+  return `${value} ${value === 1 ? singular : plural}`;
+}
+
+function localizeForZh(
+  locale: AppLocale,
+  mappings: Record<string, string>,
+  key: string | undefined,
+  fallback: string
+) {
+  if (locale !== "zh-CN" || !key) {
+    return fallback;
   }
-  const prefix = delta > 0 ? "+" : "-";
-  return locale === "zh-CN"
-    ? `${prefix}${Math.abs(delta)} 回合`
-    : `${prefix}${Math.abs(delta)} turn${Math.abs(delta) === 1 ? "" : "s"}`;
+  return mappings[key] ?? fallback;
 }
 
 function summarizeTurnOutcome(
@@ -28,7 +151,7 @@ function summarizeTurnOutcome(
 ) {
   if (!outcome) {
     return locale === "zh-CN"
-      ? `${label} 未在 compare 产物中记录。`
+      ? `${label} 未在对比产物中记录。`
       : `${label} is not recorded in the compare artifact.`;
   }
 
@@ -71,14 +194,27 @@ function summarizeTurnOutcome(
   }
 
   return locale === "zh-CN"
-    ? `${label} 与 baseline 保持同一时间点 ${formatTurnLabel(locale, resolvedCandidateTurn)}。`
+    ? `${label} 与基线保持同一时间点 ${formatTurnLabel(locale, resolvedCandidateTurn)}。`
     : `${label} stays on the baseline timing at ${formatTurnLabel(locale, resolvedCandidateTurn)}.`;
+}
+
+export function formatDeltaLabel(locale: AppLocale, delta: number | null) {
+  if (delta === null) {
+    return "n/a";
+  }
+  if (delta === 0) {
+    return locale === "zh-CN" ? "0 回合" : "0 turns";
+  }
+  const prefix = delta > 0 ? "+" : "-";
+  return locale === "zh-CN"
+    ? `${prefix}${Math.abs(delta)} 回合`
+    : `${prefix}${Math.abs(delta)} turn${Math.abs(delta) === 1 ? "" : "s"}`;
 }
 
 export function summarizeRiskShift(locale: AppLocale, outcome: CompareOutcomeDelta | undefined) {
   if (!outcome) {
     return locale === "zh-CN"
-      ? "compare 产物没有记录这条分支的风险扩散变化。"
+      ? "对比产物没有记录这条分支的风险认知变化。"
       : "The compare artifact does not record any risk-awareness delta for this branch.";
   }
 
@@ -94,43 +230,141 @@ export function summarizeRiskShift(locale: AppLocale, outcome: CompareOutcomeDel
 
   if (removed.length === 0 && added.length === 0) {
     return locale === "zh-CN"
-      ? "风险认知到达的 actor 集合与 baseline 一致。"
+      ? "风险认知到达的角色集合与基线一致。"
       : "Risk awareness reaches the same actor set as baseline.";
   }
 
   if (removed.length > 0 && added.length === 0) {
     return locale === "zh-CN"
-      ? `风险认知不再到达 ${removed.join(", ")}。`
+      ? `风险认知不再到达 ${removed.join("、")}。`
       : `Risk awareness no longer reaches ${removed.join(", ")} in this branch.`;
   }
 
   if (added.length > 0 && removed.length === 0) {
     return locale === "zh-CN"
-      ? `风险认知扩展到了 ${added.join(", ")}。`
+      ? `风险认知扩展到了 ${added.join("、")}。`
       : `Risk awareness expands to ${added.join(", ")} in this branch.`;
   }
 
   return locale === "zh-CN"
-    ? `风险认知路径发生改道：移除 ${removed.join(", ")}，新增 ${added.join(", ")}。`
+    ? `风险认知路径发生改道：移除 ${removed.join("、")}，新增 ${added.join("、")}。`
     : `Risk awareness reroutes: removed ${removed.join(", ")}; added ${added.join(", ")}.`;
 }
 
 export function buildOverviewLines(locale: AppLocale, overview: ComparisonOverview) {
   return [
-    summarizeTurnOutcome(locale, locale === "zh-CN" ? "预算曝光" : "Budget exposure", overview.delta.outcome_deltas.budget_exposed_turn),
-    summarizeTurnOutcome(locale, locale === "zh-CN" ? "账本公开" : "Ledger publication", overview.delta.outcome_deltas.ledger_public_turn),
-    summarizeTurnOutcome(locale, locale === "zh-CN" ? "疏散触发" : "Evacuation", overview.delta.outcome_deltas.evacuation_turn),
+    summarizeTurnOutcome(
+      locale,
+      locale === "zh-CN" ? "预算曝光" : "Budget exposure",
+      overview.delta.outcome_deltas.budget_exposed_turn
+    ),
+    summarizeTurnOutcome(
+      locale,
+      locale === "zh-CN" ? "账本公开" : "Ledger publication",
+      overview.delta.outcome_deltas.ledger_public_turn
+    ),
+    summarizeTurnOutcome(
+      locale,
+      locale === "zh-CN" ? "疏散触发" : "Evacuation",
+      overview.delta.outcome_deltas.evacuation_turn
+    ),
     summarizeRiskShift(locale, overview.delta.outcome_deltas.risk_known_by)
   ];
 }
 
 export function friendlyWorldName(locale: AppLocale, worldId: string | undefined) {
   if (worldId === "fog-harbor-east-gate") {
-    return locale === "zh-CN" ? "雾港东闸危机" : "Fog Harbor East Gate";
+    return locale === "zh-CN" ? "雾港东闸门危机" : "Fog Harbor East Gate";
   }
   return worldId ?? (locale === "zh-CN" ? "未知世界" : "Unknown world");
 }
 
 export function formatTurn(locale: AppLocale, turn: number | null | undefined) {
   return formatTurnLabel(locale, turn);
+}
+
+export function localizeScenarioTitle(locale: AppLocale, scenarioId: string | undefined, fallback: string) {
+  return localizeForZh(locale, scenarioTitlesZh, normalizeScenarioKey(scenarioId), fallback);
+}
+
+export function localizeScenarioDescription(
+  locale: AppLocale,
+  scenarioId: string | undefined,
+  fallback: string
+) {
+  return localizeForZh(locale, scenarioDescriptionsZh, normalizeScenarioKey(scenarioId), fallback);
+}
+
+export function localizeBranchLabel(locale: AppLocale, scenarioId: string | undefined, fallback: string) {
+  const normalizedScenarioId = normalizeScenarioKey(scenarioId);
+  if (locale !== "zh-CN") {
+    return fallback;
+  }
+  if (normalizedScenarioId === "baseline") {
+    return "基线分支";
+  }
+  return scenarioTitlesZh[normalizedScenarioId] ?? fallback;
+}
+
+export function localizeEvalName(locale: AppLocale, evalName: string) {
+  return localizeForZh(locale, evalNamesZh, evalName, evalName);
+}
+
+export function localizeEvalStatus(locale: AppLocale, status: string) {
+  return localizeForZh(locale, evalStatusesZh, status, status);
+}
+
+export function localizeEvalMetricKey(locale: AppLocale, key: string) {
+  return localizeForZh(locale, evalMetricLabelsZh, key, key);
+}
+
+export function localizeGraphStatKey(locale: AppLocale, key: string) {
+  return localizeForZh(locale, graphStatLabelsZh, key, key);
+}
+
+export function localizeClaimLabel(locale: AppLocale, label: string) {
+  return localizeForZh(locale, claimLabelsZh, label, label);
+}
+
+export function localizeDocumentKind(locale: AppLocale, kind: string) {
+  return localizeForZh(locale, documentKindLabelsZh, kind, kind);
+}
+
+export function localizeActionType(locale: AppLocale, actionType: string) {
+  return localizeForZh(locale, actionTypeLabelsZh, actionType, actionType);
+}
+
+export function localizeRubricRow(locale: AppLocale, row: RubricRow): LocalizedRubricRow {
+  if (locale !== "zh-CN") {
+    return row;
+  }
+
+  return {
+    dimension: rubricDimensionLabelsZh[row.dimension] ?? row.dimension,
+    one: rubricAnchorLabelsZh[row.one] ?? row.one,
+    three: rubricAnchorLabelsZh[row.three] ?? row.three,
+    five: rubricAnchorLabelsZh[row.five] ?? row.five
+  };
+}
+
+export function formatEvalPosture(locale: AppLocale, evalName: string, evalStatus: string) {
+  return `${localizeEvalName(locale, evalName)}: ${localizeEvalStatus(locale, evalStatus)}`;
+}
+
+export function formatScenarioMeta(locale: AppLocale, key: "branch_count" | "turn_budget", value: number) {
+  if (locale !== "zh-CN") {
+    return `${key}=${value}`;
+  }
+
+  if (key === "branch_count") {
+    return `分支数=${value}`;
+  }
+
+  return `回合预算=${value}`;
+}
+
+export function formatDivergentTurnCount(locale: AppLocale, value: number) {
+  return locale === "zh-CN"
+    ? `${value} 个分歧回合`
+    : formatCountSuffix(locale, value, "divergent turn", "divergent turns");
 }

--- a/frontend/src/app/lib/presenters.ts
+++ b/frontend/src/app/lib/presenters.ts
@@ -132,6 +132,13 @@ function formatCountSuffix(locale: AppLocale, value: number, singular: string, p
   return `${value} ${value === 1 ? singular : plural}`;
 }
 
+function formatItemCount(locale: AppLocale, value: number, singular: string, plural: string, zhUnit: string) {
+  if (locale === "zh-CN") {
+    return `${value} ${zhUnit}`;
+  }
+  return `${value} ${value === 1 ? singular : plural}`;
+}
+
 function localizeForZh(
   locale: AppLocale,
   mappings: Record<string, string>,
@@ -367,4 +374,24 @@ export function formatDivergentTurnCount(locale: AppLocale, value: number) {
   return locale === "zh-CN"
     ? `${value} 个分歧回合`
     : formatCountSuffix(locale, value, "divergent turn", "divergent turns");
+}
+
+export function formatEvidenceCount(locale: AppLocale, value: number) {
+  return formatItemCount(locale, value, "evidence item", "evidence items", "份证据");
+}
+
+export function formatDocumentCount(locale: AppLocale, value: number) {
+  return formatItemCount(locale, value, "source document", "source documents", "份来源文档");
+}
+
+export function formatRelatedTurnCount(locale: AppLocale, value: number) {
+  return formatItemCount(locale, value, "related turn", "related turns", "个关联回合");
+}
+
+export function formatParagraphCount(locale: AppLocale, value: number) {
+  return formatItemCount(locale, value, "report section", "report sections", "段报告内容");
+}
+
+export function formatClaimCount(locale: AppLocale, value: number) {
+  return formatItemCount(locale, value, "claim", "claims", "条论点");
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,10 +5,13 @@ import { LanguageSwitch } from "./components/language-switch";
 import { getCopy } from "./lib/copy";
 import { getAppLocale } from "./lib/locale";
 import {
+  formatDocumentCount,
   buildOverviewLines,
   formatDivergentTurnCount,
   formatDeltaLabel,
+  formatEvidenceCount,
   formatEvalPosture,
+  formatRelatedTurnCount,
   localizeActionType,
   localizeClaimLabel,
   localizeEvalMetricKey,
@@ -17,7 +20,24 @@ import {
   formatTurn,
   friendlyWorldName
 } from "./lib/presenters";
-import { loadWorkbenchData } from "./lib/workbench-data";
+import { loadWorkbenchData, type ClaimDrilldown } from "./lib/workbench-data";
+
+function summarizeClaimSources(drilldown: ClaimDrilldown) {
+  const documents = Array.from(
+    drilldown.evidenceChunks.reduce((map, entry) => {
+      const key = entry.document?.document_id ?? entry.chunk.document_id;
+      const current = map.get(key);
+      map.set(key, {
+        key,
+        title: entry.document?.title ?? entry.chunk.document_id,
+        count: (current?.count ?? 0) + 1
+      });
+      return map;
+    }, new Map<string, { key: string; title: string; count: number }>())
+  ).map(([, value]) => value);
+
+  return documents;
+}
 
 export async function generateMetadata(): Promise<Metadata> {
   const locale = await getAppLocale();
@@ -35,7 +55,7 @@ export default async function Page() {
   const copy = getCopy(locale);
   const data = await loadWorkbenchData();
   const worldName = friendlyWorldName(locale, data.graph.world_id);
-  const keyClaims = data.claims.slice(0, 3);
+  const keyClaims = data.claimDrilldowns.slice(0, 3);
   const topMetrics = Object.entries(data.evalSummary.metrics)
     .slice(0, 4)
     .map(([key, value]) => ({
@@ -265,22 +285,46 @@ export default async function Page() {
           <div className="sectionHeading">
             <p className="eyebrow">{copy.dashboard.claimEyebrow}</p>
             <h2>{copy.dashboard.claimTitle}</h2>
+            <p>
+              {locale === "zh-CN"
+                ? "首页只保留论点结构摘要，不直接摊开原始 claim 文本和证据摘录。"
+                : "The dashboard keeps only the claim structure in view and leaves raw claim text and evidence excerpts for deeper review."}
+            </p>
           </div>
           <div className="claimSnapshotGrid">
-            {keyClaims.map((claim) => (
+            {keyClaims.map((drilldown) => {
+              const { claim, evidenceChunks, relatedTurns } = drilldown;
+              const sourceDocuments = summarizeClaimSources(drilldown);
+              return (
               <article key={claim.claim_id} className="claimSnapshotCard">
                 <div className="interventionCardMeta">
                   <span>{claim.claim_id}</span>
                   <span className="pill">{localizeClaimLabel(locale, claim.label)}</span>
                 </div>
-                <p>{claim.text}</p>
                 <div className="artifactChipRow">
-                  {claim.evidence_ids.slice(0, 3).map((evidenceId) => (
-                    <code key={evidenceId}>{evidenceId}</code>
+                  <span className="artifactChip">{formatEvidenceCount(locale, evidenceChunks.length)}</span>
+                  <span className="artifactChip">{formatRelatedTurnCount(locale, relatedTurns.length)}</span>
+                  <span className="artifactChip">{formatDocumentCount(locale, sourceDocuments.length)}</span>
+                </div>
+                <p className="subtle">
+                  {locale === "zh-CN"
+                    ? "这条论点已被证据链约束，详情可在深度审阅页按需展开。"
+                    : "This claim stays evidence-bound, with the raw text and excerpts deferred to deep review."}
+                </p>
+                <div className="miniList">
+                  {sourceDocuments.slice(0, 2).map((document) => (
+                    <article key={document.key} className="miniCard">
+                      <strong>{document.title}</strong>
+                      <p>
+                        {locale === "zh-CN"
+                          ? `关联 ${document.count} 条证据摘录`
+                          : `${document.count} linked evidence excerpt${document.count === 1 ? "" : "s"}`}
+                      </p>
+                    </article>
                   ))}
                 </div>
               </article>
-            ))}
+            )})}
           </div>
         </section>
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,7 +6,14 @@ import { getCopy } from "./lib/copy";
 import { getAppLocale } from "./lib/locale";
 import {
   buildOverviewLines,
+  formatDivergentTurnCount,
   formatDeltaLabel,
+  formatEvalPosture,
+  localizeActionType,
+  localizeClaimLabel,
+  localizeEvalMetricKey,
+  localizeScenarioDescription,
+  localizeScenarioTitle,
   formatTurn,
   friendlyWorldName
 } from "./lib/presenters";
@@ -18,7 +25,7 @@ export async function generateMetadata(): Promise<Metadata> {
     title: locale === "zh-CN" ? "Mirror 工作台总览" : "Mirror Briefing Dashboard",
     description:
       locale === "zh-CN"
-        ? "Mirror 的双语编辑部指挥台首页，优先展示 compare、evidence 与 eval。"
+        ? "Mirror 的双语编辑部指挥台首页，优先展示对比、证据与评测。"
         : "Bilingual editorial briefing dashboard for Mirror's compare, evidence, and eval flow."
   };
 }
@@ -29,7 +36,23 @@ export default async function Page() {
   const data = await loadWorkbenchData();
   const worldName = friendlyWorldName(locale, data.graph.world_id);
   const keyClaims = data.claims.slice(0, 3);
-  const topMetrics = Object.entries(data.evalSummary.metrics).slice(0, 4);
+  const topMetrics = Object.entries(data.evalSummary.metrics)
+    .slice(0, 4)
+    .map(([key, value]) => ({
+      key,
+      label: localizeEvalMetricKey(locale, key),
+      value
+    }));
+  const baselineTitle = localizeScenarioTitle(
+    locale,
+    data.baselineRun.scenario.scenario_id,
+    data.baselineRun.scenario.title
+  );
+  const reportComparisonTitle = localizeScenarioTitle(
+    locale,
+    data.reportComparisonRun.scenario.scenario_id,
+    data.reportComparisonRun.scenario.title
+  );
 
   return (
     <main className="workbenchPage">
@@ -73,15 +96,11 @@ export default async function Page() {
           </article>
           <article className="briefCard">
             <span>{copy.metrics.evalStatus}</span>
-            <strong>
-              {data.evalSummary.eval_name}: {data.evalSummary.status}
-            </strong>
+            <strong>{formatEvalPosture(locale, data.evalSummary.eval_name, data.evalSummary.status)}</strong>
           </article>
           <article className="briefCard briefCardWide">
             <span>{copy.dashboard.currentPair}</span>
-            <strong>
-              {data.baselineRun.scenario.title} ↔ {data.reportComparisonRun.scenario.title}
-            </strong>
+            <strong>{baselineTitle} ↔ {reportComparisonTitle}</strong>
           </article>
           <article className="briefCard briefCardWide">
             <span>{copy.brand.compareArtifactLabel}</span>
@@ -119,8 +138,14 @@ export default async function Page() {
               <span>{copy.common.referenceBranch}</span>
               <code>{data.baselineRun.scenario.scenario_id}</code>
             </div>
-            <h3>{data.baselineRun.scenario.title}</h3>
-            <p>{data.baselineRun.scenario.description}</p>
+            <h3>{baselineTitle}</h3>
+            <p>
+              {localizeScenarioDescription(
+                locale,
+                data.baselineRun.scenario.scenario_id,
+                data.baselineRun.scenario.description
+              )}
+            </p>
             <div className="deltaBadgeRow">
               <span className="deltaBadge">{copy.metrics.budgetExposed}: {formatTurn(locale, data.baselineRun.summary.budget_exposed_turn)}</span>
               <span className="deltaBadge">{copy.metrics.ledgerPublic}: {formatTurn(locale, data.baselineRun.summary.ledger_public_turn)}</span>
@@ -137,11 +162,11 @@ export default async function Page() {
             return (
               <article key={overview.run.key} className="interventionCard">
                 <div className="interventionCardMeta">
-                  <span>{overview.run.label}</span>
+                  <span>{localizeScenarioTitle(locale, overview.run.scenario.scenario_id, overview.run.label)}</span>
                   <code>{overview.run.scenario.scenario_id}</code>
                 </div>
-                <h3>{overview.run.scenario.title}</h3>
-                <p>{overview.run.scenario.description}</p>
+                <h3>{localizeScenarioTitle(locale, overview.run.scenario.scenario_id, overview.run.scenario.title)}</h3>
+                <p>{localizeScenarioDescription(locale, overview.run.scenario.scenario_id, overview.run.scenario.description)}</p>
                 <div className="deltaBadgeRow">
                   <span className="deltaBadge">
                     {copy.metrics.budgetExposed}: {formatDeltaLabel(locale, overview.budgetExposureDelta)}
@@ -193,8 +218,8 @@ export default async function Page() {
           {data.comparisonOverviews.map((overview) => (
             <article key={overview.run.key} className="storyboardCard">
               <div className="interventionCardMeta">
-                <span>{overview.run.scenario.title}</span>
-                <code>{overview.divergentTurnCount} {copy.metrics.divergentTurns.toLowerCase()}</code>
+                <span>{localizeScenarioTitle(locale, overview.run.scenario.scenario_id, overview.run.scenario.title)}</span>
+                <code>{formatDivergentTurnCount(locale, overview.divergentTurnCount)}</code>
               </div>
               <div className="storyboardRows">
                 {overview.rows.slice(0, 2).map((row) => (
@@ -208,7 +233,7 @@ export default async function Page() {
                         <span>{copy.common.baseline}</span>
                         {row.reference ? (
                           <>
-                            <strong>{row.reference.turn.action_type}</strong>
+                            <strong>{localizeActionType(locale, row.reference.turn.action_type)}</strong>
                             <p>{row.reference.turn.rationale}</p>
                           </>
                         ) : (
@@ -219,7 +244,7 @@ export default async function Page() {
                         <span>{copy.common.candidate}</span>
                         {row.candidate ? (
                           <>
-                            <strong>{row.candidate.turn.action_type}</strong>
+                            <strong>{localizeActionType(locale, row.candidate.turn.action_type)}</strong>
                             <p>{row.candidate.turn.rationale}</p>
                           </>
                         ) : (
@@ -246,7 +271,7 @@ export default async function Page() {
               <article key={claim.claim_id} className="claimSnapshotCard">
                 <div className="interventionCardMeta">
                   <span>{claim.claim_id}</span>
-                  <span className="pill">{claim.label}</span>
+                  <span className="pill">{localizeClaimLabel(locale, claim.label)}</span>
                 </div>
                 <p>{claim.text}</p>
                 <div className="artifactChipRow">
@@ -266,22 +291,20 @@ export default async function Page() {
             <p>{copy.dashboard.scorecardNote}</p>
           </div>
           <div className="briefSummaryGrid">
-            {topMetrics.map(([key, value]) => (
+            {topMetrics.map(({ key, label, value }) => (
               <article key={key} className="briefCard">
-                <span>{key}</span>
+                <span>{label}</span>
                 <strong>{value}</strong>
               </article>
             ))}
           </div>
           <div className="dashboardCallout">
-            <p className="subtle">
-              {data.evalSummary.eval_name}: {data.evalSummary.status}
-            </p>
+            <p className="subtle">{formatEvalPosture(locale, data.evalSummary.eval_name, data.evalSummary.status)}</p>
             <div className="cardActions">
-              <Link className="heroAction heroActionPrimary" href="/review">
+              <Link className="surfaceAction surfaceActionPrimary" href="/review">
                 {copy.dashboard.openReview}
               </Link>
-              <Link className="heroAction" href="/review#advanced-operations">
+              <Link className="surfaceAction" href="/review#advanced-operations">
                 {copy.rubric.openLegacy}
               </Link>
             </div>

--- a/frontend/src/app/review/page.tsx
+++ b/frontend/src/app/review/page.tsx
@@ -8,7 +8,12 @@ import { getCopy } from "../lib/copy";
 import { getAppLocale } from "../lib/locale";
 import {
   buildOverviewLines,
+  formatClaimCount,
+  formatDocumentCount,
   formatEvalPosture,
+  formatEvidenceCount,
+  formatParagraphCount,
+  formatRelatedTurnCount,
   formatScenarioMeta,
   friendlyWorldName,
   localizeActionType,
@@ -19,7 +24,22 @@ import {
   localizeScenarioDescription,
   localizeScenarioTitle
 } from "../lib/presenters";
-import { loadWorkbenchData } from "../lib/workbench-data";
+import { loadWorkbenchData, type ClaimDrilldown } from "../lib/workbench-data";
+
+function summarizeClaimSources(drilldown: ClaimDrilldown) {
+  return Array.from(
+    drilldown.evidenceChunks.reduce((map, entry) => {
+      const key = entry.document?.document_id ?? entry.chunk.document_id;
+      const current = map.get(key);
+      map.set(key, {
+        key,
+        title: entry.document?.title ?? entry.chunk.document_id,
+        count: (current?.count ?? 0) + 1
+      });
+      return map;
+    }, new Map<string, { key: string; title: string; count: number }>())
+  ).map(([, value]) => value);
+}
 
 export async function generateMetadata(): Promise<Metadata> {
   const locale = await getAppLocale();
@@ -37,6 +57,7 @@ export default async function ReviewPage() {
   const copy = getCopy(locale);
   const data = await loadWorkbenchData();
   const worldName = friendlyWorldName(locale, data.graph.world_id);
+  const reportParagraphCount = data.report.split(/\n\s*\n/).filter((block) => block.trim().length > 0).length;
   const divergentTurns =
     data.reportComparison?.rows.map(({ turnIndex, reference, candidate }) => ({
       turnIndex,
@@ -180,44 +201,83 @@ export default async function ReviewPage() {
         <div className="sectionHeading">
           <p className="eyebrow">{copy.review.claimsTitle}</p>
           <h2>{copy.review.claimsSummary}</h2>
+          <p>
+            {locale === "zh-CN"
+              ? "默认先看论点结构、来源文档和关联回合，只有在需要时再展开原始 claim 文本与证据摘录。"
+              : "Default to the claim structure, source documents, and related turns; open the raw claim text and evidence excerpts only when needed."}
+          </p>
         </div>
         <div className="claimSnapshotGrid">
-          {data.claimDrilldowns.map(({ claim, evidenceChunks, relatedTurns }) => (
+          {data.claimDrilldowns.map((drilldown) => {
+            const { claim, evidenceChunks, relatedTurns } = drilldown;
+            const sourceDocuments = summarizeClaimSources(drilldown);
+            return (
             <article key={claim.claim_id} className="claimSnapshotCard claimSnapshotCardExpanded">
               <div className="interventionCardMeta">
                 <span>{claim.claim_id}</span>
                 <span className="pill">{localizeClaimLabel(locale, claim.label)}</span>
               </div>
-              <p>{claim.text}</p>
-              <div className="claimEvidence">
-                {claim.evidence_ids.map((evidenceId) => (
-                  <code key={evidenceId}>{evidenceId}</code>
-                ))}
+              <div className="artifactChipRow">
+                <span className="artifactChip">{formatEvidenceCount(locale, evidenceChunks.length)}</span>
+                <span className="artifactChip">{formatRelatedTurnCount(locale, relatedTurns.length)}</span>
+                <span className="artifactChip">{formatDocumentCount(locale, sourceDocuments.length)}</span>
               </div>
+              <p className="subtle">
+                {locale === "zh-CN"
+                  ? "这条论点默认只展示结构摘要，原始文本和摘录被收在折叠层里。"
+                  : "This claim now defaults to a structural summary, with the raw text and excerpts tucked behind an explicit drawer."}
+              </p>
               <div className="subsectionBlock">
-                <h3>{copy.common.jumpToEvidence}</h3>
+                <h3>{locale === "zh-CN" ? "来源文档" : "Source documents"}</h3>
                 <div className="miniList">
-                  {evidenceChunks.map(({ chunk, document }) => (
-                    <article key={chunk.chunk_id} className="miniCard">
-                      <strong>{document?.title ?? chunk.document_id}</strong>
-                      <p>{chunk.text}</p>
+                  {sourceDocuments.map((document) => (
+                    <article key={document.key} className="miniCard">
+                      <strong>{document.title}</strong>
+                      <p>
+                        {locale === "zh-CN"
+                          ? `关联 ${document.count} 条证据摘录`
+                          : `${document.count} linked evidence excerpt${document.count === 1 ? "" : "s"}`}
+                      </p>
                     </article>
                   ))}
                 </div>
               </div>
               <div className="subsectionBlock">
-                <h3>{copy.common.jumpToTrace}</h3>
+                <h3>{locale === "zh-CN" ? "关联回合" : "Related turns"}</h3>
                 <div className="miniList">
                   {relatedTurns.map((entry) => (
                     <article key={entry.turn.turn_id} className="miniCard">
                       <strong>{entry.turn.turn_id}</strong>
-                      <p>{entry.turn.rationale}</p>
+                      <p>
+                        {localizeActionType(locale, entry.turn.action_type)}
+                        {" · "}
+                        {localizeScenarioTitle(locale, entry.scenarioKey, entry.scenarioTitle)}
+                      </p>
                     </article>
                   ))}
                 </div>
               </div>
+              <details className="inlineDetails">
+                <summary className="inlineDetailsSummary">
+                  {locale === "zh-CN" ? "查看原始论点与证据摘录" : "Open raw claim and evidence excerpts"}
+                </summary>
+                <div className="inlineDetailsBody">
+                  <div className="subsectionBlock">
+                    <h3>{locale === "zh-CN" ? "原始论点文本" : "Raw claim text"}</h3>
+                    <p>{claim.text}</p>
+                  </div>
+                  <div className="miniList">
+                    {evidenceChunks.map(({ chunk, document }) => (
+                      <article key={chunk.chunk_id} className="miniCard">
+                        <strong>{document?.title ?? chunk.document_id}</strong>
+                        <p>{chunk.text}</p>
+                      </article>
+                    ))}
+                  </div>
+                </div>
+              </details>
             </article>
-          ))}
+          )})}
         </div>
       </section>
 
@@ -234,7 +294,18 @@ export default async function ReviewPage() {
               <code>artifacts/demo/report/report.md</code>
             </div>
             <p>{copy.review.rawReportSummary}</p>
-            <pre className="artifactPre artifactPreCompact">{data.report}</pre>
+            <div className="artifactChipRow">
+              <span className="artifactChip">{formatParagraphCount(locale, reportParagraphCount)}</span>
+              <span className="artifactChip">{formatClaimCount(locale, data.claims.length)}</span>
+            </div>
+            <details className="inlineDetails">
+              <summary className="inlineDetailsSummary">
+                {locale === "zh-CN" ? "查看原始报告文本" : "Open raw report text"}
+              </summary>
+              <div className="inlineDetailsBody">
+                <pre className="artifactPre artifactPreCompact">{data.report}</pre>
+              </div>
+            </details>
           </article>
 
           <article className="referenceCard">

--- a/frontend/src/app/review/page.tsx
+++ b/frontend/src/app/review/page.tsx
@@ -8,8 +8,16 @@ import { getCopy } from "../lib/copy";
 import { getAppLocale } from "../lib/locale";
 import {
   buildOverviewLines,
-  formatTurn,
-  friendlyWorldName
+  formatEvalPosture,
+  formatScenarioMeta,
+  friendlyWorldName,
+  localizeActionType,
+  localizeBranchLabel,
+  localizeClaimLabel,
+  localizeDocumentKind,
+  localizeGraphStatKey,
+  localizeScenarioDescription,
+  localizeScenarioTitle
 } from "../lib/presenters";
 import { loadWorkbenchData } from "../lib/workbench-data";
 
@@ -19,7 +27,7 @@ export async function generateMetadata(): Promise<Metadata> {
     title: locale === "zh-CN" ? "Mirror 深度审阅工作区" : "Mirror Deep Review Workspace",
     description:
       locale === "zh-CN"
-        ? "Mirror 的双语深度审阅页，围绕 scorecard、trace、claims 和参考面板组织。"
+        ? "Mirror 的双语深度审阅页，围绕评分卡、轨迹、论点和参考面板组织。"
         : "Bilingual deep review workspace for scorecard, trace, claims, and reference inspection in Mirror."
   };
 }
@@ -72,9 +80,7 @@ export default async function ReviewPage() {
           </article>
           <article className="briefCard">
             <span>{copy.metrics.evalStatus}</span>
-            <strong>
-              {data.evalSummary.eval_name}: {data.evalSummary.status}
-            </strong>
+            <strong>{formatEvalPosture(locale, data.evalSummary.eval_name, data.evalSummary.status)}</strong>
           </article>
         </div>
         <div className="sectionSwitch">
@@ -117,10 +123,10 @@ export default async function ReviewPage() {
             return (
               <article key={overview.run.key} id={`trace-${overview.run.key}`} className="interventionCard">
                 <div className="interventionCardMeta">
-                  <span>{overview.run.scenario.title}</span>
+                  <span>{localizeScenarioTitle(locale, overview.run.scenario.scenario_id, overview.run.scenario.title)}</span>
                   <code>{overview.run.scenario.scenario_id}</code>
                 </div>
-                <h3>{overview.run.label}</h3>
+                <h3>{localizeBranchLabel(locale, overview.run.scenario.scenario_id, overview.run.label)}</h3>
                 <ul className="summaryList">
                   {lines.map((line) => (
                     <li key={line}>{line}</li>
@@ -139,7 +145,7 @@ export default async function ReviewPage() {
                             <span>{copy.common.baseline}</span>
                             {row.reference ? (
                               <>
-                                <strong>{row.reference.turn.action_type}</strong>
+                                <strong>{localizeActionType(locale, row.reference.turn.action_type)}</strong>
                                 <p>{row.reference.turn.rationale}</p>
                               </>
                             ) : (
@@ -150,7 +156,7 @@ export default async function ReviewPage() {
                             <span>{copy.common.candidate}</span>
                             {row.candidate ? (
                               <>
-                                <strong>{row.candidate.turn.action_type}</strong>
+                                <strong>{localizeActionType(locale, row.candidate.turn.action_type)}</strong>
                                 <p>{row.candidate.turn.rationale}</p>
                               </>
                             ) : (
@@ -180,7 +186,7 @@ export default async function ReviewPage() {
             <article key={claim.claim_id} className="claimSnapshotCard claimSnapshotCardExpanded">
               <div className="interventionCardMeta">
                 <span>{claim.claim_id}</span>
-                <span className="pill">{claim.label}</span>
+                <span className="pill">{localizeClaimLabel(locale, claim.label)}</span>
               </div>
               <p>{claim.text}</p>
               <div className="claimEvidence">
@@ -239,7 +245,7 @@ export default async function ReviewPage() {
             <div className="briefSummaryGrid">
               {Object.entries(data.graph.stats).map(([key, value]) => (
                 <article key={key} className="briefCard">
-                  <span>{key}</span>
+                  <span>{localizeGraphStatKey(locale, key)}</span>
                   <strong>{value}</strong>
                 </article>
               ))}
@@ -256,12 +262,12 @@ export default async function ReviewPage() {
             <div className="miniList">
               {data.runs.map((run) => (
                 <article key={run.key} className="miniCard">
-                  <strong>{run.scenario.title}</strong>
-                  <p>{run.scenario.description}</p>
+                  <strong>{localizeScenarioTitle(locale, run.scenario.scenario_id, run.scenario.title)}</strong>
+                  <p>{localizeScenarioDescription(locale, run.scenario.scenario_id, run.scenario.description)}</p>
                   <div className="claimEvidence">
                     <code>{run.scenario.scenario_id}</code>
-                    <code>branch_count={run.scenario.branch_count}</code>
-                    <code>turn_budget={run.scenario.turn_budget}</code>
+                    <code>{formatScenarioMeta(locale, "branch_count", run.scenario.branch_count)}</code>
+                    <code>{formatScenarioMeta(locale, "turn_budget", run.scenario.turn_budget)}</code>
                   </div>
                 </article>
               ))}
@@ -279,7 +285,7 @@ export default async function ReviewPage() {
                   <strong>{document.title}</strong>
                   <div className="claimEvidence">
                     <code>{document.document_id}</code>
-                    <code>{document.kind}</code>
+                    <code>{localizeDocumentKind(locale, document.kind)}</code>
                   </div>
                 </article>
               ))}
@@ -305,7 +311,7 @@ export default async function ReviewPage() {
           <div className="editorialDrawerBody">
             <p className="editorialDrawerNote">
               {locale === "zh-CN"
-                ? "下方面板为了兼容旧工作流暂时保留英文文案。当前推荐的双语审阅路径仍以上面的 scorecard、trace、claims 和 reference 为主。"
+                ? "下方面板为了兼容旧工作流暂时保留英文文案。当前推荐的双语审阅路径仍以上面的评分卡、轨迹、论点和参考面板为主。"
                 : "The panel below remains English-first for compatibility with the older workflow. The primary bilingual review path stays in the scorecard, trace, claims, and reference sections above."}
             </p>
             <div lang="en">


### PR DESCRIPTION
## Summary
- polish the zh-CN interface so the primary UI chrome stops mixing compare/trace/claims/eval wording with Chinese labels
- fix contrast hierarchy issues where hero-oriented white text leaked into light surfaces and reduced readability
- reduce default exposure of raw report, claim text, and evidence excerpts by moving them behind summary-first cards and explicit drawers

## Validation
- npm run build --prefix frontend
- ./make.ps1 smoke
- ./make.ps1 eval-demo
- python -m backend.app.cli classify-lane --files frontend/src/app/components/review-rubric-panel.tsx frontend/src/app/globals.css frontend/src/app/lib/copy.ts frontend/src/app/lib/presenters.ts frontend/src/app/page.tsx frontend/src/app/review/page.tsx