### PR TITLE
[codex] Add Mirror Codex CLI preflight target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ MIRROR_REMOTE_SMOKE_TIMEOUT ?= 60
 MIRROR_REMOTE_SMOKE_RETRIES ?= 5
 MIRROR_REMOTE_SMOKE_RETRY_DELAY ?= 2
 
-.PHONY: setup smoke test eval-demo eval-transfer public-demo-check plugin-check plugin-release-check plugin-remote-check dev-api dev-web
+.PHONY: setup smoke test eval-demo eval-transfer public-demo-check plugin-check plugin-release-check plugin-cli-preflight plugin-remote-check dev-api dev-web
 
 setup:
 	$(PYTHON) -m pip install -e backend
@@ -39,6 +39,9 @@ plugin-release-check: plugin-check
 	$(PYTHON) scripts/check_no_secrets.py
 	$(PYTHON) -m backend.app.cli audit-phase phase2
 	git diff --check
+
+plugin-cli-preflight:
+	$(PYTHON) plugins/mirror-codex/scripts/cli_marketplace_preflight.py
 
 plugin-remote-check:
 	$(PYTHON) scripts/smoke_public_demo_web.py --base-url $(MIRROR_PUBLIC_DEMO_BASE_URL) --timeout $(MIRROR_REMOTE_SMOKE_TIMEOUT) --http-retries $(MIRROR_REMOTE_SMOKE_RETRIES) --retry-delay $(MIRROR_REMOTE_SMOKE_RETRY_DELAY)

--- a/README.md
+++ b/README.md
@@ -121,11 +121,13 @@ Validate the repo-local Codex plugin:
 ```bash
 make plugin-check
 make plugin-release-check
+make plugin-cli-preflight
 ```
 
 ```powershell
 ./make.ps1 plugin-check
 ./make.ps1 plugin-release-check
+./make.ps1 plugin-cli-preflight
 ```
 
 Start the legacy local development stack:

--- a/docs/deploy/mirror-codex-plugin-ui-acceptance.md
+++ b/docs/deploy/mirror-codex-plugin-ui-acceptance.md
@@ -42,7 +42,7 @@ there.
 Run the scriptable preflight:
 
 ```powershell
-python plugins/mirror-codex/scripts/cli_marketplace_preflight.py
+./make.ps1 plugin-cli-preflight
 ```
 
 Direct evidence: on 2026-04-27, `codex marketplace add D:\mirror` succeeded in an isolated

--- a/docs/deploy/mirror-codex-plugin.md
+++ b/docs/deploy/mirror-codex-plugin.md
@@ -34,6 +34,7 @@ From the repository root:
 python -m backend.app.cli eval-demo
 ./make.ps1 plugin-check
 ./make.ps1 plugin-release-check
+./make.ps1 plugin-cli-preflight
 ```
 
 The plugin check must report:
@@ -77,7 +78,7 @@ If the Codex CLI is installed, run the optional marketplace preflight in an isol
 temporary `CODEX_HOME`:
 
 ```powershell
-python plugins/mirror-codex/scripts/cli_marketplace_preflight.py
+./make.ps1 plugin-cli-preflight
 ```
 
 This verifies that `codex marketplace add` accepts the repository root as the local

--- a/make.ps1
+++ b/make.ps1
@@ -67,6 +67,9 @@ switch ($Target) {
         Invoke-Native python -m backend.app.cli audit-phase phase2
         Invoke-Native git diff --check
     }
+    "plugin-cli-preflight" {
+        Invoke-Native python .\plugins\mirror-codex\scripts\cli_marketplace_preflight.py
+    }
     "plugin-remote-check" {
         Invoke-Native python .\scripts\smoke_public_demo_web.py --base-url $RemoteBaseUrl --timeout $RemoteTimeout --http-retries $RemoteRetries --retry-delay $RemoteRetryDelay
     }

--- a/plugins/mirror-codex/README.md
+++ b/plugins/mirror-codex/README.md
@@ -101,6 +101,7 @@ Run these from the repository root:
 ```powershell
 ./make.ps1 plugin-check
 ./make.ps1 plugin-release-check
+./make.ps1 plugin-cli-preflight
 ```
 
 `plugin-check` runs static validation, MCP tests, the fixed stdio smoke, and repo-local plugin install acceptance. `plugin-release-check` adds plugin PR scope hygiene, secret scanning, phase2 audit, and whitespace diff validation. To run the same release steps manually:
@@ -138,7 +139,7 @@ If the Codex CLI is installed, you can also run a local marketplace preflight wi
 your real Codex home:
 
 ```powershell
-python plugins/mirror-codex/scripts/cli_marketplace_preflight.py
+./make.ps1 plugin-cli-preflight
 ```
 
 This script creates an isolated temporary `CODEX_HOME`, runs `codex marketplace add` against


### PR DESCRIPTION
## Summary

- add `plugin-cli-preflight` as an explicit Makefile and Windows `make.ps1` target
- update the root README, plugin README, runbook, and UI checklist to prefer the target
- keep the CLI preflight optional and separate from `plugin-release-check`

## Validation

- `./make.ps1 plugin-cli-preflight`
- `./make.ps1 plugin-release-check`
- `python -m pytest backend\tests\test_api.py -q`
- `git diff --check`

## Notes

`make plugin-cli-preflight` was not run on this Windows host because `make` is not installed here. The Makefile target mirrors the already-passing `make.ps1` target and should be exercised by non-Windows tooling where `make` exists.