### PR TITLE
[codex] Record Mirror Codex UI preflight limitation

### DIFF
--- a/docs/deploy/mirror-codex-plugin-ui-acceptance.md
+++ b/docs/deploy/mirror-codex-plugin-ui-acceptance.md
@@ -22,6 +22,21 @@ TODO[verify]: Record the exact Codex app UI labels and install/enable controls f
 Codex versioned environment. The current local CLI checks cannot inspect interactive Codex app
 controls directly.
 
+## Current Session Preflight
+
+Direct evidence: in the Codex thread that created this checklist, tool discovery for
+`mirror-codex` and `mirror-demo` did not expose Mirror plugin tools after PR #353 and PR #354
+were merged. This indicates the running thread cannot be used as a clean post-install UI
+acceptance session.
+
+Reasonable inference: repo-local plugin discovery is likely evaluated when a Codex app session
+or workspace is opened, not dynamically after a plugin lands on `main` inside an already-running
+thread.
+
+Do not close the UI `TODO[verify]` from this current-thread preflight alone. Use a new Codex
+app session opened at the repository root and record the exact UI labels and controls observed
+there.
+
 ## UI Acceptance Steps
 
 Start from a clean Codex app session opened at the repository root.


### PR DESCRIPTION
## What Changed

- Added a current-session preflight note to the Mirror Codex plugin UI acceptance checklist.
- Recorded that the running Codex thread did not expose `mirror-codex`/`mirror-demo` through current tool discovery after PR #353/#354 landed.
- Kept the clean Codex app UI acceptance `TODO[verify]` open instead of claiming interactive UI validation from this already-running thread.

## Tests

- [x] `./make.ps1 plugin-release-check`
- [x] `python -m pytest backend\tests\test_api.py -q`
- [x] `python plugins\mirror-codex\scripts\check_pr_scope.py --stage-list`
- [ ] `npm run build --prefix frontend` - not run because this PR does not touch frontend code or frontend routes

## Evidence Discipline

- Direct evidence: current tool discovery in this running thread did not expose Mirror plugin tools.
- Reasonable inference: repo-local plugin discovery likely happens when a Codex app session/workspace is opened, not dynamically inside an already-running thread.
- TODO[verify]: exact Codex app UI labels and install/enable controls still require a clean Codex versioned UI session.

## Safety Impact

Documentation only. No runtime mutation, provider paths, uploads, auth, billing, database, object storage, or quota behavior.