### PR TITLE
[codex] Add Mirror Codex plugin v1

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "mirror-local",
+  "interface": {
+    "displayName": "Mirror Local Plugins"
+  },
+  "plugins": [
+    {
+      "name": "mirror-codex",
+      "source": {
+        "source": "local",
+        "path": "./plugins/mirror-codex"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Engineering"
+    }
+  ]
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@
 - [ ] `./make.ps1 test`
 - [ ] `./make.ps1 smoke`
 - [ ] `./make.ps1 eval-demo`
+- [ ] `./make.ps1 plugin-release-check` (required for plugin, MCP, ADR, or public demo artifact-source changes)
 - [ ] Additional focused test(s) listed below
 
 ## Artifacts

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Generate canonical deterministic demo artifacts
         run: python -m backend.app.cli eval-demo
 
+      - name: Check repo-local Codex plugin release gate
+        run: make plugin-release-check
+
       - name: Scan generated demo artifacts
         run: python scripts/scan_frontend_bundle.py --path artifacts/demo
 

--- a/.github/workflows/phase0.yml
+++ b/.github/workflows/phase0.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Refresh canonical public demo artifacts
         run: make eval-demo
 
+      - name: Check repo-local Codex plugin release gate
+        run: make plugin-release-check
+
       - name: Scan generated demo artifacts
         run: python scripts/scan_frontend_bundle.py --path artifacts/demo
 
@@ -123,6 +126,10 @@ jobs:
       - name: Refresh canonical public demo artifacts
         shell: pwsh
         run: .\make.ps1 eval-demo
+
+      - name: Check repo-local Codex plugin release gate
+        shell: pwsh
+        run: .\make.ps1 plugin-release-check
 
       - name: Scan generated demo artifacts
         shell: pwsh

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 PYTHON ?= python
+MIRROR_PUBLIC_DEMO_BASE_URL ?= https://mirror-public-demo.onrender.com
+MIRROR_REMOTE_SMOKE_TIMEOUT ?= 60
+MIRROR_REMOTE_SMOKE_RETRIES ?= 5
+MIRROR_REMOTE_SMOKE_RETRY_DELAY ?= 2
 
-.PHONY: setup smoke test eval-demo eval-transfer public-demo-check dev-api dev-web
+.PHONY: setup smoke test eval-demo eval-transfer public-demo-check plugin-check plugin-release-check plugin-remote-check dev-api dev-web
 
 setup:
 	$(PYTHON) -m pip install -e backend
@@ -23,6 +27,21 @@ public-demo-check:
 	npm run build --prefix frontend
 	$(PYTHON) scripts/scan_frontend_bundle.py
 	$(PYTHON) scripts/smoke_public_demo_web.py
+
+plugin-check:
+	$(PYTHON) plugins/mirror-codex/scripts/validate_plugin.py
+	$(PYTHON) -m pytest plugins/mirror-codex/tests -q
+	$(PYTHON) plugins/mirror-codex/scripts/smoke_mcp_stdio.py
+	$(PYTHON) plugins/mirror-codex/scripts/acceptance_check.py
+
+plugin-release-check: plugin-check
+	$(PYTHON) plugins/mirror-codex/scripts/check_pr_scope.py
+	$(PYTHON) scripts/check_no_secrets.py
+	$(PYTHON) -m backend.app.cli audit-phase phase2
+	git diff --check
+
+plugin-remote-check:
+	$(PYTHON) scripts/smoke_public_demo_web.py --base-url $(MIRROR_PUBLIC_DEMO_BASE_URL) --timeout $(MIRROR_REMOTE_SMOKE_TIMEOUT) --http-retries $(MIRROR_REMOTE_SMOKE_RETRIES) --retry-delay $(MIRROR_REMOTE_SMOKE_RETRY_DELAY)
 
 dev-api:
 	$(PYTHON) -m uvicorn backend.app.main:app --reload

--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ make public-demo-check
 ./make.ps1 public-demo-check
 ```
 
+Validate the repo-local Codex plugin:
+
+```bash
+make plugin-check
+make plugin-release-check
+```
+
+```powershell
+./make.ps1 plugin-check
+./make.ps1 plugin-release-check
+```
+
 Start the legacy local development stack:
 
 ```bash

--- a/docs/decisions/ADR-0010-mirror-codex-plugin-mcp-contract.md
+++ b/docs/decisions/ADR-0010-mirror-codex-plugin-mcp-contract.md
@@ -1,0 +1,113 @@
+# ADR-0010: Mirror Codex Plugin MCP Contract
+
+## Status
+
+Accepted
+
+## Context
+
+The repo-local `mirror-codex` plugin gives Codex a first-party way to inspect Mirror's
+deterministic Phase 1 public demo. That plugin includes a local MCP server, so its tool
+surface is a long-lived developer contract even though it is not a public web API.
+
+ADR-0009 already defines the Phase 1 public demo artifact-source boundary: public callers
+use allowlisted logical artifact ids, public output strips implementation paths, and the
+public path does not create worlds, upload corpora, call model providers, or mutate runtime
+state. The Codex plugin must preserve that same boundary.
+
+## Decision
+
+Mirror Codex plugin v1 is read-only, local-first, and deterministic-demo-only.
+
+The plugin manifest exposes only the `Read` capability. The plugin registers one fixed local
+stdio MCP server in `plugins/mirror-codex/.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "mirror-demo": {
+      "command": "python",
+      "args": ["./scripts/run_mcp.py"]
+    }
+  }
+}
+```
+
+The command and args are hardcoded. They must not be composed from user input, provider
+configuration, environment secrets, URLs, shell snippets, or arbitrary filesystem paths.
+
+The v1 MCP tool allowlist is:
+
+- `get_demo_manifest`: no arguments.
+- `get_demo_artifact`: `artifact_id` must be one of `demo.report`, `demo.claims`,
+  `demo.eval_summary`, `demo.compare`, `demo.documents`, `demo.chunks`, `demo.graph`,
+  or `demo.rubric`.
+- `get_eval_summary`: no arguments.
+- `explain_demo_claim`: `claim_id` must be a logical claim id from `demo.claims`, not a
+  path or query.
+- `compare_demo_branches`: `candidate_branch_id` must be one of
+  `branch_harbor_comms_failure`, `branch_mayor_signal_blocked`, or
+  `branch_reporter_detained`; optional `reference_branch_id` is limited to
+  `branch_baseline`.
+
+The v1 MCP resource allowlist is:
+
+- `mirror-demo://manifest`
+- `mirror-demo://artifact/demo.report`
+- `mirror-demo://artifact/demo.claims`
+- `mirror-demo://artifact/demo.eval_summary`
+- `mirror-demo://artifact/demo.compare`
+- `mirror-demo://artifact/demo.documents`
+- `mirror-demo://artifact/demo.chunks`
+- `mirror-demo://artifact/demo.graph`
+- `mirror-demo://artifact/demo.rubric`
+
+The v1 MCP prompt allowlist is:
+
+- `inspect-public-demo`
+- `review-claim-evidence`
+- `compare-demo-branches`
+
+Every MCP tool must declare `annotations.readOnlyHint: true` and a closed input schema with
+`additionalProperties: false`. Tool schemas must not expose inputs named `path`, `file`,
+`filepath`, `filename`, `url`, `command`, `args`, `api_key`, `provider`, or `model`.
+
+The MCP server may read only the canonical demo artifacts needed for those logical ids and
+allowlisted resource URIs. It must reject path-like tool input containing `/`, `\`, `:`,
+`..`, or leading `.`. Resource reads and prompt gets must use exact allowlisted names/URIs,
+not user-provided filesystem paths, URLs, shell snippets, provider configuration, or API
+keys. It must not read secrets, shell out, call OpenAI or other model providers, upload user
+data, create worlds, start runtime sessions, write artifacts, or add Hosted GPT, BYOK, auth,
+billing, database, object storage, or quota behavior.
+
+MCP output must preserve claim reviewability. Any report claim returned by the plugin must
+keep both `label` and `evidence_ids`. Output must strip implementation path fields already
+excluded from Phase 1 public API responses, including `artifact_paths`, `summary_path`,
+`trace_path`, `snapshot_dir`, and document `source_path`.
+
+## Consequences
+
+- Developers can enable the plugin without granting it a mutation surface or provider
+  credentials.
+- The MCP server remains dependency-light and auditable in this slice.
+- Future tool, resource, or prompt additions must update this ADR, the plugin README, the
+  `mirror-demo` skill, static validation, and MCP tests in the same change.
+- Any future mutating workflow must be a separate contract and must not be added to this
+  Phase 1 public demo path by default.
+
+## Validation
+
+The plugin contract is enforced by:
+
+```bash
+make plugin-check
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-phase phase2
+git diff --check
+```
+
+If frontend code or public demo frontend routes change, also run:
+
+```bash
+npm run build --prefix frontend
+```

--- a/docs/deploy/mirror-codex-plugin.md
+++ b/docs/deploy/mirror-codex-plugin.md
@@ -1,0 +1,211 @@
+# Mirror Codex Plugin Runbook
+
+## Intent
+
+Use this runbook to verify the repo-local `mirror-codex` plugin in a clean Codex
+environment. The plugin is for read-only inspection of Mirror's deterministic Phase 1
+public demo. It must not upload data, call model providers, create worlds, mutate runtime
+state, or read arbitrary filesystem paths.
+
+## Scope
+
+This runbook covers:
+
+- repo-local marketplace discovery from `.agents/plugins/marketplace.json`
+- plugin manifest and skill validation
+- local MCP stdio smoke for the fixed `mirror-demo` server
+- manual demo-inspection prompts for Codex
+
+This runbook does not cover Hosted GPT, BYOK, corpus upload, auth, billing, database, object
+storage, quota, or runtime mutation.
+
+TODO[verify]: Codex plugin UI labels and install controls can vary by Codex version. Treat the
+filesystem checks and MCP smoke below as the stable acceptance path, and record any UI-specific
+differences in a follow-up note.
+
+## Preconditions
+
+From the repository root:
+
+```powershell
+python -m backend.app.cli eval-demo
+./make.ps1 plugin-check
+./make.ps1 plugin-release-check
+```
+
+The plugin check must report:
+
+- `Mirror Codex plugin validation passed.`
+- plugin MCP tests passing
+- `Mirror Codex MCP stdio smoke passed.`
+- `Mirror Codex plugin install acceptance passed.`
+- `Mirror Codex plugin PR scope check passed.`
+
+No provider key is required. Do not set `NEXT_PUBLIC_OPENAI_API_KEY`.
+
+## Discovery Checks
+
+Confirm the marketplace entry is repo-local and available:
+
+```powershell
+Get-Content -Raw .agents/plugins/marketplace.json
+Get-Content -Raw plugins/mirror-codex/.codex-plugin/plugin.json
+Get-Content -Raw plugins/mirror-codex/.mcp.json
+```
+
+Expected facts:
+
+- marketplace source path is `./plugins/mirror-codex`
+- installation policy is `AVAILABLE`
+- plugin capability is `Read`
+- MCP server command is `python` with args `["./scripts/run_mcp.py"]`
+- no hooks or apps are registered
+
+The deterministic install acceptance check performs the same discovery from the repository
+root, resolves the repo-local plugin path, starts the MCP server from the plugin directory
+using `.mcp.json`, and verifies tools, resources, prompts, claim evidence, sanitized document
+metadata, and path-argument rejection:
+
+```powershell
+python plugins/mirror-codex/scripts/acceptance_check.py
+```
+
+## Codex Manual Acceptance
+
+After enabling the repo-local plugin in Codex, ask Codex:
+
+```text
+Use Mirror Demo to inspect demo.claims and explain claim_evacuation_turn.
+```
+
+Expected behavior:
+
+- Codex reads Mirror's public demo boundary before summarizing.
+- Codex uses logical artifact ids, not filesystem paths.
+- The claim explanation keeps both `label` and `evidence_ids`.
+- The answer uses bounded wording such as "based on the deterministic Fog Harbor demo".
+
+Then ask:
+
+```text
+Use Mirror Demo to compare branch_reporter_detained against the baseline.
+```
+
+Expected behavior:
+
+- The comparison is framed as deterministic branch comparison, not real-world prediction.
+- Output does not expose `summary_path`, `trace_path`, `snapshot_dir`, or local paths.
+
+## Evidence Navigation Acceptance
+
+For a manual evidence walk, ask Codex:
+
+```text
+Use Mirror Demo to review claim_evacuation_turn and show how its evidence_ids map to chunks and sanitized document metadata.
+```
+
+Expected behavior:
+
+- Codex reads `demo.claims`, `demo.chunks`, and `demo.documents` through logical ids or fixed
+  `mirror-demo://...` resources.
+- Codex preserves `label` and `evidence_ids` for `claim_evacuation_turn`.
+- Codex can identify the evidence ids `chunk_doc_budget_minutes_002`,
+  `chunk_doc_budget_minutes_003`, and `chunk_doc_engineering_inspection_002`.
+- Codex uses bounded wording such as "based on the current corpus and deterministic rules".
+- Codex does not ask for filesystem paths, URLs, provider keys, uploads, or local config.
+- Codex does not expose stripped path fields such as `source_path`.
+
+## MCP Smoke
+
+Run the fixed stdio smoke:
+
+```powershell
+python plugins/mirror-codex/scripts/smoke_mcp_stdio.py
+```
+
+The smoke verifies:
+
+- `initialize`
+- `tools/list`
+- `resources/list`
+- `prompts/list`
+- `get_demo_manifest`
+- `get_eval_summary`
+- `explain_demo_claim`
+- `compare_demo_branches`
+- rejection of a path-bearing extra argument
+
+## Optional Remote Public Demo Check
+
+Remote checks are explicit release checks, not local plugin defaults:
+
+```powershell
+./make.ps1 plugin-remote-check
+./make.ps1 plugin-remote-check -BaseUrl https://mirror-public-demo.onrender.com
+```
+
+Expected remote facts:
+
+- `/api/health` and `/api/ready` return public demo mode
+- readiness reports 8 artifacts ok
+- workbench reports 4 branches and 3 claims
+- eval status is `pass`
+- mutation routes remain blocked
+
+## Troubleshooting
+
+If artifacts are missing, regenerate the deterministic demo:
+
+```powershell
+python -m backend.app.cli eval-demo
+```
+
+If the plugin does not appear in Codex UI, first verify:
+
+- `.agents/plugins/marketplace.json` exists at repo root
+- `plugins/mirror-codex/.codex-plugin/plugin.json` has `"name": "mirror-codex"`
+- `.mcp.json` registers only `mirror-demo`
+
+If remote smoke fails with a URL or TLS error, rerun with explicit retries and inspect whether
+PowerShell can reach the endpoints:
+
+```powershell
+Invoke-WebRequest -UseBasicParsing -Uri https://mirror-public-demo.onrender.com/api/health
+Invoke-WebRequest -UseBasicParsing -Uri https://mirror-public-demo.onrender.com/api/ready
+```
+
+If secret scanning fails, do not suppress the finding. Remove the secret-shaped value and rerun:
+
+```powershell
+python scripts/check_no_secrets.py
+```
+
+## Release Gate
+
+For plugin-facing changes, run:
+
+```powershell
+./make.ps1 plugin-release-check
+```
+
+The release gate includes `plugins/mirror-codex/scripts/check_pr_scope.py`. It allows the
+plugin V1 files and reports local-only untracked `docs/plans/...` files separately so they
+stay out of the plugin PR.
+
+To print the exact path list for staging, run:
+
+```powershell
+python plugins/mirror-codex/scripts/check_pr_scope.py --stage-list
+```
+
+Review the output first. To stage only those paths:
+
+```powershell
+python plugins/mirror-codex/scripts/check_pr_scope.py --stage-list | git add --pathspec-from-file=-
+```
+
+If frontend code or frontend routes changed, also run:
+
+```powershell
+npm run build --prefix frontend
+```

--- a/docs/deploy/mirror-codex-plugin.md
+++ b/docs/deploy/mirror-codex-plugin.md
@@ -189,8 +189,9 @@ For plugin-facing changes, run:
 ```
 
 The release gate includes `plugins/mirror-codex/scripts/check_pr_scope.py`. It allows the
-plugin V1 files and reports local-only untracked `docs/plans/...` files separately so they
-stay out of the plugin PR.
+plugin V1 files and reports local-only untracked `docs/plans/...` files plus generated
+`backend/mirror_engine.egg-info/...` packaging metadata separately so they stay out of the
+plugin PR.
 
 To print the exact path list for staging, run:
 

--- a/docs/deploy/render-public-demo.md
+++ b/docs/deploy/render-public-demo.md
@@ -31,6 +31,8 @@ After the Render deploy finishes, verify:
 ```bash
 curl --fail https://<service>.onrender.com/api/health
 curl --fail https://<service>.onrender.com/api/ready
+python scripts/smoke_public_demo_web.py --base-url https://<service>.onrender.com --timeout 60
+MIRROR_PUBLIC_DEMO_BASE_URL=https://<service>.onrender.com make plugin-remote-check
 ```
 
 Expected public behavior:

--- a/docs/releases/mirror-codex-plugin-v1.md
+++ b/docs/releases/mirror-codex-plugin-v1.md
@@ -16,7 +16,8 @@ public demo.
 - `plugin-release-check` local release gate
 - `plugin-remote-check` explicit remote public demo gate
 - deterministic repo-local plugin install acceptance check
-- PR scope hygiene that keeps local-only `docs/plans/...` files out of the plugin PR
+- PR scope hygiene that keeps local-only `docs/plans/...` files and generated
+  `backend/mirror_engine.egg-info/...` packaging metadata out of the plugin PR
 - Linux, Windows, and deploy workflow gates for `plugin-release-check`
 - optional remote public demo smoke with HTTP retry controls
 
@@ -94,7 +95,8 @@ npm run build --prefix frontend
 - `acceptance_check.py` verifies marketplace discovery, plugin manifest shape, `.mcp.json`
   launch, tools/resources/prompts, claim evidence, sanitized documents, and path rejection.
 - `check_pr_scope.py` reports the plugin V1 file scope and excludes local-only untracked
-  `docs/plans/...` files from the plugin PR.
+  `docs/plans/...` files and generated `backend/mirror_engine.egg-info/...` packaging metadata
+  from the plugin PR.
 - MCP output must strip internal path fields such as `artifact_paths`, `summary_path`,
   `trace_path`, `snapshot_dir`, and document `source_path`.
 - Claims returned through the plugin must preserve both `label` and `evidence_ids`.

--- a/docs/releases/mirror-codex-plugin-v1.md
+++ b/docs/releases/mirror-codex-plugin-v1.md
@@ -1,0 +1,156 @@
+# Mirror Codex Plugin v1
+
+Mirror Codex Plugin v1 is the first repo-local Codex plugin surface for Mirror's Phase 1
+public demo.
+
+## Highlights
+
+- repo-local plugin at `plugins/mirror-codex`
+- marketplace entry at `.agents/plugins/marketplace.json`
+- `mirror-demo` skill for deterministic public demo onboarding
+- read-only local MCP server for logical artifact and claim/evidence inspection
+- fixed MCP resources and prompts for safer onboarding navigation
+- documented evidence navigation example for `claim_evacuation_turn`
+- durable MCP contract in `docs/decisions/ADR-0010-mirror-codex-plugin-mcp-contract.md`
+- `plugin-check` target in `Makefile` and `make.ps1`
+- `plugin-release-check` local release gate
+- `plugin-remote-check` explicit remote public demo gate
+- deterministic repo-local plugin install acceptance check
+- PR scope hygiene that keeps local-only `docs/plans/...` files out of the plugin PR
+- Linux, Windows, and deploy workflow gates for `plugin-release-check`
+- optional remote public demo smoke with HTTP retry controls
+
+## Tool Surface
+
+The v1 MCP tool allowlist is:
+
+- `get_demo_manifest`
+- `get_demo_artifact`
+- `get_eval_summary`
+- `explain_demo_claim`
+- `compare_demo_branches`
+
+All tools are read-only, schema-bound, and logical-id-only. They must not accept arbitrary
+filesystem paths, URLs, shell commands, provider config, API keys, or model names.
+
+The v1 MCP resource allowlist uses fixed `mirror-demo://...` URIs for the manifest and
+public demo artifacts. The v1 prompt allowlist is:
+
+- `inspect-public-demo`
+- `review-claim-evidence`
+- `compare-demo-branches`
+
+Resources and prompts are read-only and must not accept arbitrary paths, URLs, provider
+configuration, API keys, user uploads, or mutation requests.
+
+The documented evidence navigation flow uses `demo.claims`, `demo.chunks`, and
+`demo.documents` to map `claim_evacuation_turn` to its `label`, `evidence_ids`, evidence
+chunks, and sanitized document metadata. The example stays bounded to deterministic demo
+support and must not expose stripped path fields such as `source_path`.
+
+## Safety Boundary
+
+The plugin preserves the Phase 1 public demo boundary:
+
+- deterministic-only
+- read-only
+- precomputed canonical Fog Harbor artifacts
+- no Hosted GPT
+- no BYOK
+- no corpus upload
+- no create-world flow
+- no runtime mutation
+- no auth, billing, database, object storage, or quota
+- no provider secrets in repository files, frontend code, build logs, artifacts, or error pages
+
+Mirror remains a constrained, evidence-backed, replayable what-if sandbox for fictional or
+explicitly authorized worlds. It is not a real-world prediction machine, real-person digital
+twin system, political persuasion tool, or high-risk decision system.
+
+## Validation
+
+Local plugin release gate:
+
+```powershell
+./make.ps1 plugin-release-check
+```
+
+Optional explicit remote public demo check:
+
+```powershell
+./make.ps1 plugin-remote-check
+./make.ps1 plugin-remote-check -BaseUrl https://mirror-public-demo.onrender.com
+```
+
+If frontend code or frontend routes changed, also run:
+
+```powershell
+npm run build --prefix frontend
+```
+
+## Acceptance Notes
+
+- `plugin-check` runs plugin static validation, MCP tests, and MCP stdio smoke.
+- `acceptance_check.py` verifies marketplace discovery, plugin manifest shape, `.mcp.json`
+  launch, tools/resources/prompts, claim evidence, sanitized documents, and path rejection.
+- `check_pr_scope.py` reports the plugin V1 file scope and excludes local-only untracked
+  `docs/plans/...` files from the plugin PR.
+- MCP output must strip internal path fields such as `artifact_paths`, `summary_path`,
+  `trace_path`, `snapshot_dir`, and document `source_path`.
+- Claims returned through the plugin must preserve both `label` and `evidence_ids`.
+
+## PR Draft
+
+### What Changed
+
+- Added the repo-local `mirror-codex` Codex plugin with a `Read`-only manifest, `mirror-demo`
+  skill, fixed `.mcp.json`, and local Python MCP server.
+- Added read-only MCP tools, resources, and prompts for the deterministic Fog Harbor public
+  demo. Inputs are logical ids only; tools do not accept filesystem paths, URLs, provider
+  config, API keys, model names, uploads, or mutation requests.
+- Added plugin validation, MCP tests, stdio smoke, deterministic install acceptance, and PR
+  scope hygiene. `plugin-release-check` now runs those checks plus secret scan, phase2 audit,
+  and whitespace diff validation.
+- Added the durable MCP contract ADR and operator docs for install acceptance, evidence
+  navigation, release checks, and explicit remote public demo smoke.
+
+### Tests
+
+- [x] `./make.ps1 plugin-release-check`
+- [x] `python -m pytest backend\tests\test_api.py -q`
+- [x] `python plugins\mirror-codex\scripts\check_pr_scope.py --stage-list`
+- [x] `./make.ps1 plugin-remote-check`
+- [ ] `npm run build --prefix frontend` - not run because this PR does not touch frontend code
+
+### Artifacts
+
+- Direct evidence: local `plugin-release-check` reports plugin validation passed, 8 MCP tests
+  passed, MCP stdio smoke passed, install acceptance passed, PR scope check passed, secret
+  scan passed, and phase2 audit status `pass`.
+- Direct evidence: remote public demo smoke against `https://mirror-public-demo.onrender.com`
+  reports 8 artifacts OK, 3 claims, eval status `pass`, and key pages returning 200.
+- Direct evidence: PR scope check reports local-only untracked `docs/plans/...` files as
+  excluded from the plugin PR.
+- Reasonable inference: `npm run build --prefix frontend` is not required for this PR because
+  the change set does not modify frontend code or frontend routes.
+
+### Contract Impact
+
+- Adds ADR-0010 as the durable v1 contract for the repo-local Mirror Codex plugin MCP surface.
+- Does not change scenario DSL, simulation runtime, public demo artifact layout, claim labels,
+  run trace shape, frontend routes, or backend public API routes.
+- Claims returned through the plugin preserve both `label` and `evidence_ids`.
+
+### Safety Impact
+
+- Preserves the Phase 1 public demo boundary: deterministic-only, read-only, precomputed,
+  anonymous, and local-first for plugin usage.
+- Does not add Hosted GPT, BYOK, corpus upload, create-world, runtime mutation, auth, billing,
+  database, object storage, quotas, or provider secret handling.
+- Does not present Mirror as a real-world prediction tool, real-person digital twin system,
+  political persuasion tool, or high-risk decision system.
+
+### TODO[verify]
+
+- TODO[verify]: Record the exact Codex UI install wording after testing this plugin in a
+  clean Codex versioned environment.

--- a/docs/releases/mirror-codex-plugin-v1.md
+++ b/docs/releases/mirror-codex-plugin-v1.md
@@ -113,6 +113,8 @@ npm run build --prefix frontend
 - Added plugin validation, MCP tests, stdio smoke, deterministic install acceptance, and PR
   scope hygiene. `plugin-release-check` now runs those checks plus secret scan, phase2 audit,
   and whitespace diff validation.
+- Scoped PR hygiene reports local-only plan files and generated editable-install egg metadata
+  separately so they do not get staged into the plugin PR.
 - Added the durable MCP contract ADR and operator docs for install acceptance, evidence
   navigation, release checks, and explicit remote public demo smoke.
 
@@ -131,8 +133,9 @@ npm run build --prefix frontend
   scan passed, and phase2 audit status `pass`.
 - Direct evidence: remote public demo smoke against `https://mirror-public-demo.onrender.com`
   reports 8 artifacts OK, 3 claims, eval status `pass`, and key pages returning 200.
-- Direct evidence: PR scope check reports local-only untracked `docs/plans/...` files as
-  excluded from the plugin PR.
+- Direct evidence: PR scope check reports local-only untracked `docs/plans/...` files and
+  generated `backend/mirror_engine.egg-info/...` packaging metadata as excluded from the
+  plugin PR.
 - Reasonable inference: `npm run build --prefix frontend` is not required for this PR because
   the change set does not modify frontend code or frontend routes.
 

--- a/make.ps1
+++ b/make.ps1
@@ -1,41 +1,80 @@
 param(
     [Parameter(Position = 0)]
-    [string]$Target = "smoke"
+    [string]$Target = "smoke",
+    [string]$BaseUrl = $env:MIRROR_PUBLIC_DEMO_BASE_URL
 )
 
 $ErrorActionPreference = "Stop"
 $Root = Split-Path -Parent $MyInvocation.MyCommand.Path
 $NpmCommand = Get-Command npm.cmd -ErrorAction SilentlyContinue
 $Npm = if ($NpmCommand) { $NpmCommand.Source } else { "npm" }
+$RemoteBaseUrl = if ($BaseUrl) { $BaseUrl } else { "https://mirror-public-demo.onrender.com" }
+$RemoteTimeout = if ($env:MIRROR_REMOTE_SMOKE_TIMEOUT) { $env:MIRROR_REMOTE_SMOKE_TIMEOUT } else { "60" }
+$RemoteRetries = if ($env:MIRROR_REMOTE_SMOKE_RETRIES) { $env:MIRROR_REMOTE_SMOKE_RETRIES } else { "5" }
+$RemoteRetryDelay = if ($env:MIRROR_REMOTE_SMOKE_RETRY_DELAY) { $env:MIRROR_REMOTE_SMOKE_RETRY_DELAY } else { "2" }
+
+function Invoke-Native {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Command,
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$Arguments
+    )
+
+    & $Command @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed with exit code ${LASTEXITCODE}: $Command $($Arguments -join ' ')"
+    }
+}
+
+function Invoke-PluginCheck {
+    Invoke-Native python .\plugins\mirror-codex\scripts\validate_plugin.py
+    Invoke-Native python -m pytest plugins\mirror-codex\tests -q
+    Invoke-Native python .\plugins\mirror-codex\scripts\smoke_mcp_stdio.py
+    Invoke-Native python .\plugins\mirror-codex\scripts\acceptance_check.py
+}
 
 switch ($Target) {
     "setup" {
-        python -m pip install -e "$Root\backend"
+        Invoke-Native python -m pip install -e "$Root\backend"
     }
     "smoke" {
-        python -m backend.app.cli smoke
+        Invoke-Native python -m backend.app.cli smoke
     }
     "test" {
-        python -m pytest backend/tests -q
+        Invoke-Native python -m pytest backend/tests -q
     }
     "eval-demo" {
-        python -m backend.app.cli eval-demo
+        Invoke-Native python -m backend.app.cli eval-demo
     }
     "eval-transfer" {
-        python -m backend.app.cli eval-transfer
+        Invoke-Native python -m backend.app.cli eval-transfer
     }
     "public-demo-check" {
-        python -m backend.app.cli eval-demo
-        python .\scripts\scan_frontend_bundle.py --path artifacts\demo
-        & $Npm run build --prefix frontend
-        python .\scripts\scan_frontend_bundle.py
-        python .\scripts\smoke_public_demo_web.py
+        Invoke-Native python -m backend.app.cli eval-demo
+        Invoke-Native python .\scripts\scan_frontend_bundle.py --path artifacts\demo
+        Invoke-Native $Npm run build --prefix frontend
+        Invoke-Native python .\scripts\scan_frontend_bundle.py
+        Invoke-Native python .\scripts\smoke_public_demo_web.py
+    }
+    "plugin-check" {
+        Invoke-PluginCheck
+    }
+    "plugin-release-check" {
+        Invoke-PluginCheck
+        Invoke-Native python .\plugins\mirror-codex\scripts\check_pr_scope.py
+        Invoke-Native python .\scripts\check_no_secrets.py
+        Invoke-Native python -m backend.app.cli audit-phase phase2
+        Invoke-Native git diff --check
+    }
+    "plugin-remote-check" {
+        Invoke-Native python .\scripts\smoke_public_demo_web.py --base-url $RemoteBaseUrl --timeout $RemoteTimeout --http-retries $RemoteRetries --retry-delay $RemoteRetryDelay
     }
     "dev-api" {
-        python -m uvicorn backend.app.main:app --reload
+        Invoke-Native python -m uvicorn backend.app.main:app --reload
     }
     "dev-web" {
-        & $Npm run dev --prefix frontend
+        Invoke-Native $Npm run dev --prefix frontend
     }
     default {
         throw "Unknown target: $Target"

--- a/plugins/mirror-codex/.codex-plugin/plugin.json
+++ b/plugins/mirror-codex/.codex-plugin/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "mirror-codex",
+  "version": "0.1.0",
+  "description": "Read-only Codex workflows and MCP tools for understanding Mirror's deterministic Phase 1 public demo.",
+  "author": {
+    "name": "YSCJRH",
+    "url": "https://github.com/YSCJRH"
+  },
+  "homepage": "https://github.com/YSCJRH/mirror-sim",
+  "repository": "https://github.com/YSCJRH/mirror-sim",
+  "license": "MIT",
+  "keywords": [
+    "codex",
+    "mirror",
+    "simulation",
+    "deterministic-demo",
+    "read-only",
+    "evidence"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Mirror Codex",
+    "shortDescription": "Inspect Mirror's deterministic public demo safely.",
+    "longDescription": "Mirror Codex helps developers understand the read-only deterministic Fog Harbor public demo, inspect claim-linked evidence, run local checks, and keep provider secrets out of repository, frontend, logs, artifacts, and error output. Its MCP server exposes only hardcoded read-only tools over logical demo artifact ids and does not call model providers.",
+    "developerName": "YSCJRH",
+    "category": "Engineering",
+    "capabilities": [
+      "Read"
+    ],
+    "websiteURL": "https://github.com/YSCJRH/mirror-sim",
+    "privacyPolicyURL": "https://github.com/YSCJRH/mirror-sim#phase-1-public-demo-mode",
+    "termsOfServiceURL": "https://github.com/YSCJRH/mirror-sim/blob/main/LICENSE",
+    "defaultPrompt": [
+      "Use Mirror Demo to explain the public demo safety boundary.",
+      "Use Mirror Demo to inspect claims and evidence.",
+      "Use Mirror Demo to run public demo checks."
+    ],
+    "brandColor": "#2563EB",
+    "screenshots": []
+  }
+}

--- a/plugins/mirror-codex/.mcp.json
+++ b/plugins/mirror-codex/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "mirror-demo": {
+      "command": "python",
+      "args": [
+        "./scripts/run_mcp.py"
+      ]
+    }
+  }
+}

--- a/plugins/mirror-codex/README.md
+++ b/plugins/mirror-codex/README.md
@@ -116,7 +116,8 @@ git diff --check
 ```
 
 The PR scope check allows this plugin V1 change set and reports local-only untracked
-`docs/plans/...` files separately so they do not get staged into the plugin PR.
+`docs/plans/...` files and generated `backend/mirror_engine.egg-info/...` packaging metadata
+separately so they do not get staged into the plugin PR.
 
 To prepare a precise staging list without adding local-only plan files:
 

--- a/plugins/mirror-codex/README.md
+++ b/plugins/mirror-codex/README.md
@@ -1,0 +1,163 @@
+# Mirror Codex Plugin
+
+Mirror Codex is a repo-local Codex plugin for understanding Mirror's Phase 1 public demo.
+
+This first version is intentionally read-only and local-first. It packages one skill, `mirror-demo`, plus a small MCP server that guides Codex through the deterministic Fog Harbor demo without accepting arbitrary artifact paths, uploading data, calling model providers, or enabling runtime mutation.
+
+## Boundaries
+
+- Mirror is a constrained, evidence-backed, replayable what-if simulation sandbox for fictional or explicitly authorized worlds.
+- The Phase 1 public demo is deterministic-only, read-only, anonymous, and precomputed.
+- The public path does not create worlds, upload corpora, start new runs, enable Hosted GPT or BYOK, call the OpenAI API, add auth, add billing, add a database, add object storage, or add quotas.
+- User configuration and provider secrets must stay in the user's local environment or their own deployment environment. They must not be committed, exposed to frontend code, printed in build logs, written to artifacts, or included in error pages.
+- Do not use `NEXT_PUBLIC_OPENAI_API_KEY`.
+
+## Contents
+
+- `.codex-plugin/plugin.json`: Codex plugin metadata with `Read` capability only.
+- `skills/mirror-demo/SKILL.md`: Workflow instructions for safe demo inspection.
+- `.mcp.json`: MCP server registration for the fixed read-only `mirror-demo` stdio server.
+- `mirror_codex_mcp/`: Local Python implementation for read-only demo tools.
+- `scripts/run_mcp.py`: MCP server entrypoint.
+- `scripts/smoke_mcp_stdio.py`: Fixed stdio smoke test for plugin install readiness.
+- `scripts/acceptance_check.py`: Repo-local plugin install acceptance check.
+- `scripts/check_pr_scope.py`: Workspace scope check for the plugin V1 PR.
+- `scripts/validate_plugin.py`: Static validation for the plugin shell.
+- `tests/`: Plugin MCP and sanitizer tests.
+
+## Runbook
+
+Use `docs/deploy/mirror-codex-plugin.md` for clean Codex install acceptance. Use `docs/releases/mirror-codex-plugin-v1.md` for the v1 release note and validation gate.
+
+## MCP Tools
+
+The MCP server exposes only these read-only tools:
+
+- `get_demo_manifest`
+- `get_demo_artifact`
+- `get_eval_summary`
+- `explain_demo_claim`
+- `compare_demo_branches`
+
+Tool inputs are logical ids such as `demo.claims`, `claim_evacuation_turn`, and `branch_reporter_detained`. Inputs are not filesystem paths, URLs, shell commands, provider names, or API-key fields.
+
+## MCP Resources And Prompts
+
+The MCP server also exposes read-only resources and prompts for easier onboarding.
+
+Resource URIs are fixed allowlist entries:
+
+- `mirror-demo://manifest`
+- `mirror-demo://artifact/demo.claims`
+- `mirror-demo://artifact/demo.eval_summary`
+- `mirror-demo://artifact/demo.compare`
+
+The full artifact URI set mirrors the logical public demo artifact ids. Prompt names are fixed allowlist entries:
+
+- `inspect-public-demo`
+- `review-claim-evidence`
+- `compare-demo-branches`
+
+Resources and prompts do not accept arbitrary paths, URLs, commands, provider config, API keys, model names, uploads, or mutation requests.
+
+## Evidence Navigation Example
+
+For a bounded claim review, use fixed MCP resources or equivalent logical artifact ids:
+
+1. Read `mirror-demo://artifact/demo.claims`.
+2. Select `claim_evacuation_turn`.
+3. Preserve the claim `label` and `evidence_ids` in any summary.
+4. Read `mirror-demo://artifact/demo.chunks` and match these evidence ids:
+   `chunk_doc_budget_minutes_002`, `chunk_doc_budget_minutes_003`, and
+   `chunk_doc_engineering_inspection_002`.
+5. Read `mirror-demo://artifact/demo.documents` and match each chunk's `document_id` to
+   sanitized document metadata.
+6. Phrase the conclusion as "based on the current corpus and deterministic rules"; do not
+   present it as a real-world prediction.
+
+Do not ask the user for filesystem paths, URLs, provider keys, or local config during this
+workflow. Public and plugin-facing output must not expose stripped path fields such as
+`source_path`.
+
+## MCP Contract
+
+The durable v1 MCP contract is recorded in `docs/decisions/ADR-0010-mirror-codex-plugin-mcp-contract.md`. Keep the plugin README, skill, validator, and tests in sync with that ADR when changing the tool surface.
+
+Contract summary:
+
+- One fixed local stdio server: `python ./scripts/run_mcp.py`.
+- Five allowlisted read-only tools, all with `annotations.readOnlyHint: true`.
+- Fixed read-only resources under `mirror-demo://...` and fixed prompt names.
+- Closed input schemas with `additionalProperties: false`.
+- Logical ids only; no arbitrary paths, URLs, commands, provider config, API keys, or model names.
+- Sanitized output only; no `artifact_paths`, `summary_path`, `trace_path`, `snapshot_dir`, or document `source_path`.
+- Claims returned through the plugin must keep both `label` and `evidence_ids`.
+
+## Typical Checks
+
+Run these from the repository root:
+
+```powershell
+./make.ps1 plugin-check
+./make.ps1 plugin-release-check
+```
+
+`plugin-check` runs static validation, MCP tests, the fixed stdio smoke, and repo-local plugin install acceptance. `plugin-release-check` adds plugin PR scope hygiene, secret scanning, phase2 audit, and whitespace diff validation. To run the same release steps manually:
+
+```powershell
+python plugins/mirror-codex/scripts/validate_plugin.py
+python -m pytest plugins/mirror-codex/tests -q
+python plugins/mirror-codex/scripts/smoke_mcp_stdio.py
+python plugins/mirror-codex/scripts/acceptance_check.py
+python plugins/mirror-codex/scripts/check_pr_scope.py
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-phase phase2
+git diff --check
+```
+
+The PR scope check allows this plugin V1 change set and reports local-only untracked
+`docs/plans/...` files separately so they do not get staged into the plugin PR.
+
+To prepare a precise staging list without adding local-only plan files:
+
+```powershell
+python plugins/mirror-codex/scripts/check_pr_scope.py --stage-list
+```
+
+The output is path-only and can be reviewed before staging, or piped to Git:
+
+```powershell
+python plugins/mirror-codex/scripts/check_pr_scope.py --stage-list | git add --pathspec-from-file=-
+```
+
+For a clean local install check, enable the repo-local `mirror-codex` plugin from `.agents/plugins/marketplace.json`, then ask Codex to use the `mirror-demo` skill to inspect `demo.claims` and compare `branch_reporter_detained`. The same MCP path is covered by `smoke_mcp_stdio.py`.
+
+Remote public demo checks are optional and must be explicit. They are not part of `plugin-check`:
+
+```powershell
+./make.ps1 plugin-remote-check
+./make.ps1 plugin-remote-check -BaseUrl https://mirror-public-demo.onrender.com
+```
+
+Keep this remote check out of default local validation so the plugin remains local-first and usable without network access.
+
+If a later change touches frontend code, also run:
+
+```powershell
+npm run build --prefix frontend
+```
+
+## Public Demo Surfaces
+
+Use logical artifact ids from the public manifest:
+
+- `demo.report`
+- `demo.claims`
+- `demo.eval_summary`
+- `demo.compare`
+- `demo.documents`
+- `demo.chunks`
+- `demo.graph`
+- `demo.rubric`
+
+Do not treat a user-supplied filesystem path as a demo artifact id.

--- a/plugins/mirror-codex/mirror_codex_mcp/__init__.py
+++ b/plugins/mirror-codex/mirror_codex_mcp/__init__.py
@@ -1,0 +1,5 @@
+"""Read-only MCP helpers for the Mirror Codex plugin."""
+
+from .server import main
+
+__all__ = ["main"]

--- a/plugins/mirror-codex/mirror_codex_mcp/server.py
+++ b/plugins/mirror-codex/mirror_codex_mcp/server.py
@@ -1,0 +1,645 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+
+SERVER_NAME = "mirror-codex"
+SERVER_VERSION = "0.1.0"
+PROTOCOL_VERSION = "2025-06-18"
+REFERENCE_BRANCH_ID = "branch_baseline"
+PUBLIC_DEMO_ARTIFACTS: dict[str, dict[str, Any]] = {
+    "demo.report": {
+        "label": "Canonical report",
+        "kind": "text",
+        "mediaType": "text/markdown; charset=utf-8",
+        "root": "artifacts",
+        "path": ("report", "report.md"),
+    },
+    "demo.claims": {
+        "label": "Claims",
+        "kind": "json",
+        "mediaType": "application/json; charset=utf-8",
+        "root": "artifacts",
+        "path": ("report", "claims.json"),
+    },
+    "demo.eval_summary": {
+        "label": "Evaluation summary",
+        "kind": "json",
+        "mediaType": "application/json; charset=utf-8",
+        "root": "artifacts",
+        "path": ("eval", "summary.json"),
+    },
+    "demo.compare": {
+        "label": "Branch comparison",
+        "kind": "json",
+        "mediaType": "application/json; charset=utf-8",
+        "root": "artifacts",
+        "path": ("compare", "scenario_fog_harbor_phase44_matrix", "compare.json"),
+    },
+    "demo.documents": {
+        "label": "Evidence documents",
+        "kind": "jsonl",
+        "mediaType": "application/x-ndjson; charset=utf-8",
+        "root": "artifacts",
+        "path": ("ingest", "documents.jsonl"),
+    },
+    "demo.chunks": {
+        "label": "Evidence chunks",
+        "kind": "jsonl",
+        "mediaType": "application/x-ndjson; charset=utf-8",
+        "root": "artifacts",
+        "path": ("ingest", "chunks.jsonl"),
+    },
+    "demo.graph": {
+        "label": "World graph",
+        "kind": "json",
+        "mediaType": "application/json; charset=utf-8",
+        "root": "artifacts",
+        "path": ("graph", "graph.json"),
+    },
+    "demo.rubric": {
+        "label": "Human review rubric",
+        "kind": "text",
+        "mediaType": "text/markdown; charset=utf-8",
+        "root": "repo",
+        "path": ("docs", "rubrics", "human-review.md"),
+    },
+}
+BRANCH_IDS = (
+    "branch_baseline",
+    "branch_harbor_comms_failure",
+    "branch_mayor_signal_blocked",
+    "branch_reporter_detained",
+)
+RESOURCE_URI_PREFIX = "mirror-demo://artifact/"
+RESOURCE_URIS = {
+    "mirror-demo://manifest": "demo.manifest",
+    **{
+        f"{RESOURCE_URI_PREFIX}{artifact_id}": artifact_id
+        for artifact_id in PUBLIC_DEMO_ARTIFACTS
+    },
+}
+PROMPT_NAMES = (
+    "inspect-public-demo",
+    "review-claim-evidence",
+    "compare-demo-branches",
+)
+
+
+class ToolInputError(ValueError):
+    """Raised when a tool input violates the logical-id contract."""
+
+
+class ToolDataError(RuntimeError):
+    """Raised when canonical demo artifacts are missing or invalid."""
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def artifacts_root() -> Path:
+    return repo_root() / "artifacts" / "demo"
+
+
+def reject_path_like(value: str, field_name: str) -> None:
+    if any(part in value for part in ("/", "\\", ":", "..")) or value.startswith("."):
+        raise ToolInputError(
+            f"{field_name} must be a logical Mirror demo id, not a filesystem path or URL."
+        )
+
+
+def parse_jsonl(text: str) -> list[Any]:
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+def sanitize_public_artifact(artifact_id: str, data: Any) -> Any:
+    if artifact_id == "demo.eval_summary" and isinstance(data, dict):
+        return {key: value for key, value in data.items() if key != "artifact_paths"}
+
+    if artifact_id == "demo.compare" and isinstance(data, dict):
+        public_compare = dict(data)
+        public_branches = []
+        for branch in public_compare.get("branches", []):
+            if isinstance(branch, dict):
+                public_branches.append(
+                    {
+                        key: value
+                        for key, value in branch.items()
+                        if key not in {"summary_path", "trace_path", "snapshot_dir"}
+                    }
+                )
+            else:
+                public_branches.append(branch)
+        public_compare["branches"] = public_branches
+        return public_compare
+
+    if artifact_id == "demo.documents" and isinstance(data, list):
+        return [
+            {key: value for key, value in row.items() if key != "source_path"}
+            if isinstance(row, dict)
+            else row
+            for row in data
+        ]
+
+    return data
+
+
+def manifest_entry(artifact_id: str, artifact: dict[str, Any]) -> dict[str, str]:
+    return {
+        "id": artifact_id,
+        "label": str(artifact["label"]),
+        "kind": str(artifact["kind"]),
+        "mediaType": str(artifact["mediaType"]),
+    }
+
+
+def get_demo_manifest() -> dict[str, Any]:
+    return {
+        "demo": "fog-harbor",
+        "mode": "deterministic-only",
+        "mutation": "disabled",
+        "artifacts": [
+            manifest_entry(artifact_id, artifact)
+            for artifact_id, artifact in PUBLIC_DEMO_ARTIFACTS.items()
+        ],
+    }
+
+
+def artifact_path(artifact_id: str) -> Path:
+    reject_path_like(artifact_id, "artifact_id")
+    artifact = PUBLIC_DEMO_ARTIFACTS.get(artifact_id)
+    if not artifact:
+        raise ToolInputError(f"Artifact id `{artifact_id}` is not in the public demo allowlist.")
+    root = repo_root() if artifact["root"] == "repo" else artifacts_root()
+    return root.joinpath(*artifact["path"])
+
+
+def read_demo_artifact_payload(artifact_id: str) -> tuple[str, Any]:
+    path = artifact_path(artifact_id)
+    artifact = PUBLIC_DEMO_ARTIFACTS[artifact_id]
+    try:
+        text = path.read_text(encoding="utf-8")
+        if artifact["kind"] == "json":
+            return "data", sanitize_public_artifact(artifact_id, json.loads(text))
+        if artifact["kind"] == "jsonl":
+            return "rows", sanitize_public_artifact(artifact_id, parse_jsonl(text))
+        return "content", text
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ToolDataError(
+            f"Canonical demo artifact `{artifact_id}` is unavailable. Run `python -m backend.app.cli eval-demo` first."
+        ) from exc
+
+
+def get_demo_artifact(artifact_id: str) -> dict[str, Any]:
+    payload_key, payload = read_demo_artifact_payload(artifact_id)
+    return {
+        "id": artifact_id,
+        "kind": PUBLIC_DEMO_ARTIFACTS[artifact_id]["kind"],
+        payload_key: payload,
+    }
+
+
+def get_eval_summary() -> dict[str, Any]:
+    return get_demo_artifact("demo.eval_summary")
+
+
+def resource_definitions() -> list[dict[str, str]]:
+    resources = [
+        {
+            "uri": "mirror-demo://manifest",
+            "name": "Mirror public demo manifest",
+            "description": "Allowlisted logical artifact ids for the deterministic public demo.",
+            "mimeType": "application/json; charset=utf-8",
+        }
+    ]
+    resources.extend(
+        {
+            "uri": f"{RESOURCE_URI_PREFIX}{artifact_id}",
+            "name": str(artifact["label"]),
+            "description": f"Read-only Mirror public demo artifact `{artifact_id}`.",
+            "mimeType": str(artifact["mediaType"]),
+        }
+        for artifact_id, artifact in PUBLIC_DEMO_ARTIFACTS.items()
+    )
+    return resources
+
+
+def read_resource(uri: str) -> dict[str, Any]:
+    if uri not in RESOURCE_URIS:
+        raise ToolInputError(f"Resource uri `{uri}` is not in the Mirror demo allowlist.")
+    if uri == "mirror-demo://manifest":
+        return {
+            "contents": [
+                {
+                    "uri": uri,
+                    "mimeType": "application/json; charset=utf-8",
+                    "text": json.dumps(get_demo_manifest(), ensure_ascii=False, indent=2),
+                }
+            ]
+        }
+
+    artifact_id = RESOURCE_URIS[uri]
+    artifact = get_demo_artifact(artifact_id)
+    media_type = str(PUBLIC_DEMO_ARTIFACTS[artifact_id]["mediaType"])
+    if "content" in artifact:
+        text = str(artifact["content"])
+    else:
+        text = json.dumps(artifact, ensure_ascii=False, indent=2)
+    return {"contents": [{"uri": uri, "mimeType": media_type, "text": text}]}
+
+
+def explain_demo_claim(claim_id: str) -> dict[str, Any]:
+    reject_path_like(claim_id, "claim_id")
+    claims = get_demo_artifact("demo.claims")["data"]
+    chunks = get_demo_artifact("demo.chunks")["rows"]
+    documents = get_demo_artifact("demo.documents")["rows"]
+    claim = next((item for item in claims if item.get("claim_id") == claim_id), None)
+    if claim is None:
+        raise ToolInputError(f"Claim id `{claim_id}` is not present in demo.claims.")
+
+    evidence_ids = set(claim.get("evidence_ids", []))
+    evidence_chunks = [chunk for chunk in chunks if chunk.get("chunk_id") in evidence_ids]
+    document_ids = {chunk.get("document_id") for chunk in evidence_chunks}
+    evidence_documents = [
+        document for document in documents if document.get("document_id") in document_ids
+    ]
+
+    return {
+        "claim": claim,
+        "evidence_chunks": evidence_chunks,
+        "evidence_documents": evidence_documents,
+        "notes": [
+            "This explanation is bounded to the canonical deterministic Fog Harbor demo artifacts.",
+            "The claim keeps both label and evidence_ids for reviewability.",
+        ],
+    }
+
+
+def compare_demo_branches(candidate_branch_id: str, reference_branch_id: str = REFERENCE_BRANCH_ID) -> dict[str, Any]:
+    reject_path_like(candidate_branch_id, "candidate_branch_id")
+    reject_path_like(reference_branch_id, "reference_branch_id")
+    if reference_branch_id != REFERENCE_BRANCH_ID:
+        raise ToolInputError(f"Only `{REFERENCE_BRANCH_ID}` is supported as the reference branch.")
+
+    compare = get_demo_artifact("demo.compare")["data"]
+    branches = compare.get("branches", [])
+    branch = next((item for item in branches if item.get("branch_id") == candidate_branch_id), None)
+    if branch is None:
+        raise ToolInputError(f"Branch id `{candidate_branch_id}` is not present in demo.compare.")
+    if branch.get("is_reference"):
+        raise ToolInputError("Choose a non-reference candidate branch.")
+
+    delta = next(
+        (item for item in compare.get("reference_deltas", []) if item.get("branch_id") == candidate_branch_id),
+        None,
+    )
+    if delta is None:
+        raise ToolDataError(f"No reference delta exists for `{candidate_branch_id}`.")
+
+    return {
+        "compare_id": compare.get("compare_id"),
+        "scenario_id": compare.get("scenario_id"),
+        "seed": compare.get("seed"),
+        "reference_branch_id": reference_branch_id,
+        "candidate_branch": branch,
+        "delta": delta,
+        "notes": [
+            "This is a deterministic branch comparison, not a real-world prediction.",
+            "Path-bearing branch fields are removed from public MCP output.",
+        ],
+    }
+
+
+def schema_string(description: str, enum: tuple[str, ...] | None = None) -> dict[str, Any]:
+    schema: dict[str, Any] = {"type": "string", "description": description}
+    if enum:
+        schema["enum"] = list(enum)
+    return schema
+
+
+def prompt_definitions() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": "inspect-public-demo",
+            "title": "Inspect Public Demo",
+            "description": "Guide a read-only inspection of the deterministic Fog Harbor public demo.",
+            "arguments": [],
+        },
+        {
+            "name": "review-claim-evidence",
+            "title": "Review Claim Evidence",
+            "description": "Guide claim and evidence review while preserving label and evidence_ids.",
+            "arguments": [],
+        },
+        {
+            "name": "compare-demo-branches",
+            "title": "Compare Demo Branches",
+            "description": "Guide deterministic branch comparison against the baseline branch.",
+            "arguments": [],
+        },
+    ]
+
+
+def prompt_messages(name: str, arguments: Any | None = None) -> dict[str, Any]:
+    if name not in PROMPT_NAMES:
+        raise ToolInputError(f"Prompt `{name}` is not in the Mirror demo allowlist.")
+    if arguments not in (None, {}):
+        raise ToolInputError(f"Prompt `{name}` does not accept arguments.")
+
+    prompts = {
+        "inspect-public-demo": (
+            "Inspect Mirror's deterministic Phase 1 public demo in read-only mode. "
+            "Use logical artifact ids or mirror-demo:// resources only. Summarize the manifest, "
+            "eval status, and safety boundary without presenting the demo as a real-world prediction."
+        ),
+        "review-claim-evidence": (
+            "Review demo.claims and explain claim_evacuation_turn with its evidence. "
+            "Keep both label and evidence_ids in the answer, cite bounded deterministic-demo context, "
+            "and do not use filesystem paths or provider calls."
+        ),
+        "compare-demo-branches": (
+            "Compare branch_reporter_detained against branch_baseline using the deterministic demo compare artifact. "
+            "Describe branch deltas as scenario-bounded what-if output, not certain real-world conclusions."
+        ),
+    }
+    return {
+        "description": prompt_definitions()[PROMPT_NAMES.index(name)]["description"],
+        "messages": [
+            {
+                "role": "user",
+                "content": {
+                    "type": "text",
+                    "text": prompts[name],
+                },
+            }
+        ],
+    }
+
+
+def tool_definitions() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": "get_demo_manifest",
+            "title": "Get Demo Manifest",
+            "description": "Return the allowlisted logical artifact ids for the deterministic Mirror public demo.",
+            "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
+            "annotations": {"readOnlyHint": True},
+        },
+        {
+            "name": "get_demo_artifact",
+            "title": "Get Demo Artifact",
+            "description": "Return one allowlisted public demo artifact by logical artifact id.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "artifact_id": schema_string(
+                        "Logical public demo artifact id, never a filesystem path.",
+                        tuple(PUBLIC_DEMO_ARTIFACTS.keys()),
+                    )
+                },
+                "required": ["artifact_id"],
+                "additionalProperties": False,
+            },
+            "annotations": {"readOnlyHint": True},
+        },
+        {
+            "name": "get_eval_summary",
+            "title": "Get Eval Summary",
+            "description": "Return the sanitized deterministic eval summary for the canonical public demo.",
+            "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
+            "annotations": {"readOnlyHint": True},
+        },
+        {
+            "name": "explain_demo_claim",
+            "title": "Explain Demo Claim",
+            "description": "Return a demo claim with its evidence chunks and document metadata by claim id.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "claim_id": schema_string("Claim id from demo.claims, never a path or query.")
+                },
+                "required": ["claim_id"],
+                "additionalProperties": False,
+            },
+            "annotations": {"readOnlyHint": True},
+        },
+        {
+            "name": "compare_demo_branches",
+            "title": "Compare Demo Branches",
+            "description": "Return the deterministic delta between the baseline and one candidate demo branch.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "candidate_branch_id": schema_string(
+                        "Candidate branch id from demo.compare.",
+                        tuple(branch for branch in BRANCH_IDS if branch != REFERENCE_BRANCH_ID),
+                    ),
+                    "reference_branch_id": schema_string(
+                        "Reference branch id. Only branch_baseline is supported.",
+                        (REFERENCE_BRANCH_ID,),
+                    ),
+                },
+                "required": ["candidate_branch_id"],
+                "additionalProperties": False,
+            },
+            "annotations": {"readOnlyHint": True},
+        },
+    ]
+
+
+def require_string(arguments: dict[str, Any], name: str) -> str:
+    value = arguments.get(name)
+    if not isinstance(value, str) or not value:
+        raise ToolInputError(f"`{name}` must be a non-empty string.")
+    return value
+
+
+TOOL_HANDLERS: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = {
+    "get_demo_manifest": lambda _arguments: get_demo_manifest(),
+    "get_demo_artifact": lambda arguments: get_demo_artifact(require_string(arguments, "artifact_id")),
+    "get_eval_summary": lambda _arguments: get_eval_summary(),
+    "explain_demo_claim": lambda arguments: explain_demo_claim(require_string(arguments, "claim_id")),
+}
+TOOL_ALLOWED_ARGUMENTS: dict[str, set[str]] = {
+    "get_demo_manifest": set(),
+    "get_demo_artifact": {"artifact_id"},
+    "get_eval_summary": set(),
+    "explain_demo_claim": {"claim_id"},
+    "compare_demo_branches": {"candidate_branch_id", "reference_branch_id"},
+}
+
+
+def handle_compare_demo_branches(arguments: dict[str, Any]) -> dict[str, Any]:
+    reference_branch_id = arguments.get("reference_branch_id", REFERENCE_BRANCH_ID)
+    if not isinstance(reference_branch_id, str):
+        raise ToolInputError("`reference_branch_id` must be a string when provided.")
+    return compare_demo_branches(
+        require_string(arguments, "candidate_branch_id"),
+        reference_branch_id,
+    )
+
+
+TOOL_HANDLERS["compare_demo_branches"] = handle_compare_demo_branches
+
+
+def tool_result(payload: dict[str, Any], *, is_error: bool = False) -> dict[str, Any]:
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": json.dumps(payload, ensure_ascii=False, indent=2),
+            }
+        ],
+        "structuredContent": payload,
+        "isError": is_error,
+    }
+
+
+def call_tool(name: str, arguments: Any | None) -> dict[str, Any]:
+    if name not in TOOL_HANDLERS:
+        raise KeyError(name)
+    if arguments is None:
+        arguments = {}
+    if not isinstance(arguments, dict):
+        return tool_result({"error": "arguments must be an object"}, is_error=True)
+    try:
+        extra_arguments = set(arguments) - TOOL_ALLOWED_ARGUMENTS[name]
+        if extra_arguments:
+            raise ToolInputError(
+                f"Unsupported argument(s) for `{name}`: {', '.join(sorted(extra_arguments))}."
+            )
+        return tool_result(TOOL_HANDLERS[name](arguments))
+    except (ToolInputError, ToolDataError) as exc:
+        return tool_result({"error": str(exc)}, is_error=True)
+
+
+def success_response(request_id: Any, result: dict[str, Any]) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+
+def error_response(request_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}}
+
+
+def handle_request(message: dict[str, Any]) -> dict[str, Any] | None:
+    request_id = message.get("id")
+    method = message.get("method")
+    is_notification = "id" not in message
+
+    if method == "notifications/initialized":
+        return None
+    if is_notification:
+        return None
+    if method == "initialize":
+        params = message.get("params")
+        client_protocol = params.get("protocolVersion") if isinstance(params, dict) else None
+        return success_response(
+            request_id,
+            {
+                "protocolVersion": client_protocol if isinstance(client_protocol, str) else PROTOCOL_VERSION,
+                "capabilities": {
+                    "tools": {"listChanged": False},
+                    "resources": {"listChanged": False},
+                    "prompts": {"listChanged": False},
+                },
+                "serverInfo": {"name": SERVER_NAME, "version": SERVER_VERSION},
+            },
+        )
+    if method == "ping":
+        return success_response(request_id, {})
+    if method == "resources/list":
+        return success_response(request_id, {"resources": resource_definitions()})
+    if method == "resources/read":
+        params = message.get("params")
+        if not isinstance(params, dict) or not isinstance(params.get("uri"), str):
+            return error_response(request_id, -32602, "resources/read requires params.uri.")
+        extra_params = set(params) - {"uri"}
+        if extra_params:
+            return error_response(
+                request_id,
+                -32602,
+                f"Unsupported resources/read parameter(s): {', '.join(sorted(extra_params))}.",
+            )
+        try:
+            return success_response(request_id, read_resource(params["uri"]))
+        except (ToolInputError, ToolDataError) as exc:
+            return error_response(request_id, -32602, str(exc))
+    if method == "prompts/list":
+        return success_response(request_id, {"prompts": prompt_definitions()})
+    if method == "prompts/get":
+        params = message.get("params")
+        if not isinstance(params, dict) or not isinstance(params.get("name"), str):
+            return error_response(request_id, -32602, "prompts/get requires params.name.")
+        extra_params = set(params) - {"name", "arguments"}
+        if extra_params:
+            return error_response(
+                request_id,
+                -32602,
+                f"Unsupported prompts/get parameter(s): {', '.join(sorted(extra_params))}.",
+            )
+        try:
+            return success_response(
+                request_id,
+                prompt_messages(params["name"], params.get("arguments")),
+            )
+        except ToolInputError as exc:
+            return error_response(request_id, -32602, str(exc))
+    if method == "tools/list":
+        return success_response(request_id, {"tools": tool_definitions()})
+    if method == "tools/call":
+        params = message.get("params")
+        if not isinstance(params, dict) or not isinstance(params.get("name"), str):
+            return error_response(request_id, -32602, "tools/call requires params.name.")
+        try:
+            return success_response(request_id, call_tool(params["name"], params.get("arguments")))
+        except KeyError:
+            return error_response(request_id, -32601, f"Unknown tool: {params['name']}")
+
+    return error_response(request_id, -32601, f"Unknown method: {method}")
+
+
+def write_message(message: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(message, ensure_ascii=False, separators=(",", ":")) + "\n")
+    sys.stdout.flush()
+
+
+def serve_stdio() -> int:
+    for line in sys.stdin:
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            write_message(error_response(None, -32700, "Parse error"))
+            continue
+        if isinstance(payload, list):
+            responses = []
+            for item in payload:
+                if isinstance(item, dict):
+                    response = handle_request(item)
+                    if response is not None:
+                        responses.append(response)
+                else:
+                    responses.append(error_response(None, -32600, "Invalid Request"))
+            if responses:
+                write_message(responses)  # type: ignore[arg-type]
+            continue
+        if not isinstance(payload, dict):
+            write_message(error_response(None, -32600, "Invalid Request"))
+            continue
+        response = handle_request(payload)
+        if response is not None:
+            write_message(response)
+    return 0
+
+
+def main() -> int:
+    return serve_stdio()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/mirror-codex/scripts/acceptance_check.py
+++ b/plugins/mirror-codex/scripts/acceptance_check.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+sys.dont_write_bytecode = True
+PLUGIN_NAME = "mirror-codex"
+MCP_SERVER_NAME = "mirror-demo"
+REPO_ROOT = Path(__file__).resolve().parents[3]
+EXPECTED_TOOLS = {
+    "get_demo_manifest",
+    "get_demo_artifact",
+    "get_eval_summary",
+    "explain_demo_claim",
+    "compare_demo_branches",
+}
+EXPECTED_RESOURCES = {
+    "mirror-demo://manifest",
+    "mirror-demo://artifact/demo.report",
+    "mirror-demo://artifact/demo.claims",
+    "mirror-demo://artifact/demo.eval_summary",
+    "mirror-demo://artifact/demo.compare",
+    "mirror-demo://artifact/demo.documents",
+    "mirror-demo://artifact/demo.chunks",
+    "mirror-demo://artifact/demo.graph",
+    "mirror-demo://artifact/demo.rubric",
+}
+EXPECTED_PROMPTS = {
+    "inspect-public-demo",
+    "review-claim-evidence",
+    "compare-demo-branches",
+}
+EXPECTED_EVIDENCE_IDS = {
+    "chunk_doc_budget_minutes_002",
+    "chunk_doc_budget_minutes_003",
+    "chunk_doc_engineering_inspection_002",
+}
+FORBIDDEN_OUTPUT_FIELDS = {
+    "artifact_paths",
+    "summary_path",
+    "trace_path",
+    "snapshot_dir",
+    "source_path",
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise AssertionError(f"{path} must contain a JSON object.")
+    return payload
+
+
+def assert_inside(base: Path, candidate: Path) -> None:
+    try:
+        candidate.resolve().relative_to(base.resolve())
+    except ValueError as exc:
+        raise AssertionError(f"Path escapes repository root: {candidate}") from exc
+
+
+def marketplace_plugin_root() -> Path:
+    marketplace = load_json(REPO_ROOT / ".agents" / "plugins" / "marketplace.json")
+    plugins = marketplace.get("plugins")
+    if not isinstance(plugins, list):
+        raise AssertionError("marketplace plugins must be a list.")
+
+    entry = next((item for item in plugins if isinstance(item, dict) and item.get("name") == PLUGIN_NAME), None)
+    if entry is None:
+        raise AssertionError("marketplace does not include mirror-codex.")
+    if entry.get("policy") != {"installation": "AVAILABLE", "authentication": "ON_INSTALL"}:
+        raise AssertionError("marketplace policy must keep mirror-codex available and on-install authenticated.")
+    if entry.get("category") != "Engineering":
+        raise AssertionError("marketplace category must remain Engineering.")
+
+    source = entry.get("source")
+    if source != {"source": "local", "path": "./plugins/mirror-codex"}:
+        raise AssertionError("marketplace source must be the fixed repo-local plugin path.")
+
+    source_path = Path(source["path"])
+    if source_path.is_absolute() or ".." in source_path.parts:
+        raise AssertionError("marketplace plugin path must be a repository-relative local path.")
+
+    plugin_root = (REPO_ROOT / source_path).resolve()
+    assert_inside(REPO_ROOT, plugin_root)
+    if not plugin_root.is_dir():
+        raise AssertionError(f"marketplace plugin path does not exist: {plugin_root}")
+    return plugin_root
+
+
+def validate_plugin_shell(plugin_root: Path) -> dict[str, Any]:
+    manifest = load_json(plugin_root / ".codex-plugin" / "plugin.json")
+    if manifest.get("name") != PLUGIN_NAME:
+        raise AssertionError("plugin manifest name must match mirror-codex.")
+    if manifest.get("skills") != "./skills/":
+        raise AssertionError("plugin manifest must expose ./skills/.")
+    if manifest.get("mcpServers") != "./.mcp.json":
+        raise AssertionError("plugin manifest must point to ./.mcp.json.")
+    if "hooks" in manifest or "apps" in manifest:
+        raise AssertionError("v1 install acceptance forbids hooks and apps.")
+    if manifest.get("interface", {}).get("capabilities") != ["Read"]:
+        raise AssertionError("plugin manifest capability must be Read only.")
+
+    skills_path = (plugin_root / manifest["skills"]).resolve()
+    assert_inside(plugin_root, skills_path)
+    if not (skills_path / "mirror-demo" / "SKILL.md").is_file():
+        raise AssertionError("mirror-demo skill is missing from plugin skills path.")
+
+    mcp_path = (plugin_root / manifest["mcpServers"]).resolve()
+    assert_inside(plugin_root, mcp_path)
+    mcp_config = load_json(mcp_path)
+    servers = mcp_config.get("mcpServers")
+    if not isinstance(servers, dict) or set(servers) != {MCP_SERVER_NAME}:
+        raise AssertionError(".mcp.json must register only mirror-demo.")
+    server = servers[MCP_SERVER_NAME]
+    if server != {"command": "python", "args": ["./scripts/run_mcp.py"]}:
+        raise AssertionError(".mcp.json must use the fixed local python entrypoint.")
+    if not (plugin_root / "scripts" / "run_mcp.py").is_file():
+        raise AssertionError("MCP entrypoint is missing.")
+    return server
+
+
+def request(request_id: int, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {"jsonrpc": "2.0", "id": request_id, "method": method}
+    if params is not None:
+        payload["params"] = params
+    return payload
+
+
+def run_mcp_from_config(plugin_root: Path, server: dict[str, Any]) -> list[dict[str, Any]]:
+    messages = [
+        request(1, "initialize", {"protocolVersion": "2025-06-18"}),
+        request(2, "tools/list"),
+        request(3, "resources/list"),
+        request(4, "prompts/list"),
+        request(
+            5,
+            "tools/call",
+            {"name": "explain_demo_claim", "arguments": {"claim_id": "claim_evacuation_turn"}},
+        ),
+        request(
+            6,
+            "resources/read",
+            {"uri": "mirror-demo://artifact/demo.documents"},
+        ),
+        request(
+            7,
+            "tools/call",
+            {
+                "name": "get_demo_artifact",
+                "arguments": {"artifact_id": "demo.claims", "path": "artifacts/demo/report/claims.json"},
+            },
+        ),
+    ]
+    stdin = "\n".join(json.dumps(message, separators=(",", ":")) for message in messages) + "\n"
+
+    command = [sys.executable if server["command"] == "python" else server["command"], *server["args"]]
+    completed = subprocess.run(
+        command,
+        cwd=plugin_root,
+        input=stdin,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            f"MCP stdio server exited {completed.returncode}.\nSTDERR:\n{completed.stderr}"
+        )
+    responses = [json.loads(line) for line in completed.stdout.splitlines() if line.strip()]
+    if len(responses) != len(messages):
+        raise AssertionError(f"Expected {len(messages)} JSON-RPC responses, got {len(responses)}.")
+    return responses
+
+
+def get_response(responses: list[dict[str, Any]], request_id: int) -> dict[str, Any]:
+    response = next((item for item in responses if item.get("id") == request_id), None)
+    if response is None:
+        raise AssertionError(f"Missing JSON-RPC response id {request_id}.")
+    return response
+
+
+def result_for(responses: list[dict[str, Any]], request_id: int) -> dict[str, Any]:
+    response = get_response(responses, request_id)
+    if "error" in response:
+        raise AssertionError(f"Response id {request_id} returned JSON-RPC error: {response['error']}")
+    result = response.get("result")
+    if not isinstance(result, dict):
+        raise AssertionError(f"Response id {request_id} result must be an object.")
+    return result
+
+
+def assert_no_forbidden_output(payload: Any) -> None:
+    text = json.dumps(payload, ensure_ascii=False)
+    leaked = sorted(field for field in FORBIDDEN_OUTPUT_FIELDS if field in text)
+    if leaked:
+        raise AssertionError(f"MCP output leaked internal field(s): {', '.join(leaked)}.")
+    if "D:/mirror" in text or "D:\\mirror" in text or "artifacts/demo" in text:
+        raise AssertionError("MCP output leaked a local filesystem path.")
+
+
+def validate_mcp_responses(responses: list[dict[str, Any]]) -> None:
+    initialize = result_for(responses, 1)
+    capabilities = initialize.get("capabilities", {})
+    if not {"tools", "resources", "prompts"}.issubset(capabilities):
+        raise AssertionError("initialize response must advertise tools, resources, and prompts.")
+
+    tools = result_for(responses, 2).get("tools")
+    if not isinstance(tools, list) or {tool.get("name") for tool in tools} != EXPECTED_TOOLS:
+        raise AssertionError("tools/list response drifted from the v1 allowlist.")
+    for tool in tools:
+        if tool.get("annotations", {}).get("readOnlyHint") is not True:
+            raise AssertionError(f"{tool.get('name')} must be annotated read-only.")
+        if tool.get("inputSchema", {}).get("additionalProperties") is not False:
+            raise AssertionError(f"{tool.get('name')} must use a closed input schema.")
+
+    resources = result_for(responses, 3).get("resources")
+    if not isinstance(resources, list) or {resource.get("uri") for resource in resources} != EXPECTED_RESOURCES:
+        raise AssertionError("resources/list response drifted from the v1 allowlist.")
+
+    prompts = result_for(responses, 4).get("prompts")
+    if not isinstance(prompts, list) or {prompt.get("name") for prompt in prompts} != EXPECTED_PROMPTS:
+        raise AssertionError("prompts/list response drifted from the v1 allowlist.")
+    if any(prompt.get("arguments") != [] for prompt in prompts):
+        raise AssertionError("v1 prompts must not accept arguments.")
+
+    claim_result = result_for(responses, 5)
+    if claim_result.get("isError") is not False:
+        raise AssertionError(f"claim explanation unexpectedly failed: {claim_result}")
+    claim = claim_result.get("structuredContent", {}).get("claim", {})
+    if claim.get("claim_id") != "claim_evacuation_turn":
+        raise AssertionError("claim explanation returned the wrong claim id.")
+    if claim.get("label") != "evidence_backed":
+        raise AssertionError("claim explanation must preserve the claim label.")
+    if set(claim.get("evidence_ids", [])) != EXPECTED_EVIDENCE_IDS:
+        raise AssertionError("claim explanation evidence_ids drifted from the canonical demo.")
+    assert_no_forbidden_output(claim_result)
+
+    documents_result = result_for(responses, 6)
+    assert_no_forbidden_output(documents_result)
+    contents = documents_result.get("contents")
+    if not isinstance(contents, list) or not contents:
+        raise AssertionError("document resource read must return contents.")
+    if contents[0].get("uri") != "mirror-demo://artifact/demo.documents":
+        raise AssertionError("document resource read returned the wrong URI.")
+
+    negative = result_for(responses, 7)
+    if negative.get("isError") is not True:
+        raise AssertionError("path-bearing extra tool argument must be rejected.")
+    if "Unsupported argument" not in negative.get("structuredContent", {}).get("error", ""):
+        raise AssertionError("path-bearing extra tool argument failed with an unexpected message.")
+
+
+def main() -> int:
+    try:
+        plugin_root = marketplace_plugin_root()
+        server = validate_plugin_shell(plugin_root)
+        validate_mcp_responses(run_mcp_from_config(plugin_root, server))
+    except (AssertionError, json.JSONDecodeError) as exc:
+        print(f"Mirror Codex plugin install acceptance failed: {exc}", file=sys.stderr)
+        return 1
+
+    print("Mirror Codex plugin install acceptance passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/mirror-codex/scripts/check_pr_scope.py
+++ b/plugins/mirror-codex/scripts/check_pr_scope.py
@@ -26,6 +26,7 @@ ALLOWED_PREFIXES = {
     "plugins/mirror-codex/",
 }
 LOCAL_ONLY_UNTRACKED_PREFIXES = {
+    "backend/mirror_engine.egg-info/",
     "docs/plans/",
 }
 

--- a/plugins/mirror-codex/scripts/check_pr_scope.py
+++ b/plugins/mirror-codex/scripts/check_pr_scope.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import PurePosixPath
+
+
+sys.dont_write_bytecode = True
+
+ALLOWED_EXACT_PATHS = {
+    ".agents/plugins/marketplace.json",
+    ".github/pull_request_template.md",
+    ".github/workflows/deploy-web.yml",
+    ".github/workflows/phase0.yml",
+    "Makefile",
+    "README.md",
+    "docs/decisions/ADR-0010-mirror-codex-plugin-mcp-contract.md",
+    "docs/deploy/mirror-codex-plugin.md",
+    "docs/deploy/render-public-demo.md",
+    "docs/releases/mirror-codex-plugin-v1.md",
+    "make.ps1",
+    "scripts/smoke_public_demo_web.py",
+}
+ALLOWED_PREFIXES = {
+    "plugins/mirror-codex/",
+}
+LOCAL_ONLY_UNTRACKED_PREFIXES = {
+    "docs/plans/",
+}
+
+
+def normalize_path(path: str) -> str:
+    return path.replace("\\", "/").strip("/")
+
+
+def is_allowed_scope(path: str) -> bool:
+    normalized = normalize_path(path)
+    return normalized in ALLOWED_EXACT_PATHS or any(
+        normalized.startswith(prefix) for prefix in ALLOWED_PREFIXES
+    )
+
+
+def is_local_only_untracked(path: str) -> bool:
+    normalized = normalize_path(path)
+    return any(normalized.startswith(prefix) for prefix in LOCAL_ONLY_UNTRACKED_PREFIXES)
+
+
+def tracked_or_untracked_status() -> list[tuple[str, str]]:
+    completed = subprocess.run(
+        ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(f"git status failed:\n{completed.stderr}")
+
+    entries: list[tuple[str, str]] = []
+    for line in completed.stdout.splitlines():
+        if not line:
+            continue
+        status = line[:2]
+        raw_path = line[3:]
+        if " -> " in raw_path:
+            _, raw_path = raw_path.rsplit(" -> ", 1)
+        entries.append((status, normalize_path(raw_path)))
+    return entries
+
+
+def sort_key(item: tuple[str, str]) -> str:
+    return PurePosixPath(item[1]).as_posix()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check that the workspace only contains the Mirror Codex Plugin V1 PR scope.",
+    )
+    parser.add_argument(
+        "--stage-list",
+        action="store_true",
+        help="Print only in-scope paths, one per line, for git add --pathspec-from-file=-.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        entries = tracked_or_untracked_status()
+    except AssertionError as exc:
+        print(f"Mirror Codex plugin PR scope check failed: {exc}", file=sys.stderr)
+        return 1
+
+    in_scope: list[tuple[str, str]] = []
+    ignored_local: list[tuple[str, str]] = []
+    unexpected: list[tuple[str, str]] = []
+
+    for status, path in entries:
+        if is_allowed_scope(path):
+            in_scope.append((status, path))
+            continue
+        if status == "??" and is_local_only_untracked(path):
+            ignored_local.append((status, path))
+            continue
+        unexpected.append((status, path))
+
+    if unexpected:
+        print("Mirror Codex plugin PR scope check failed: unexpected workspace paths:", file=sys.stderr)
+        for status, path in sorted(unexpected, key=sort_key):
+            print(f"  {status} {path}", file=sys.stderr)
+        if ignored_local:
+            print("\nAllowed local-only untracked paths excluded from plugin PR:", file=sys.stderr)
+            for status, path in sorted(ignored_local, key=sort_key):
+                print(f"  {status} {path}", file=sys.stderr)
+        return 1
+
+    if args.stage_list:
+        for _, path in sorted(in_scope, key=sort_key):
+            print(path)
+        return 0
+
+    print("Mirror Codex plugin PR scope check passed.")
+    if in_scope:
+        print("Plugin V1 scoped workspace paths:")
+        for status, path in sorted(in_scope, key=sort_key):
+            print(f"  {status} {path}")
+    if ignored_local:
+        print("Local-only untracked paths excluded from plugin PR:")
+        for status, path in sorted(ignored_local, key=sort_key):
+            print(f"  {status} {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/mirror-codex/scripts/run_mcp.py
+++ b/plugins/mirror-codex/scripts/run_mcp.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+from mirror_codex_mcp.server import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/mirror-codex/scripts/smoke_mcp_stdio.py
+++ b/plugins/mirror-codex/scripts/smoke_mcp_stdio.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+sys.dont_write_bytecode = True
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+ENTRYPOINT = PLUGIN_ROOT / "scripts" / "run_mcp.py"
+EXPECTED_TOOLS = {
+    "get_demo_manifest",
+    "get_demo_artifact",
+    "get_eval_summary",
+    "explain_demo_claim",
+    "compare_demo_branches",
+}
+EXPECTED_RESOURCES = {
+    "mirror-demo://manifest",
+    "mirror-demo://artifact/demo.report",
+    "mirror-demo://artifact/demo.claims",
+    "mirror-demo://artifact/demo.eval_summary",
+    "mirror-demo://artifact/demo.compare",
+    "mirror-demo://artifact/demo.documents",
+    "mirror-demo://artifact/demo.chunks",
+    "mirror-demo://artifact/demo.graph",
+    "mirror-demo://artifact/demo.rubric",
+}
+EXPECTED_PROMPTS = {
+    "inspect-public-demo",
+    "review-claim-evidence",
+    "compare-demo-branches",
+}
+FORBIDDEN_OUTPUT_FIELDS = {
+    "artifact_paths",
+    "summary_path",
+    "trace_path",
+    "snapshot_dir",
+    "source_path",
+}
+
+
+def request(request_id: int, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {"jsonrpc": "2.0", "id": request_id, "method": method}
+    if params is not None:
+        payload["params"] = params
+    return payload
+
+
+def run_smoke() -> list[dict[str, Any]]:
+    messages = [
+        request(1, "initialize", {"protocolVersion": "2025-06-18"}),
+        request(2, "tools/list"),
+        request(3, "tools/call", {"name": "get_demo_manifest", "arguments": {}}),
+        request(4, "tools/call", {"name": "get_eval_summary", "arguments": {}}),
+        request(
+            5,
+            "tools/call",
+            {"name": "explain_demo_claim", "arguments": {"claim_id": "claim_evacuation_turn"}},
+        ),
+        request(
+            6,
+            "tools/call",
+            {
+                "name": "compare_demo_branches",
+                "arguments": {"candidate_branch_id": "branch_reporter_detained"},
+            },
+        ),
+        request(
+            7,
+            "tools/call",
+            {
+                "name": "get_demo_artifact",
+                "arguments": {"artifact_id": "demo.claims", "path": "artifacts/demo/report/claims.json"},
+            },
+        ),
+        request(8, "resources/list"),
+        request(
+            9,
+            "resources/read",
+            {"uri": "mirror-demo://artifact/demo.eval_summary"},
+        ),
+        request(
+            10,
+            "resources/read",
+            {"uri": "file:///D:/mirror/artifacts/demo/report/claims.json"},
+        ),
+        request(11, "prompts/list"),
+        request(12, "prompts/get", {"name": "compare-demo-branches"}),
+        request(13, "prompts/get", {"name": "inspect-public-demo", "arguments": {"path": "secret"}}),
+    ]
+    stdin = "\n".join(json.dumps(message, separators=(",", ":")) for message in messages) + "\n"
+    completed = subprocess.run(
+        [sys.executable, str(ENTRYPOINT)],
+        cwd=PLUGIN_ROOT,
+        input=stdin,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            f"MCP stdio server exited {completed.returncode}.\nSTDERR:\n{completed.stderr}"
+        )
+    responses = [json.loads(line) for line in completed.stdout.splitlines() if line.strip()]
+    if len(responses) != len(messages):
+        raise AssertionError(f"Expected {len(messages)} responses, got {len(responses)}.")
+    return responses
+
+
+def result_for(responses: list[dict[str, Any]], request_id: int) -> dict[str, Any]:
+    response = next((item for item in responses if item.get("id") == request_id), None)
+    if response is None:
+        raise AssertionError(f"Missing response id {request_id}.")
+    if "error" in response:
+        raise AssertionError(f"Response id {request_id} returned JSON-RPC error: {response['error']}")
+    result = response.get("result")
+    if not isinstance(result, dict):
+        raise AssertionError(f"Response id {request_id} result must be an object.")
+    return result
+
+
+def structured_tool_result(responses: list[dict[str, Any]], request_id: int) -> dict[str, Any]:
+    result = result_for(responses, request_id)
+    if result.get("isError") is not False:
+        raise AssertionError(f"Tool response id {request_id} unexpectedly failed: {result}")
+    content = result.get("structuredContent")
+    if not isinstance(content, dict):
+        raise AssertionError(f"Tool response id {request_id} must include structuredContent.")
+    return content
+
+
+def assert_no_forbidden_output(payload: Any) -> None:
+    text = json.dumps(payload, ensure_ascii=False)
+    leaked = sorted(field for field in FORBIDDEN_OUTPUT_FIELDS if field in text)
+    if leaked:
+        raise AssertionError(f"MCP output leaked internal field(s): {', '.join(leaked)}.")
+    if "D:/mirror" in text or "D:\\mirror" in text or "artifacts/demo" in text:
+        raise AssertionError("MCP output leaked a local filesystem path.")
+
+
+def validate_responses(responses: list[dict[str, Any]]) -> None:
+    initialize = result_for(responses, 1)
+    if initialize.get("serverInfo", {}).get("name") != "mirror-codex":
+        raise AssertionError("initialize response did not identify mirror-codex.")
+
+    tools = result_for(responses, 2).get("tools")
+    if not isinstance(tools, list):
+        raise AssertionError("tools/list response must include tools list.")
+    if {tool.get("name") for tool in tools} != EXPECTED_TOOLS:
+        raise AssertionError("tools/list response drifted from the expected tool allowlist.")
+    for tool in tools:
+        if tool.get("annotations", {}).get("readOnlyHint") is not True:
+            raise AssertionError(f"{tool.get('name')} is missing readOnlyHint.")
+        if tool.get("inputSchema", {}).get("additionalProperties") is not False:
+            raise AssertionError(f"{tool.get('name')} schema is not closed.")
+
+    manifest = structured_tool_result(responses, 3)
+    if manifest.get("mode") != "deterministic-only" or manifest.get("mutation") != "disabled":
+        raise AssertionError("manifest did not preserve deterministic read-only mode.")
+    assert_no_forbidden_output(manifest)
+
+    eval_summary = structured_tool_result(responses, 4)
+    if eval_summary.get("data", {}).get("status") != "pass":
+        raise AssertionError("eval summary did not report pass.")
+    assert_no_forbidden_output(eval_summary)
+
+    claim = structured_tool_result(responses, 5).get("claim", {})
+    if not claim.get("label") or not claim.get("evidence_ids"):
+        raise AssertionError("claim explanation must preserve label and evidence_ids.")
+
+    branch_compare = structured_tool_result(responses, 6)
+    if branch_compare.get("reference_branch_id") != "branch_baseline":
+        raise AssertionError("branch comparison did not use the baseline reference branch.")
+    assert_no_forbidden_output(branch_compare)
+
+    negative = result_for(responses, 7)
+    if negative.get("isError") is not True:
+        raise AssertionError("path-bearing extra argument must be rejected.")
+    if "Unsupported argument" not in negative.get("structuredContent", {}).get("error", ""):
+        raise AssertionError("negative path-like smoke did not fail for the expected reason.")
+
+    resources = result_for(responses, 8).get("resources")
+    if not isinstance(resources, list):
+        raise AssertionError("resources/list response must include resources list.")
+    if {resource.get("uri") for resource in resources} != EXPECTED_RESOURCES:
+        raise AssertionError("resources/list response drifted from the expected resource allowlist.")
+
+    eval_resource = result_for(responses, 9)
+    assert_no_forbidden_output(eval_resource)
+    contents = eval_resource.get("contents")
+    if not isinstance(contents, list) or not contents:
+        raise AssertionError("resources/read must return contents.")
+    if contents[0].get("uri") != "mirror-demo://artifact/demo.eval_summary":
+        raise AssertionError("resources/read returned the wrong URI.")
+
+    invalid_resource = next((item for item in responses if item.get("id") == 10), None)
+    if not invalid_resource or invalid_resource.get("error", {}).get("code") != -32602:
+        raise AssertionError("invalid resource URI must be rejected.")
+
+    prompts = result_for(responses, 11).get("prompts")
+    if not isinstance(prompts, list):
+        raise AssertionError("prompts/list response must include prompts list.")
+    if {prompt.get("name") for prompt in prompts} != EXPECTED_PROMPTS:
+        raise AssertionError("prompts/list response drifted from the expected prompt allowlist.")
+    if any(prompt.get("arguments") != [] for prompt in prompts):
+        raise AssertionError("v1 prompts must not accept arguments.")
+
+    prompt_payload = result_for(responses, 12)
+    prompt_text = json.dumps(prompt_payload, ensure_ascii=False)
+    if "branch_reporter_detained" not in prompt_text or "real-world" not in prompt_text:
+        raise AssertionError("branch comparison prompt did not preserve bounded guidance.")
+
+    invalid_prompt = next((item for item in responses if item.get("id") == 13), None)
+    if not invalid_prompt or invalid_prompt.get("error", {}).get("code") != -32602:
+        raise AssertionError("prompt arguments must be rejected.")
+
+
+def main() -> int:
+    try:
+        validate_responses(run_smoke())
+    except (AssertionError, json.JSONDecodeError) as exc:
+        print(f"Mirror Codex MCP stdio smoke failed: {exc}", file=sys.stderr)
+        return 1
+    print("Mirror Codex MCP stdio smoke passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/mirror-codex/scripts/validate_plugin.py
+++ b/plugins/mirror-codex/scripts/validate_plugin.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+sys.dont_write_bytecode = True
+PLUGIN_NAME = "mirror-codex"
+REQUIRED_ARTIFACT_IDS = {
+    "demo.report",
+    "demo.claims",
+    "demo.eval_summary",
+    "demo.compare",
+    "demo.documents",
+    "demo.chunks",
+    "demo.graph",
+    "demo.rubric",
+}
+REQUIRED_TOOL_NAMES = {
+    "get_demo_manifest",
+    "get_demo_artifact",
+    "get_eval_summary",
+    "explain_demo_claim",
+    "compare_demo_branches",
+}
+REQUIRED_RESOURCE_URIS = {
+    "mirror-demo://manifest",
+    "mirror-demo://artifact/demo.report",
+    "mirror-demo://artifact/demo.claims",
+    "mirror-demo://artifact/demo.eval_summary",
+    "mirror-demo://artifact/demo.compare",
+    "mirror-demo://artifact/demo.documents",
+    "mirror-demo://artifact/demo.chunks",
+    "mirror-demo://artifact/demo.graph",
+    "mirror-demo://artifact/demo.rubric",
+}
+REQUIRED_PROMPT_NAMES = {
+    "inspect-public-demo",
+    "review-claim-evidence",
+    "compare-demo-branches",
+}
+FORBIDDEN_TOOL_INPUTS = {
+    "path",
+    "file",
+    "filepath",
+    "filename",
+    "url",
+    "command",
+    "args",
+    "api_key",
+    "provider",
+    "model",
+}
+SECRET_PATTERNS = [
+    re.compile(r"\bsk-(?:proj-|svcacct-)?[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"(?im)^\s*NEXT_PUBLIC_[A-Z_]*OPENAI_API_KEY\s*[:=]\s*['\"]?[^#\s'\"]+"),
+    re.compile(r"(?im)^\s*(OPENAI_API_KEY|MIRROR_HOSTED_OPENAI_API_KEY)\s*[:=]\s*['\"]?sk-"),
+]
+CONTRACT_ADR = "docs/decisions/ADR-0010-mirror-codex-plugin-mcp-contract.md"
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise AssertionError(f"{path} must contain a JSON object.")
+    return payload
+
+
+def assert_true(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def plugin_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def validate_plugin_manifest(root: Path) -> None:
+    manifest_path = root / ".codex-plugin" / "plugin.json"
+    manifest = load_json(manifest_path)
+    manifest_text = manifest_path.read_text(encoding="utf-8")
+
+    assert_true(manifest.get("name") == PLUGIN_NAME, "plugin name must match folder name.")
+    assert_true(manifest.get("version") == "0.1.0", "plugin version must be 0.1.0.")
+    assert_true(manifest.get("skills") == "./skills/", "plugin must expose ./skills/.")
+    assert_true(manifest.get("mcpServers") == "./.mcp.json", "plugin must point at ./.mcp.json.")
+    assert_true("hooks" not in manifest, "V1 must not register hooks.")
+    assert_true("apps" not in manifest, "V1 must not register apps.")
+    assert_true("[TODO:" not in manifest_text, "plugin manifest must not contain TODO placeholders.")
+
+    interface = manifest.get("interface")
+    assert_true(isinstance(interface, dict), "plugin interface must be an object.")
+    assert_true(interface.get("capabilities") == ["Read"], "V1 plugin capability must be Read only.")
+
+    prompts = interface.get("defaultPrompt")
+    assert_true(isinstance(prompts, list) and 1 <= len(prompts) <= 3, "defaultPrompt must include 1-3 prompts.")
+    for prompt in prompts:
+        assert_true(isinstance(prompt, str) and len(prompt) <= 128, "default prompts must be short strings.")
+
+
+def validate_mcp_placeholder(root: Path) -> None:
+    payload = load_json(root / ".mcp.json")
+    servers = payload.get("mcpServers")
+    assert_true(isinstance(servers, dict), ".mcp.json must contain mcpServers object.")
+    assert_true(set(servers) == {"mirror-demo"}, ".mcp.json must register only mirror-demo.")
+    server = servers["mirror-demo"]
+    assert_true(server == {"command": "python", "args": ["./scripts/run_mcp.py"]}, ".mcp.json must use one fixed local python entrypoint.")
+    assert_true((root / "scripts" / "run_mcp.py").exists(), "MCP entrypoint must exist.")
+    assert_true((root / "scripts" / "smoke_mcp_stdio.py").exists(), "MCP stdio smoke script must exist.")
+    assert_true((root / "scripts" / "acceptance_check.py").exists(), "plugin install acceptance script must exist.")
+    assert_true((root / "scripts" / "check_pr_scope.py").exists(), "plugin PR scope check script must exist.")
+    assert_true((root / "mirror_codex_mcp" / "server.py").exists(), "MCP server module must exist.")
+
+
+def validate_skill(root: Path) -> None:
+    skill_path = root / "skills" / "mirror-demo" / "SKILL.md"
+    assert_true(skill_path.exists(), "mirror-demo skill must exist.")
+    text = skill_path.read_text(encoding="utf-8")
+    assert_true(text.startswith("---\n"), "skill must start with YAML frontmatter.")
+    assert_true("name: mirror-demo" in text, "skill frontmatter must name mirror-demo.")
+    assert_true("description:" in text, "skill frontmatter must include a description.")
+    for artifact_id in REQUIRED_ARTIFACT_IDS:
+        assert_true(artifact_id in text, f"skill must mention logical artifact id {artifact_id}.")
+    assert_true("Do not use `NEXT_PUBLIC_OPENAI_API_KEY`" in text, "skill must forbid public provider keys.")
+    for tool_name in REQUIRED_TOOL_NAMES:
+        assert_true(tool_name in text, f"skill must mention MCP tool {tool_name}.")
+    for resource_uri in REQUIRED_RESOURCE_URIS:
+        if resource_uri in {"mirror-demo://artifact/demo.report", "mirror-demo://artifact/demo.documents", "mirror-demo://artifact/demo.chunks", "mirror-demo://artifact/demo.graph", "mirror-demo://artifact/demo.rubric"}:
+            continue
+        assert_true(resource_uri in text, f"skill must mention MCP resource {resource_uri}.")
+    for prompt_name in REQUIRED_PROMPT_NAMES:
+        assert_true(prompt_name in text, f"skill must mention MCP prompt {prompt_name}.")
+    assert_true("Do not add mutating tools" in text, "skill must preserve the read-only MCP boundary.")
+    assert_true(CONTRACT_ADR in text, "skill must point to the MCP contract ADR.")
+    assert_true("smoke_mcp_stdio.py" in text, "skill must mention the MCP stdio smoke.")
+
+
+def validate_plugin_readme(root: Path) -> None:
+    readme_path = root / "README.md"
+    text = readme_path.read_text(encoding="utf-8")
+    assert_true(CONTRACT_ADR in text, "plugin README must point to the MCP contract ADR.")
+    assert_true("additionalProperties: false" in text, "plugin README must document closed MCP schemas.")
+    assert_true("annotations.readOnlyHint: true" in text, "plugin README must document read-only MCP annotations.")
+    assert_true("smoke_mcp_stdio.py" in text, "plugin README must document the MCP stdio smoke.")
+    assert_true("acceptance_check.py" in text, "plugin README must document the install acceptance check.")
+    assert_true("check_pr_scope.py" in text, "plugin README must document the PR scope check.")
+    for tool_name in REQUIRED_TOOL_NAMES:
+        assert_true(tool_name in text, f"plugin README must mention MCP tool {tool_name}.")
+    assert_true("mirror-demo://manifest" in text, "plugin README must document MCP resources.")
+    for prompt_name in REQUIRED_PROMPT_NAMES:
+        assert_true(prompt_name in text, f"plugin README must mention MCP prompt {prompt_name}.")
+
+
+def validate_contract_adr(root: Path) -> None:
+    adr_path = root / CONTRACT_ADR
+    assert_true(adr_path.exists(), "MCP contract ADR must exist.")
+    text = adr_path.read_text(encoding="utf-8")
+    assert_true("# ADR-0010: Mirror Codex Plugin MCP Contract" in text, "ADR title must be stable.")
+    assert_true("Accepted" in text, "ADR must be accepted.")
+    assert_true("annotations.readOnlyHint: true" in text, "ADR must require read-only tool annotations.")
+    assert_true("additionalProperties: false" in text, "ADR must require closed tool schemas.")
+    for artifact_id in REQUIRED_ARTIFACT_IDS:
+        assert_true(artifact_id in text, f"ADR must mention artifact id {artifact_id}.")
+    for tool_name in REQUIRED_TOOL_NAMES:
+        assert_true(tool_name in text, f"ADR must mention MCP tool {tool_name}.")
+    for resource_uri in REQUIRED_RESOURCE_URIS:
+        assert_true(resource_uri in text, f"ADR must mention MCP resource {resource_uri}.")
+    for prompt_name in REQUIRED_PROMPT_NAMES:
+        assert_true(prompt_name in text, f"ADR must mention MCP prompt {prompt_name}.")
+    for forbidden in FORBIDDEN_TOOL_INPUTS:
+        assert_true(f"`{forbidden}`" in text, f"ADR must mention forbidden input `{forbidden}`.")
+
+
+def validate_mcp_static_contract(root: Path) -> None:
+    server_text = (root / "mirror_codex_mcp" / "server.py").read_text(encoding="utf-8")
+    run_text = (root / "scripts" / "run_mcp.py").read_text(encoding="utf-8")
+
+    assert_true("subprocess" not in server_text, "MCP server must not shell out.")
+    assert_true("OPENAI_API_KEY" not in server_text, "MCP server must not reference provider secrets.")
+    assert_true("MIRROR_HOSTED_OPENAI_API_KEY" not in server_text, "MCP server must not reference hosted provider secrets.")
+    assert_true("mcp.server" not in server_text, "MCP server must avoid new SDK dependency in this slice.")
+    assert_true("subprocess" not in run_text, "MCP entrypoint must not shell out.")
+    for tool_name in REQUIRED_TOOL_NAMES:
+        assert_true(tool_name in server_text, f"MCP server must implement {tool_name}.")
+    for prompt_name in REQUIRED_PROMPT_NAMES:
+        assert_true(prompt_name in server_text, f"MCP server must allowlist prompt {prompt_name}.")
+
+    sys.path.insert(0, str(root))
+    from mirror_codex_mcp import server as mcp_server  # noqa: PLC0415
+
+    tools = mcp_server.tool_definitions()
+    assert_true({tool["name"] for tool in tools} == REQUIRED_TOOL_NAMES, "MCP tool set must match the PR 2 allowlist.")
+    for tool in tools:
+        assert_true(tool.get("annotations", {}).get("readOnlyHint") is True, f"{tool['name']} must be annotated read-only.")
+        schema = tool.get("inputSchema")
+        assert_true(isinstance(schema, dict), f"{tool['name']} must have an input schema.")
+        assert_true(schema.get("additionalProperties") is False, f"{tool['name']} schema must be closed.")
+        properties = schema.get("properties", {})
+        assert_true(isinstance(properties, dict), f"{tool['name']} input properties must be an object.")
+        forbidden = FORBIDDEN_TOOL_INPUTS.intersection(properties)
+        assert_true(not forbidden, f"{tool['name']} must not expose forbidden inputs: {sorted(forbidden)}")
+
+    expected_properties = {
+        "get_demo_manifest": set(),
+        "get_demo_artifact": {"artifact_id"},
+        "get_eval_summary": set(),
+        "explain_demo_claim": {"claim_id"},
+        "compare_demo_branches": {"candidate_branch_id", "reference_branch_id"},
+    }
+    expected_required = {
+        "get_demo_manifest": set(),
+        "get_demo_artifact": {"artifact_id"},
+        "get_eval_summary": set(),
+        "explain_demo_claim": {"claim_id"},
+        "compare_demo_branches": {"candidate_branch_id"},
+    }
+    for tool in tools:
+        schema = tool["inputSchema"]
+        properties = schema.get("properties", {})
+        assert_true(set(properties) == expected_properties[tool["name"]], f"{tool['name']} properties drifted from ADR.")
+        assert_true(set(schema.get("required", [])) == expected_required[tool["name"]], f"{tool['name']} required fields drifted from ADR.")
+
+    resources = mcp_server.resource_definitions()
+    assert_true({resource["uri"] for resource in resources} == REQUIRED_RESOURCE_URIS, "MCP resource set must match ADR allowlist.")
+    for resource in resources:
+        uri = resource["uri"]
+        assert_true(isinstance(uri, str) and uri.startswith("mirror-demo://"), f"resource uri must be logical: {uri}")
+        assert_true("/.." not in uri and "\\" not in uri, f"resource uri must not look path-like: {uri}")
+
+    prompts = mcp_server.prompt_definitions()
+    assert_true({prompt["name"] for prompt in prompts} == REQUIRED_PROMPT_NAMES, "MCP prompt set must match ADR allowlist.")
+    for prompt in prompts:
+        assert_true(prompt.get("arguments") == [], f"{prompt['name']} must not accept prompt arguments in v1.")
+
+
+def validate_marketplace(root: Path) -> None:
+    marketplace = load_json(root / ".agents" / "plugins" / "marketplace.json")
+    plugins = marketplace.get("plugins")
+    assert_true(isinstance(plugins, list), "marketplace plugins must be a list.")
+    entry = next((item for item in plugins if isinstance(item, dict) and item.get("name") == PLUGIN_NAME), None)
+    assert_true(entry is not None, "marketplace must include mirror-codex.")
+    assert_true(entry.get("source") == {"source": "local", "path": "./plugins/mirror-codex"}, "marketplace source must be repo-local.")
+    assert_true(entry.get("policy") == {"installation": "AVAILABLE", "authentication": "ON_INSTALL"}, "marketplace policy must match V1 defaults.")
+    assert_true(entry.get("category") == "Engineering", "marketplace category must be Engineering.")
+
+
+def validate_no_secret_shapes(root: Path) -> None:
+    findings: list[str] = []
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        for pattern in SECRET_PATTERNS:
+            if pattern.search(text):
+                findings.append(str(path))
+                break
+    assert_true(not findings, "plugin contains possible provider secret exposure:\n" + "\n".join(findings))
+
+
+def main() -> int:
+    root = repo_root()
+    p_root = plugin_root()
+
+    try:
+        validate_plugin_manifest(p_root)
+        validate_mcp_placeholder(p_root)
+        validate_skill(p_root)
+        validate_plugin_readme(p_root)
+        validate_contract_adr(root)
+        validate_mcp_static_contract(p_root)
+        validate_marketplace(root)
+        validate_no_secret_shapes(p_root)
+    except AssertionError as error:
+        print(f"Mirror Codex plugin validation failed: {error}", file=sys.stderr)
+        return 1
+
+    print("Mirror Codex plugin validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/mirror-codex/skills/mirror-demo/SKILL.md
+++ b/plugins/mirror-codex/skills/mirror-demo/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: mirror-demo
+description: Use when Codex needs to explain, inspect, or validate Mirror's read-only deterministic Phase 1 public demo, including manifest, claims, evidence, eval summary, branch comparison, and public safety boundaries. Use for Mirror public demo onboarding, safe local demo checks, and claim/evidence review without model calls or filesystem-path artifact access.
+---
+
+# Mirror Demo
+
+Use this skill to help developers understand and inspect Mirror's deterministic public demo.
+
+## Core Contract
+
+- Keep the workflow read-only, deterministic, and local-first.
+- Treat Mirror as a constrained what-if sandbox for fictional or explicitly authorized worlds.
+- Do not present Mirror as a real-world prediction machine.
+- Do not build real-person personas, digital doubles, political persuasion, law-enforcement scoring, hiring, credit, medical, or judicial decision systems.
+- Do not create worlds, upload corpora, start runtime sessions, generate branches, mutate artifacts, or call model providers.
+- Do not ask for or write provider secrets. Do not use `NEXT_PUBLIC_OPENAI_API_KEY`.
+- Keep user configuration in local env or the user's own deployment environment; never put it in repo files, frontend code, build logs, artifacts, or error pages.
+
+## First Pass
+
+Read the boundary docs before summarizing or advising:
+
+```powershell
+Get-Content -Raw AGENTS.md
+Get-Content -Raw README.md
+rg -n "Phase 1 Public Demo Mode|What Mirror Is Not|Public read-only endpoints" README.md
+```
+
+If deeper architecture context matters, read `mirror.md` and distinguish direct evidence, reasonable inference, and open questions.
+
+For MCP tool-contract questions, read `docs/decisions/ADR-0010-mirror-codex-plugin-mcp-contract.md`. Treat it as the durable v1 boundary for the repo-local plugin.
+
+## Demo Workflow
+
+Use public logical artifact ids, not arbitrary filesystem paths:
+
+- `demo.report`
+- `demo.claims`
+- `demo.eval_summary`
+- `demo.compare`
+- `demo.documents`
+- `demo.chunks`
+- `demo.graph`
+- `demo.rubric`
+
+To inspect the local public demo API contract, prefer:
+
+```powershell
+rg -n "PUBLIC_DEMO_ARTIFACTS|/public-demo/manifest|/public-demo/artifacts|/readyz|/healthz" backend\app\main.py
+rg -n "PUBLIC_DEMO_ARTIFACTS|ArtifactSource|normalizeTrustedDemoPath" frontend\src\app\lib
+```
+
+To inspect claims and evidence, verify every report claim has both `label` and `evidence_ids`. Summaries must say "based on the current corpus and deterministic rules" or equivalent bounded language, not certain real-world conclusions.
+
+## MCP Tools
+
+If the Mirror Codex plugin MCP server is enabled, use only its read-only tools:
+
+- `get_demo_manifest`
+- `get_demo_artifact`
+- `get_eval_summary`
+- `explain_demo_claim`
+- `compare_demo_branches`
+
+Pass only logical ids such as `demo.claims`, `claim_evacuation_turn`, or `branch_reporter_detained`. Do not pass filesystem paths, URLs, shell commands, provider names, API keys, or config values.
+
+## MCP Resources And Prompts
+
+If MCP resources are available, use only fixed `mirror-demo://...` resources such as:
+
+- `mirror-demo://manifest`
+- `mirror-demo://artifact/demo.claims`
+- `mirror-demo://artifact/demo.eval_summary`
+- `mirror-demo://artifact/demo.compare`
+
+If MCP prompts are available, use only fixed prompt names:
+
+- `inspect-public-demo`
+- `review-claim-evidence`
+- `compare-demo-branches`
+
+Do not invent resource URIs or prompt arguments. Do not pass paths, URLs, provider config, API keys, model names, or user documents.
+
+## Evidence Navigation
+
+For a claim/evidence review, keep the chain explicit and read-only:
+
+1. Read `mirror-demo://artifact/demo.claims` or `demo.claims`.
+2. Pick the requested logical claim id, for example `claim_evacuation_turn`.
+3. Preserve the claim `label` and `evidence_ids`.
+4. Read `mirror-demo://artifact/demo.chunks` or `demo.chunks` and match evidence ids such as
+   `chunk_doc_budget_minutes_002`, `chunk_doc_budget_minutes_003`, and
+   `chunk_doc_engineering_inspection_002`.
+5. Read `mirror-demo://artifact/demo.documents` or `demo.documents` and match each chunk's
+   `document_id` to sanitized document metadata.
+6. Summarize only what the deterministic demo supports. Use bounded language such as
+   "based on the current corpus and deterministic rules."
+
+Do not expose document `source_path`, local artifact paths, or user-local configuration in the
+answer.
+
+## Validation
+
+For plugin/demo-only work that does not touch frontend code, run:
+
+```powershell
+./make.ps1 plugin-release-check
+```
+
+`plugin-release-check` runs static validation, MCP tests, `python plugins/mirror-codex/scripts/smoke_mcp_stdio.py`, secret scan, phase2 audit, and whitespace diff validation.
+
+If frontend code or frontend routes changed, also run:
+
+```powershell
+npm run build --prefix frontend
+```
+
+Remote public demo smoke is optional and only for explicit release checks:
+
+```powershell
+python scripts/smoke_public_demo_web.py --base-url https://mirror-public-demo.onrender.com
+```
+
+Do not add this remote check to the default plugin workflow.
+
+## MCP Boundary
+
+This plugin registers one fixed local stdio MCP server. Keep tool inputs schema-bound to logical ids and keep the command/args in `.mcp.json` hardcoded. Do not add mutating tools, arbitrary path reads, model calls, uploads, hosted provider paths, BYOK, auth, billing, database, object storage, or quota behavior.
+
+If the MCP tool, resource, or prompt surface changes, update the ADR, plugin README, this skill, static validator, and plugin tests in the same change.

--- a/plugins/mirror-codex/tests/test_mcp_server.py
+++ b/plugins/mirror-codex/tests/test_mcp_server.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+from mirror_codex_mcp import server
+
+
+def as_text(payload: object) -> str:
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def test_manifest_uses_logical_artifact_ids_only() -> None:
+    manifest = server.get_demo_manifest()
+
+    assert manifest["mode"] == "deterministic-only"
+    assert {artifact["id"] for artifact in manifest["artifacts"]} >= {
+        "demo.claims",
+        "demo.eval_summary",
+        "demo.compare",
+    }
+    assert "relativePath" not in as_text(manifest)
+    assert "artifacts/demo" not in as_text(manifest)
+
+
+def test_artifact_sanitizers_match_public_api_boundary() -> None:
+    eval_payload = server.get_eval_summary()
+    compare_payload = server.get_demo_artifact("demo.compare")
+    documents_payload = server.get_demo_artifact("demo.documents")
+
+    combined = as_text(
+        {
+            "eval": eval_payload,
+            "compare": compare_payload,
+            "documents": documents_payload,
+        }
+    )
+    assert "artifact_paths" not in combined
+    assert "summary_path" not in combined
+    assert "trace_path" not in combined
+    assert "snapshot_dir" not in combined
+    assert "source_path" not in combined
+    assert "D:/mirror" not in combined
+
+
+def test_rejects_path_like_artifact_ids() -> None:
+    with pytest.raises(server.ToolInputError):
+        server.get_demo_artifact("artifacts/demo/report/claims.json")
+
+    result = server.call_tool(
+        "get_demo_artifact",
+        {"artifact_id": "artifacts\\demo\\report\\claims.json"},
+    )
+    assert result["isError"] is True
+    assert "not a filesystem path" in result["structuredContent"]["error"]
+
+    extra_arg_result = server.call_tool(
+        "get_demo_artifact",
+        {"artifact_id": "demo.claims", "path": "artifacts/demo/report/claims.json"},
+    )
+    assert extra_arg_result["isError"] is True
+    assert "Unsupported argument" in extra_arg_result["structuredContent"]["error"]
+
+
+def test_explain_demo_claim_preserves_claim_integrity() -> None:
+    payload = server.explain_demo_claim("claim_evacuation_turn")
+
+    claim = payload["claim"]
+    assert claim["claim_id"] == "claim_evacuation_turn"
+    assert claim["label"] == "evidence_backed"
+    assert claim["evidence_ids"]
+    assert payload["evidence_chunks"]
+    assert payload["evidence_documents"]
+
+
+def test_compare_demo_branches_returns_sanitized_delta() -> None:
+    payload = server.compare_demo_branches("branch_reporter_detained")
+
+    assert payload["reference_branch_id"] == "branch_baseline"
+    assert payload["candidate_branch"]["branch_id"] == "branch_reporter_detained"
+    assert payload["delta"]["divergent_turn_count"] == 6
+    assert "summary_path" not in as_text(payload)
+
+
+def test_json_rpc_tools_list_and_call() -> None:
+    list_response = server.handle_request({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    assert list_response is not None
+    tool_names = {tool["name"] for tool in list_response["result"]["tools"]}
+    assert {
+        "get_demo_manifest",
+        "get_demo_artifact",
+        "get_eval_summary",
+        "explain_demo_claim",
+        "compare_demo_branches",
+    } <= tool_names
+
+    call_response = server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "get_demo_artifact",
+                "arguments": {"artifact_id": "demo.claims"},
+            },
+        }
+    )
+    assert call_response is not None
+    assert call_response["result"]["isError"] is False
+    assert call_response["result"]["structuredContent"]["id"] == "demo.claims"
+
+
+def test_json_rpc_resources_and_prompts_are_read_only_allowlists() -> None:
+    resources_response = server.handle_request(
+        {"jsonrpc": "2.0", "id": 3, "method": "resources/list"}
+    )
+    assert resources_response is not None
+    resource_uris = {item["uri"] for item in resources_response["result"]["resources"]}
+    assert resource_uris == {
+        "mirror-demo://manifest",
+        "mirror-demo://artifact/demo.report",
+        "mirror-demo://artifact/demo.claims",
+        "mirror-demo://artifact/demo.eval_summary",
+        "mirror-demo://artifact/demo.compare",
+        "mirror-demo://artifact/demo.documents",
+        "mirror-demo://artifact/demo.chunks",
+        "mirror-demo://artifact/demo.graph",
+        "mirror-demo://artifact/demo.rubric",
+    }
+
+    read_response = server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "resources/read",
+            "params": {"uri": "mirror-demo://artifact/demo.eval_summary"},
+        }
+    )
+    assert read_response is not None
+    contents = read_response["result"]["contents"]
+    assert contents[0]["uri"] == "mirror-demo://artifact/demo.eval_summary"
+    assert "artifact_paths" not in contents[0]["text"]
+    assert "D:/mirror" not in contents[0]["text"]
+
+    invalid_resource = server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "resources/read",
+            "params": {"uri": "file:///D:/mirror/artifacts/demo/report/claims.json"},
+        }
+    )
+    assert invalid_resource is not None
+    assert invalid_resource["error"]["code"] == -32602
+
+    resource_extra_arg = server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "resources/read",
+            "params": {"uri": "mirror-demo://manifest", "path": "artifacts/demo"},
+        }
+    )
+    assert resource_extra_arg is not None
+    assert resource_extra_arg["error"]["code"] == -32602
+
+    prompts_response = server.handle_request(
+        {"jsonrpc": "2.0", "id": 6, "method": "prompts/list"}
+    )
+    assert prompts_response is not None
+    prompts = {item["name"]: item for item in prompts_response["result"]["prompts"]}
+    assert set(prompts) == {
+        "inspect-public-demo",
+        "review-claim-evidence",
+        "compare-demo-branches",
+    }
+    assert all(item["arguments"] == [] for item in prompts.values())
+
+    prompt_response = server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "prompts/get",
+            "params": {"name": "compare-demo-branches"},
+        }
+    )
+    assert prompt_response is not None
+    text = prompt_response["result"]["messages"][0]["content"]["text"]
+    assert "branch_reporter_detained" in text
+    assert "real-world" in text
+
+    prompt_with_args = server.handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "prompts/get",
+            "params": {"name": "inspect-public-demo", "arguments": {"path": "secret"}},
+        }
+    )
+    assert prompt_with_args is not None
+    assert prompt_with_args["error"]["code"] == -32602
+
+
+def test_tool_schemas_match_read_only_contract() -> None:
+    tools = {tool["name"]: tool for tool in server.tool_definitions()}
+    expected_properties = {
+        "get_demo_manifest": set(),
+        "get_demo_artifact": {"artifact_id"},
+        "get_eval_summary": set(),
+        "explain_demo_claim": {"claim_id"},
+        "compare_demo_branches": {"candidate_branch_id", "reference_branch_id"},
+    }
+    expected_required = {
+        "get_demo_manifest": set(),
+        "get_demo_artifact": {"artifact_id"},
+        "get_eval_summary": set(),
+        "explain_demo_claim": {"claim_id"},
+        "compare_demo_branches": {"candidate_branch_id"},
+    }
+    forbidden = {
+        "path",
+        "file",
+        "filepath",
+        "filename",
+        "url",
+        "command",
+        "args",
+        "api_key",
+        "provider",
+        "model",
+    }
+
+    assert set(tools) == {
+        "get_demo_manifest",
+        "get_demo_artifact",
+        "get_eval_summary",
+        "explain_demo_claim",
+        "compare_demo_branches",
+    }
+    for name, tool in tools.items():
+        schema = tool["inputSchema"]
+        properties = schema["properties"]
+        assert tool["annotations"]["readOnlyHint"] is True
+        assert schema["additionalProperties"] is False
+        assert set(properties) == expected_properties[name]
+        assert set(schema.get("required", [])) == expected_required[name]
+        assert forbidden.isdisjoint(properties)
+
+    artifact_enum = tools["get_demo_artifact"]["inputSchema"]["properties"]["artifact_id"]["enum"]
+    assert set(artifact_enum) == set(server.PUBLIC_DEMO_ARTIFACTS)
+
+    compare_schema = tools["compare_demo_branches"]["inputSchema"]["properties"]
+    assert compare_schema["candidate_branch_id"]["enum"] == [
+        "branch_harbor_comms_failure",
+        "branch_mayor_signal_blocked",
+        "branch_reporter_detained",
+    ]
+    assert compare_schema["reference_branch_id"]["enum"] == ["branch_baseline"]

--- a/scripts/smoke_public_demo_web.py
+++ b/scripts/smoke_public_demo_web.py
@@ -15,6 +15,9 @@ from pathlib import Path
 from typing import Any
 
 
+TRANSIENT_HTTP_STATUSES = {408, 425, 429, 500, 502, 503, 504}
+
+
 def pick_free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))
@@ -49,6 +52,56 @@ def request_headers(auth_header: str | None, *, json_body: bool = False) -> dict
     return headers
 
 
+def describe_url_error(error: BaseException) -> str:
+    if isinstance(error, urllib.error.URLError):
+        reason = error.reason
+        return f"{type(reason).__name__}: {reason}"
+    return f"{type(error).__name__}: {error}"
+
+
+def read_http_response(
+    request: urllib.request.Request,
+    *,
+    timeout: int,
+    attempts: int,
+    retry_delay: float,
+) -> tuple[int, str, str]:
+    attempts = max(1, attempts)
+    last_error = "no response"
+    for attempt in range(1, attempts + 1):
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                return (
+                    response.status,
+                    response.headers.get("Content-Type", ""),
+                    response.read().decode("utf-8", errors="replace"),
+                )
+        except urllib.error.HTTPError as error:
+            if error.code not in TRANSIENT_HTTP_STATUSES:
+                raise
+            body = error.read().decode("utf-8", errors="replace")
+            last_error = f"status {error.code}: {body[:240]}"
+            if error.code in TRANSIENT_HTTP_STATUSES and attempt < attempts:
+                time.sleep(retry_delay)
+                continue
+            raise RuntimeError(
+                f"HTTP request failed for {display_url(request.full_url)} after "
+                f"{attempt} attempt(s): {last_error}"
+            ) from error
+        except (urllib.error.URLError, TimeoutError, OSError) as error:
+            last_error = describe_url_error(error)
+            if attempt < attempts:
+                time.sleep(retry_delay)
+                continue
+            raise RuntimeError(
+                f"HTTP request failed for {display_url(request.full_url)} after "
+                f"{attempt} attempt(s): {last_error}"
+            ) from error
+    raise RuntimeError(
+        f"HTTP request failed for {display_url(request.full_url)} after {attempts} attempt(s): {last_error}"
+    )
+
+
 def wait_for_ready(base_url: str, timeout_seconds: int, auth_header: str | None) -> None:
     deadline = time.time() + timeout_seconds
     last_error = "no response"
@@ -63,7 +116,7 @@ def wait_for_ready(base_url: str, timeout_seconds: int, auth_header: str | None)
         except urllib.error.HTTPError as error:
             last_error = f"status {error.code}"
         except Exception as error:
-            last_error = str(error)
+            last_error = describe_url_error(error)
         time.sleep(1)
     raise RuntimeError(
         f"Mirror public demo did not become ready within {timeout_seconds} seconds at "
@@ -71,7 +124,15 @@ def wait_for_ready(base_url: str, timeout_seconds: int, auth_header: str | None)
     )
 
 
-def http_json(base_url: str, path: str, auth_header: str | None, payload: dict[str, Any] | None = None):
+def http_json(
+    base_url: str,
+    path: str,
+    auth_header: str | None,
+    payload: dict[str, Any] | None = None,
+    *,
+    attempts: int = 1,
+    retry_delay: float = 1.0,
+):
     data = None
     method = "GET"
     if payload is not None:
@@ -83,11 +144,15 @@ def http_json(base_url: str, path: str, auth_header: str | None, payload: dict[s
         headers=request_headers(auth_header, json_body=payload is not None),
         method=method,
     )
-    with urllib.request.urlopen(request, timeout=30) as response:
-        raw = response.read().decode("utf-8")
-        if "application/json" in response.headers.get("Content-Type", ""):
-            return json.loads(raw)
-        return {"status": response.status, "body": raw}
+    status, content_type, raw = read_http_response(
+        request,
+        timeout=30,
+        attempts=attempts,
+        retry_delay=retry_delay,
+    )
+    if "application/json" in content_type:
+        return json.loads(raw)
+    return {"status": status, "body": raw}
 
 
 def expect_http_status(
@@ -96,9 +161,19 @@ def expect_http_status(
     auth_header: str | None,
     expected_status: int,
     payload: dict[str, Any] | None = None,
+    *,
+    attempts: int = 1,
+    retry_delay: float = 1.0,
 ) -> None:
     try:
-        http_json(base_url, path, auth_header, payload)
+        http_json(
+            base_url,
+            path,
+            auth_header,
+            payload,
+            attempts=attempts,
+            retry_delay=retry_delay,
+        )
     except urllib.error.HTTPError as error:
         if error.code == expected_status:
             return
@@ -107,10 +182,21 @@ def expect_http_status(
     raise RuntimeError(f"Expected {expected_status} for {path}, got success.")
 
 
-def assert_status_200(url: str, auth_header: str | None) -> int:
+def assert_status_200(
+    url: str,
+    auth_header: str | None,
+    *,
+    attempts: int = 1,
+    retry_delay: float = 1.0,
+) -> int:
     request = urllib.request.Request(url, headers=request_headers(auth_header))
-    with urllib.request.urlopen(request, timeout=30) as response:
-        return response.status
+    status, _content_type, _raw = read_http_response(
+        request,
+        timeout=30,
+        attempts=attempts,
+        retry_delay=retry_delay,
+    )
+    return status
 
 
 def main() -> int:
@@ -120,6 +206,8 @@ def main() -> int:
     parser.add_argument("--timeout", type=int, default=30)
     parser.add_argument("--base-url", help="Use an already-running Mirror web base URL.")
     parser.add_argument("--no-start", action="store_true", help="Do not start a local Next server.")
+    parser.add_argument("--http-retries", type=int, default=5, help="Retry transient HTTP/TLS failures.")
+    parser.add_argument("--retry-delay", type=float, default=2.0, help="Seconds between transient HTTP retries.")
     parser.add_argument("--basic-auth-user", default=os.environ.get("MIRROR_SMOKE_BASIC_AUTH_USER"))
     parser.add_argument("--basic-auth-password", default=os.environ.get("MIRROR_SMOKE_BASIC_AUTH_PASSWORD"))
     args = parser.parse_args()
@@ -163,11 +251,32 @@ def main() -> int:
             env=env,
         )
 
+    http_attempts = max(1, args.http_retries)
+    retry_delay = max(0.0, args.retry_delay)
+
     try:
         wait_for_ready(base_url, args.timeout, auth_header)
-        health_payload = http_json(base_url, "/api/health", auth_header)
-        ready_payload = http_json(base_url, "/api/ready", auth_header)
-        manifest_payload = http_json(base_url, "/api/public-demo/manifest", auth_header)
+        health_payload = http_json(
+            base_url,
+            "/api/health",
+            auth_header,
+            attempts=http_attempts,
+            retry_delay=retry_delay,
+        )
+        ready_payload = http_json(
+            base_url,
+            "/api/ready",
+            auth_header,
+            attempts=http_attempts,
+            retry_delay=retry_delay,
+        )
+        manifest_payload = http_json(
+            base_url,
+            "/api/public-demo/manifest",
+            auth_header,
+            attempts=http_attempts,
+            retry_delay=retry_delay,
+        )
 
         if health_payload.get("status") != "ok":
             raise RuntimeError(f"Unexpected health payload: {health_payload}")
@@ -185,14 +294,62 @@ def main() -> int:
         if not expected_ids.issubset(artifact_ids):
             raise RuntimeError(f"Manifest missing expected ids: {expected_ids - artifact_ids}")
 
-        claims_payload = http_json(base_url, "/api/public-demo/artifacts/demo.claims", auth_header)
-        eval_payload = http_json(base_url, "/api/public-demo/artifacts/demo.eval_summary", auth_header)
-        compare_payload = http_json(base_url, "/api/public-demo/artifacts/demo.compare", auth_header)
-        report_payload = http_json(base_url, "/api/public-demo/artifacts/demo.report", auth_header)
-        documents_payload = http_json(base_url, "/api/public-demo/artifacts/demo.documents", auth_header)
-        chunks_payload = http_json(base_url, "/api/public-demo/artifacts/demo.chunks", auth_header)
-        graph_payload = http_json(base_url, "/api/public-demo/artifacts/demo.graph", auth_header)
-        rubric_payload = http_json(base_url, "/api/public-demo/artifacts/demo.rubric", auth_header)
+        claims_payload = http_json(
+            base_url,
+            "/api/public-demo/artifacts/demo.claims",
+            auth_header,
+            attempts=http_attempts,
+            retry_delay=retry_delay,
+        )
+        eval_payload = http_json(
+            base_url,
+            "/api/public-demo/artifacts/demo.eval_summary",
+            auth_header,
+            attempts=http_attempts,
+            retry_delay=retry_delay,
+        )
+        compare_payload = http_json(
+            base_url,
+            "/api/public-demo/artifacts/demo.compare",
+            auth_header,
+            attempts=http_attempts,
+            retry_delay=retry_delay,
+        )
+        report_payload = http_json(
+            base_url,
+            "/api/public-demo/artifacts/demo.report",
+            auth_header,
+            attempts=http_attempts,
+            retry_delay=retry_delay,
+        )
+        documents_payload = http_json(
+            base_url,
+            "/api/public-demo/artifacts/demo.documents",
+            auth_header,
+            attempts=http_attempts,
+            retry_delay=retry_delay,
+        )
+        chunks_payload = http_json(
+            base_url,
+            "/api/public-demo/artifacts/demo.chunks",
+            auth_header,
+            attempts=http_attempts,
+            retry_delay=retry_delay,
+        )
+        graph_payload = http_json(
+            base_url,
+            "/api/public-demo/artifacts/demo.graph",
+            auth_header,
+            attempts=http_attempts,
+            retry_delay=retry_delay,
+        )
+        rubric_payload = http_json(
+            base_url,
+            "/api/public-demo/artifacts/demo.rubric",
+            auth_header,
+            attempts=http_attempts,
+            retry_delay=retry_delay,
+        )
 
         public_payload_text = json.dumps(
             {
@@ -238,6 +395,8 @@ def main() -> int:
                 "scenarioId": "scenario_baseline",
                 "decisionProvider": "deterministic_only",
             },
+            attempts=http_attempts,
+            retry_delay=retry_delay,
         )
         expect_http_status(
             base_url,
@@ -251,6 +410,8 @@ def main() -> int:
                 "decisionProvider": "deterministic_only",
                 "perturbation": {"kind": "blocked_public_demo"},
             },
+            attempts=http_attempts,
+            retry_delay=retry_delay,
         )
         expect_http_status(
             base_url,
@@ -262,15 +423,50 @@ def main() -> int:
                 "sessionId": "public-demo-disabled",
                 "toNode": "node_root",
             },
+            attempts=http_attempts,
+            retry_delay=retry_delay,
         )
-        expect_http_status(base_url, "/api/worlds/create", auth_header, 403, {"name": "blocked"})
+        expect_http_status(
+            base_url,
+            "/api/worlds/create",
+            auth_header,
+            403,
+            {"name": "blocked"},
+            attempts=http_attempts,
+            retry_delay=retry_delay,
+        )
 
         page_statuses = {
-            "/": assert_status_200(f"{base_url}/", auth_header),
-            "/review": assert_status_200(f"{base_url}/review", auth_header),
-            f"/changes/{branch_id}": assert_status_200(f"{base_url}/changes/{branch_id}", auth_header),
-            f"/explain/{branch_id}": assert_status_200(f"{base_url}/explain/{branch_id}", auth_header),
-            "/worlds/new": assert_status_200(f"{base_url}/worlds/new", auth_header),
+            "/": assert_status_200(
+                f"{base_url}/",
+                auth_header,
+                attempts=http_attempts,
+                retry_delay=retry_delay,
+            ),
+            "/review": assert_status_200(
+                f"{base_url}/review",
+                auth_header,
+                attempts=http_attempts,
+                retry_delay=retry_delay,
+            ),
+            f"/changes/{branch_id}": assert_status_200(
+                f"{base_url}/changes/{branch_id}",
+                auth_header,
+                attempts=http_attempts,
+                retry_delay=retry_delay,
+            ),
+            f"/explain/{branch_id}": assert_status_200(
+                f"{base_url}/explain/{branch_id}",
+                auth_header,
+                attempts=http_attempts,
+                retry_delay=retry_delay,
+            ),
+            "/worlds/new": assert_status_200(
+                f"{base_url}/worlds/new",
+                auth_header,
+                attempts=http_attempts,
+                retry_delay=retry_delay,
+            ),
         }
 
         claims = claims_payload.get("data", [])
@@ -308,4 +504,7 @@ if __name__ == "__main__":
     except urllib.error.HTTPError as error:
         body = error.read().decode("utf-8", errors="replace")
         print(body, file=sys.stderr)
-        raise
+        raise SystemExit(1) from error
+    except RuntimeError as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(1) from error


### PR DESCRIPTION
### What Changed

- Added the repo-local `mirror-codex` Codex plugin with a `Read`-only manifest, `mirror-demo`
  skill, fixed `.mcp.json`, and local Python MCP server.
- Added read-only MCP tools, resources, and prompts for the deterministic Fog Harbor public
  demo. Inputs are logical ids only; tools do not accept filesystem paths, URLs, provider
  config, API keys, model names, uploads, or mutation requests.
- Added plugin validation, MCP tests, stdio smoke, deterministic install acceptance, and PR
  scope hygiene. `plugin-release-check` now runs those checks plus secret scan, phase2 audit,
  and whitespace diff validation.
- Scoped PR hygiene reports local-only plan files and generated editable-install egg metadata
  separately so they do not get staged into the plugin PR.
- Added the durable MCP contract ADR and operator docs for install acceptance, evidence
  navigation, release checks, and explicit remote public demo smoke.

### Tests

- [x] `./make.ps1 plugin-release-check`
- [x] `python -m pytest backend\tests\test_api.py -q`
- [x] `python plugins\mirror-codex\scripts\check_pr_scope.py --stage-list`
- [x] `./make.ps1 plugin-remote-check`
- [ ] `npm run build --prefix frontend` - not run because this PR does not touch frontend code

### Artifacts

- Direct evidence: local `plugin-release-check` reports plugin validation passed, 8 MCP tests
  passed, MCP stdio smoke passed, install acceptance passed, PR scope check passed, secret
  scan passed, and phase2 audit status `pass`.
- Direct evidence: remote public demo smoke against `https://mirror-public-demo.onrender.com`
  reports 8 artifacts OK, 3 claims, eval status `pass`, and key pages returning 200.
- Direct evidence: PR scope check reports local-only untracked `docs/plans/...` files and
  generated `backend/mirror_engine.egg-info/...` packaging metadata as excluded from the
  plugin PR.
- Reasonable inference: `npm run build --prefix frontend` is not required for this PR because
  the change set does not modify frontend code or frontend routes.

### Contract Impact

- Adds ADR-0010 as the durable v1 contract for the repo-local Mirror Codex plugin MCP surface.
- Does not change scenario DSL, simulation runtime, public demo artifact layout, claim labels,
  run trace shape, frontend routes, or backend public API routes.
- Claims returned through the plugin preserve both `label` and `evidence_ids`.

### Safety Impact

- Preserves the Phase 1 public demo boundary: deterministic-only, read-only, precomputed,
  anonymous, and local-first for plugin usage.
- Does not add Hosted GPT, BYOK, corpus upload, create-world, runtime mutation, auth, billing,
  database, object storage, quotas, or provider secret handling.
- Does not present Mirror as a real-world prediction tool, real-person digital twin system,
  political persuasion tool, or high-risk decision system.

### TODO[verify]

- TODO[verify]: Record the exact Codex UI install wording after testing this plugin in a
  clean Codex versioned environment.