### PR TITLE
[codex] Document Mirror Codex UI acceptance

### DIFF
--- a/docs/deploy/mirror-codex-plugin-ui-acceptance.md
+++ b/docs/deploy/mirror-codex-plugin-ui-acceptance.md
@@ -1,0 +1,74 @@
+# Mirror Codex Plugin UI Acceptance
+
+## Intent
+
+Use this checklist to verify the repo-local `mirror-codex` plugin in a Codex app session after
+PR #353. This is a UI-facing complement to `docs/deploy/mirror-codex-plugin.md`; it does not
+replace the deterministic filesystem and MCP checks.
+
+## Current Evidence
+
+- Direct evidence: `main` contains `.agents/plugins/marketplace.json` with a repo-local
+  `mirror-codex` entry whose source path is `./plugins/mirror-codex`, installation policy is
+  `AVAILABLE`, and category is `Engineering`.
+- Direct evidence: `plugins/mirror-codex/.codex-plugin/plugin.json` exposes `skills:
+  "./skills/"`, `mcpServers: "./.mcp.json"`, and interface capability `Read`.
+- Direct evidence: `plugins/mirror-codex/.mcp.json` registers one fixed `mirror-demo` server
+  with command `python` and args `["./scripts/run_mcp.py"]`.
+- Direct evidence: `./make.ps1 plugin-release-check` validates the plugin manifest, MCP
+  tools/resources/prompts, install acceptance, secret scan, phase2 audit, and PR scope.
+
+TODO[verify]: Record the exact Codex app UI labels and install/enable controls from a clean
+Codex versioned environment. The current local CLI checks cannot inspect interactive Codex app
+controls directly.
+
+## UI Acceptance Steps
+
+Start from a clean Codex app session opened at the repository root.
+
+1. Open the plugin or marketplace view.
+2. Confirm the marketplace display name is `Mirror Local Plugins`.
+3. Confirm a repo-local plugin named `mirror-codex` or displayed as `Mirror Codex` is visible.
+4. Confirm the plugin shows a read-only capability or equivalent `Read` wording.
+5. Enable or install the plugin using the app UI.
+6. Confirm the `mirror-demo` skill is available.
+7. Confirm the MCP server named `mirror-demo` is registered, if the UI exposes MCP servers.
+8. Ask: `Use Mirror Demo to inspect demo.claims and explain claim_evacuation_turn.`
+9. Ask: `Use Mirror Demo to compare branch_reporter_detained against the baseline.`
+10. Ask: `Use Mirror Demo to review claim_evacuation_turn and show how its evidence_ids map to chunks and sanitized document metadata.`
+
+## Expected Behavior
+
+- Codex frames Mirror as a constrained, evidence-backed, replayable what-if simulation sandbox
+  for fictional or explicitly authorized worlds.
+- Codex keeps the Phase 1 public demo deterministic-only, read-only, anonymous, precomputed,
+  and local-first for plugin use.
+- Codex uses logical artifact ids or fixed `mirror-demo://...` resources, not arbitrary
+  filesystem paths.
+- Claim responses preserve both `label` and `evidence_ids`.
+- Evidence navigation for `claim_evacuation_turn` includes
+  `chunk_doc_budget_minutes_002`, `chunk_doc_budget_minutes_003`, and
+  `chunk_doc_engineering_inspection_002`.
+- Output does not expose `artifact_paths`, `summary_path`, `trace_path`, `snapshot_dir`,
+  document `source_path`, local filesystem paths, provider config, API keys, or model names.
+- Output does not present Mirror as a real-world prediction tool, real-person digital twin
+  system, political persuasion tool, or high-risk decision system.
+
+## Failure Handling
+
+If the plugin does not appear in the UI, rerun:
+
+```powershell
+python plugins/mirror-codex/scripts/acceptance_check.py
+```
+
+Then confirm:
+
+- `.agents/plugins/marketplace.json` exists at repo root
+- the marketplace source path is `./plugins/mirror-codex`
+- `plugins/mirror-codex/.codex-plugin/plugin.json` has `"name": "mirror-codex"`
+- `plugins/mirror-codex/.mcp.json` registers only `mirror-demo`
+
+If UI labels differ from this document, update this file and
+`docs/deploy/mirror-codex-plugin.md` with the direct evidence and leave any remaining unknowns
+as `TODO[verify]: ...`.

--- a/docs/deploy/mirror-codex-plugin.md
+++ b/docs/deploy/mirror-codex-plugin.md
@@ -23,6 +23,9 @@ TODO[verify]: Codex plugin UI labels and install controls can vary by Codex vers
 filesystem checks and MCP smoke below as the stable acceptance path, and record any UI-specific
 differences in a follow-up note.
 
+For the UI-facing acceptance checklist and evidence log, see
+`docs/deploy/mirror-codex-plugin-ui-acceptance.md`.
+
 ## Preconditions
 
 From the repository root:
@@ -165,6 +168,9 @@ If the plugin does not appear in Codex UI, first verify:
 - `.agents/plugins/marketplace.json` exists at repo root
 - `plugins/mirror-codex/.codex-plugin/plugin.json` has `"name": "mirror-codex"`
 - `.mcp.json` registers only `mirror-demo`
+
+Then follow `docs/deploy/mirror-codex-plugin-ui-acceptance.md` to record the exact Codex app
+labels and any version-specific install behavior.
 
 If remote smoke fails with a URL or TLS error, rerun with explicit retries and inspect whether
 PowerShell can reach the endpoints:

--- a/plugins/mirror-codex/scripts/check_pr_scope.py
+++ b/plugins/mirror-codex/scripts/check_pr_scope.py
@@ -17,6 +17,7 @@ ALLOWED_EXACT_PATHS = {
     "README.md",
     "docs/decisions/ADR-0010-mirror-codex-plugin-mcp-contract.md",
     "docs/deploy/mirror-codex-plugin.md",
+    "docs/deploy/mirror-codex-plugin-ui-acceptance.md",
     "docs/deploy/render-public-demo.md",
     "docs/releases/mirror-codex-plugin-v1.md",
     "make.ps1",


### PR DESCRIPTION
## What Changed

- Added `docs/deploy/mirror-codex-plugin-ui-acceptance.md` as the UI-facing acceptance checklist for the repo-local Mirror Codex plugin.
- Linked the UI checklist from the existing plugin runbook.
- Added the new checklist path to the plugin PR scope allowlist.

## Tests

- [x] `./make.ps1 plugin-release-check`
- [x] `python -m pytest backend\tests\test_api.py -q`
- [x] `python plugins\mirror-codex\scripts\check_pr_scope.py --stage-list`
- [ ] `npm run build --prefix frontend` - not run because this PR does not touch frontend code or frontend routes

## Evidence Discipline

- Direct evidence: deterministic local plugin acceptance validates marketplace, manifest, MCP tools/resources/prompts, secret scan, phase2 audit, and PR scope.
- TODO[verify]: exact Codex app UI labels and install/enable controls still require a clean Codex versioned UI session.

## Safety Impact

- Documentation only; no runtime mutation, provider access, uploads, auth, billing, database, object storage, or quota behavior.
- Preserves deterministic-only, read-only, local-first plugin scope.