### PR TITLE
Add Render public demo deployment config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV NODE_ENV=production \
     MIRROR_PUBLIC_DEMO_MODE=1 \
     MIRROR_ALLOW_ANONYMOUS_RUNS=0 \
     MIRROR_HOSTED_MODEL_ENABLED=0 \
+    PORT=3000 \
     PYTHON=/opt/mirror-venv/bin/python \
     PATH=/opt/mirror-venv/bin:$PATH
 
@@ -39,7 +40,7 @@ WORKDIR /app/mirror/frontend
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
-    CMD node -e "fetch('http://127.0.0.1:3000/api/ready').then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
+    CMD node -e "const port = process.env.PORT || '3000'; fetch(`http://127.0.0.1:${port}/api/ready`).then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
 
 ENTRYPOINT ["/app/mirror/scripts/bootstrap-production.sh"]
-CMD ["node", "node_modules/next/dist/bin/next", "start", "--hostname", "0.0.0.0", "--port", "3000"]
+CMD ["sh", "-c", "exec node node_modules/next/dist/bin/next start --hostname 0.0.0.0 --port ${PORT:-3000}"]

--- a/docs/deploy/render-public-demo.md
+++ b/docs/deploy/render-public-demo.md
@@ -1,0 +1,42 @@
+# Render Public Demo Deployment
+
+## Intent
+
+Render is the fastest no-VM path for Phase 1 because it can build the repo Dockerfile and publish a public `onrender.com` URL without Hosted GPT, BYOK, auth, database, object storage, or provider secrets.
+
+## Blueprint
+
+The repo-root `render.yaml` defines one Docker web service:
+
+- `runtime: docker`
+- `dockerfilePath: ./Dockerfile`
+- `healthCheckPath: /api/ready`
+- public demo flags enabled
+- anonymous runtime mutation and hosted model access disabled
+
+## Dashboard Steps
+
+1. In Render, create a new Blueprint from the GitHub repository.
+2. Select `main` and the repo-root `render.yaml`.
+3. Review the single service named `mirror-public-demo`.
+4. Deploy the Blueprint.
+5. Open the generated `https://<service>.onrender.com` URL.
+
+No OpenAI or provider API key should be configured for Phase 1.
+
+## Validation
+
+After the Render deploy finishes, verify:
+
+```bash
+curl --fail https://<service>.onrender.com/api/health
+curl --fail https://<service>.onrender.com/api/ready
+```
+
+Expected public behavior:
+
+- `/` loads the guided public demo.
+- `/review` loads the advanced read-only review surface.
+- `/api/public-demo/manifest` returns only logical artifact ids.
+- runtime mutation endpoints return `403` in public demo mode.
+

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,23 @@
+services:
+  - type: web
+    name: mirror-public-demo
+    runtime: docker
+    plan: free
+    branch: main
+    autoDeployTrigger: checksPass
+    dockerfilePath: ./Dockerfile
+    dockerContext: .
+    healthCheckPath: /api/ready
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: MIRROR_ENV
+        value: production
+      - key: MIRROR_BOOTSTRAP_DEMO
+        value: "1"
+      - key: MIRROR_PUBLIC_DEMO_MODE
+        value: "1"
+      - key: MIRROR_ALLOW_ANONYMOUS_RUNS
+        value: "0"
+      - key: MIRROR_HOSTED_MODEL_ENABLED
+        value: "0"


### PR DESCRIPTION
﻿## Summary

Adds the fastest no-VM deployment path for the Phase 1 public deterministic-only demo on Render.

## Changes

- Add `render.yaml` for a single Docker web service with `/api/ready` health checks.
- Keep public demo flags enabled and hosted model / anonymous mutation disabled.
- Update Docker startup and healthcheck to honor platform-injected `PORT`.
- Document the Render Blueprint deployment steps and validation commands.

## Validation

- `python scripts/check_no_secrets.py`
- `git diff --check`
- `./make.ps1 public-demo-check`

## Safety

No OpenAI or provider API key is required or configured. This remains a read-only, deterministic public demo path.
