### PR TITLE
[codex] Add Mirror Codex CLI marketplace preflight

### DIFF
--- a/docs/deploy/mirror-codex-plugin-ui-acceptance.md
+++ b/docs/deploy/mirror-codex-plugin-ui-acceptance.md
@@ -39,6 +39,12 @@ there.
 
 ## CLI Marketplace Preflight
 
+Run the scriptable preflight:
+
+```powershell
+python plugins/mirror-codex/scripts/cli_marketplace_preflight.py
+```
+
 Direct evidence: on 2026-04-27, `codex marketplace add D:\mirror` succeeded in an isolated
 temporary `CODEX_HOME` and wrote:
 

--- a/docs/deploy/mirror-codex-plugin.md
+++ b/docs/deploy/mirror-codex-plugin.md
@@ -73,6 +73,18 @@ metadata, and path-argument rejection:
 python plugins/mirror-codex/scripts/acceptance_check.py
 ```
 
+If the Codex CLI is installed, run the optional marketplace preflight in an isolated
+temporary `CODEX_HOME`:
+
+```powershell
+python plugins/mirror-codex/scripts/cli_marketplace_preflight.py
+```
+
+This verifies that `codex marketplace add` accepts the repository root as the local
+marketplace source and records whether `codex debug prompt-input` sees the `mirror-demo`
+skill. It does not call `codex exec`, does not call model providers, and does not replace
+clean Codex app UI acceptance.
+
 ## Codex Manual Acceptance
 
 After enabling the repo-local plugin in Codex, ask Codex:

--- a/plugins/mirror-codex/README.md
+++ b/plugins/mirror-codex/README.md
@@ -21,6 +21,7 @@ This first version is intentionally read-only and local-first. It packages one s
 - `scripts/run_mcp.py`: MCP server entrypoint.
 - `scripts/smoke_mcp_stdio.py`: Fixed stdio smoke test for plugin install readiness.
 - `scripts/acceptance_check.py`: Repo-local plugin install acceptance check.
+- `scripts/cli_marketplace_preflight.py`: Optional Codex CLI marketplace registration preflight.
 - `scripts/check_pr_scope.py`: Workspace scope check for the plugin V1 PR.
 - `scripts/validate_plugin.py`: Static validation for the plugin shell.
 - `tests/`: Plugin MCP and sanitizer tests.
@@ -132,6 +133,17 @@ python plugins/mirror-codex/scripts/check_pr_scope.py --stage-list | git add --p
 ```
 
 For a clean local install check, enable the repo-local `mirror-codex` plugin from `.agents/plugins/marketplace.json`, then ask Codex to use the `mirror-demo` skill to inspect `demo.claims` and compare `branch_reporter_detained`. The same MCP path is covered by `smoke_mcp_stdio.py`.
+
+If the Codex CLI is installed, you can also run a local marketplace preflight without using
+your real Codex home:
+
+```powershell
+python plugins/mirror-codex/scripts/cli_marketplace_preflight.py
+```
+
+This script creates an isolated temporary `CODEX_HOME`, runs `codex marketplace add` against
+the repository root, and renders `codex debug prompt-input`. It does not call `codex exec`,
+does not call model providers, and does not close the Codex app UI `TODO[verify]`.
 
 Remote public demo checks are optional and must be explicit. They are not part of `plugin-check`:
 

--- a/plugins/mirror-codex/scripts/cli_marketplace_preflight.py
+++ b/plugins/mirror-codex/scripts/cli_marketplace_preflight.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+sys.dont_write_bytecode = True
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PLUGIN_KEY = 'mirror-codex@mirror-local'
+MARKETPLACE_SECTION = "[marketplaces.mirror-local]"
+DEBUG_PROMPT = "Inspect the Mirror public demo claims."
+SECRET_ENV_MARKERS = ("API_KEY", "TOKEN", "SECRET")
+
+
+def redact_env(env: dict[str, str]) -> dict[str, str]:
+    sanitized = dict(env)
+    sanitized["CODEX_HOME"] = sanitized["CODEX_HOME"]
+    for key in list(sanitized):
+        if key.upper() in {"CODEX_THREAD_ID", "CODEX_INTERNAL_ORIGINATOR_OVERRIDE"}:
+            sanitized.pop(key, None)
+            continue
+        if any(marker in key.upper() for marker in SECRET_ENV_MARKERS):
+            sanitized.pop(key, None)
+    return sanitized
+
+
+def run_command(command: list[str], *, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def short_text(text: str, limit: int = 800) -> str:
+    collapsed = "\n".join(line.rstrip() for line in text.splitlines() if line.strip())
+    if len(collapsed) <= limit:
+        return collapsed
+    return collapsed[: limit - 3] + "..."
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def skill_visible_in_prompt(prompt_json: str) -> bool:
+    try:
+        payload = json.loads(prompt_json)
+    except json.JSONDecodeError:
+        return False
+    text = json.dumps(payload, ensure_ascii=False)
+    return "- mirror-demo:" in text or "skills/mirror-demo/SKILL.md" in text
+
+
+def append_manual_plugin_enable(config_path: Path) -> None:
+    with config_path.open("a", encoding="utf-8", newline="\n") as handle:
+        handle.write(f'\n[plugins."{PLUGIN_KEY}"]\n')
+        handle.write("enabled = true\n")
+
+
+def run_preflight(codex_command: str, keep_temp: bool) -> dict[str, Any]:
+    temp_context: tempfile.TemporaryDirectory[str] | None = None
+    if keep_temp:
+        temp_home = Path(tempfile.mkdtemp(prefix="mirror-codex-home-"))
+    else:
+        temp_context = tempfile.TemporaryDirectory(prefix="mirror-codex-home-")
+        temp_home = Path(temp_context.name)
+
+    env = dict(os.environ)
+    env["CODEX_HOME"] = str(temp_home)
+    env = redact_env(env)
+
+    codex_path = shutil.which(codex_command)
+    if codex_path is None:
+        if temp_context is not None:
+            temp_context.cleanup()
+        raise AssertionError(f"Codex CLI was not found on PATH: {codex_command}")
+
+    result: dict[str, Any] = {
+        "repo_root": str(REPO_ROOT),
+        "codex_command": codex_path,
+        "temp_home": str(temp_home) if keep_temp else "<temporary>",
+        "kept_temp_home": keep_temp,
+        "calls_model_provider": False,
+        "ui_todo_closed": False,
+        "checks": {},
+        "notes": [
+            "TODO[verify]: This CLI preflight does not inspect interactive Codex app UI controls.",
+        ],
+    }
+
+    add_repo = run_command([codex_path, "marketplace", "add", str(REPO_ROOT)], env=env)
+    config_path = temp_home / "config.toml"
+    config_text = read_text(config_path)
+    result["checks"]["marketplace_add_repo_root"] = {
+        "passed": add_repo.returncode == 0,
+        "returncode": add_repo.returncode,
+        "stdout": short_text(add_repo.stdout),
+        "stderr": short_text(add_repo.stderr),
+    }
+    result["checks"]["temp_config_contains_marketplace"] = {
+        "passed": MARKETPLACE_SECTION in config_text and 'source_type = "local"' in config_text,
+    }
+
+    wrong_root = run_command([codex_path, "marketplace", "add", str(REPO_ROOT / ".agents" / "plugins")], env=env)
+    result["checks"]["marketplace_add_agents_plugins_subdir"] = {
+        "passed": wrong_root.returncode != 0,
+        "returncode": wrong_root.returncode,
+        "stdout": short_text(wrong_root.stdout),
+        "stderr": short_text(wrong_root.stderr),
+        "interpretation": "Expected failure: the CLI treats the argument as the marketplace root.",
+    }
+
+    prompt_after_add = run_command(
+        [codex_path, "-C", str(REPO_ROOT), "debug", "prompt-input", DEBUG_PROMPT],
+        env=env,
+    )
+    result["checks"]["debug_prompt_after_marketplace_add"] = {
+        "passed": prompt_after_add.returncode == 0,
+        "returncode": prompt_after_add.returncode,
+        "mirror_demo_skill_visible": skill_visible_in_prompt(prompt_after_add.stdout),
+        "stderr": short_text(prompt_after_add.stderr),
+    }
+
+    if not config_path.exists():
+        raise AssertionError("Codex CLI did not create a temp config.toml after marketplace add.")
+    append_manual_plugin_enable(config_path)
+    prompt_after_manual_enable = run_command(
+        [codex_path, "-C", str(REPO_ROOT), "debug", "prompt-input", DEBUG_PROMPT],
+        env=env,
+    )
+    result["checks"]["debug_prompt_after_manual_plugin_enable"] = {
+        "passed": prompt_after_manual_enable.returncode == 0,
+        "returncode": prompt_after_manual_enable.returncode,
+        "mirror_demo_skill_visible": skill_visible_in_prompt(prompt_after_manual_enable.stdout),
+        "stderr": short_text(prompt_after_manual_enable.stderr),
+        "interpretation": "Manual config editing is only a troubleshooting probe, not UI install acceptance.",
+    }
+
+    if temp_context is not None:
+        temp_context.cleanup()
+    return result
+
+
+def preflight_passed(result: dict[str, Any]) -> bool:
+    checks = result.get("checks", {})
+    required = {
+        "marketplace_add_repo_root",
+        "temp_config_contains_marketplace",
+        "marketplace_add_agents_plugins_subdir",
+        "debug_prompt_after_marketplace_add",
+        "debug_prompt_after_manual_plugin_enable",
+    }
+    return all(checks.get(name, {}).get("passed") is True for name in required)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a local Codex CLI marketplace preflight for the Mirror Codex plugin.",
+    )
+    parser.add_argument(
+        "--codex",
+        default="codex",
+        help="Codex CLI command to execute. Defaults to 'codex'.",
+    )
+    parser.add_argument(
+        "--keep-temp",
+        action="store_true",
+        help="Keep the isolated CODEX_HOME for manual inspection.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        result = run_preflight(args.codex, args.keep_temp)
+    except AssertionError as exc:
+        print(f"Mirror Codex CLI marketplace preflight failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if not preflight_passed(result):
+        print("Mirror Codex CLI marketplace preflight failed one or more required checks.", file=sys.stderr)
+        return 1
+    print("Mirror Codex CLI marketplace preflight passed.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/mirror-codex/scripts/validate_plugin.py
+++ b/plugins/mirror-codex/scripts/validate_plugin.py
@@ -116,6 +116,7 @@ def validate_mcp_placeholder(root: Path) -> None:
     assert_true((root / "scripts" / "run_mcp.py").exists(), "MCP entrypoint must exist.")
     assert_true((root / "scripts" / "smoke_mcp_stdio.py").exists(), "MCP stdio smoke script must exist.")
     assert_true((root / "scripts" / "acceptance_check.py").exists(), "plugin install acceptance script must exist.")
+    assert_true((root / "scripts" / "cli_marketplace_preflight.py").exists(), "Codex CLI marketplace preflight script must exist.")
     assert_true((root / "scripts" / "check_pr_scope.py").exists(), "plugin PR scope check script must exist.")
     assert_true((root / "mirror_codex_mcp" / "server.py").exists(), "MCP server module must exist.")
 
@@ -151,6 +152,7 @@ def validate_plugin_readme(root: Path) -> None:
     assert_true("annotations.readOnlyHint: true" in text, "plugin README must document read-only MCP annotations.")
     assert_true("smoke_mcp_stdio.py" in text, "plugin README must document the MCP stdio smoke.")
     assert_true("acceptance_check.py" in text, "plugin README must document the install acceptance check.")
+    assert_true("cli_marketplace_preflight.py" in text, "plugin README must document the Codex CLI marketplace preflight.")
     assert_true("check_pr_scope.py" in text, "plugin README must document the PR scope check.")
     for tool_name in REQUIRED_TOOL_NAMES:
         assert_true(tool_name in text, f"plugin README must mention MCP tool {tool_name}.")


### PR DESCRIPTION
## Summary

- add a local Codex CLI marketplace preflight script for the Mirror Codex plugin
- document the script from the plugin README, deploy runbook, and UI acceptance checklist
- extend static plugin validation so the preflight helper remains present and documented

## Validation

- `python plugins\mirror-codex\scripts\cli_marketplace_preflight.py`
- `./make.ps1 plugin-release-check`
- `python -m pytest backend\tests\test_api.py -q`
- `git diff --check`

## Notes

The preflight uses an isolated temporary `CODEX_HOME`, calls `codex marketplace add` and `codex debug prompt-input`, and does not call `codex exec` or model providers. It does not close the Codex app UI `TODO[verify]`.