### PR TITLE
Fix Render Next startup path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
     CMD node -e "const port = process.env.PORT || '3000'; fetch(`http://127.0.0.1:${port}/api/ready`).then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
 
 ENTRYPOINT ["/app/mirror/scripts/bootstrap-production.sh"]
-CMD ["sh", "-c", "exec node node_modules/next/dist/bin/next start --hostname 0.0.0.0 --port ${PORT:-3000}"]
+CMD ["sh", "-c", "exec node /app/mirror/frontend/node_modules/next/dist/bin/next start --hostname 0.0.0.0 --port ${PORT:-3000}"]


### PR DESCRIPTION
## Summary

Fixes the Render container startup path reported in deploy logs:

```text
Error: Cannot find module '/app/mirror/node_modules/next/dist/bin/next'
```

`bootstrap-production.sh` intentionally changes the working directory to `/app/mirror` so it can validate and bootstrap canonical artifacts. The Docker `CMD` was still using a relative `node_modules/...` path, which only works from `/app/mirror/frontend`.

## Change

- Start Next with the absolute path `/app/mirror/frontend/node_modules/next/dist/bin/next`.
- Keep Render `$PORT` support and public demo flags unchanged.

## Validation

- `python scripts/check_no_secrets.py`
- `git diff --check`
- `./make.ps1 public-demo-check`
