### PR TITLE
Sync Phase 47 queue state

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,9 +258,9 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 
 - `v0.1.0` is the formal release baseline.
 - The current stop-state / queue state lives in [docs/plans/current-state-baseline.md](docs/plans/current-state-baseline.md).
-- The proposed successor gate lives in [docs/plans/phase-47-successor-gate-2026-05-16.md](docs/plans/phase-47-successor-gate-2026-05-16.md).
+- The approved Phase 47 successor gate lives in [docs/plans/phase-47-successor-gate-2026-05-16.md](docs/plans/phase-47-successor-gate-2026-05-16.md).
+- The active GitHub milestone is `Phase 47 - Boundary Readiness and Successor Hygiene`; `audit-github-queue` reports `ready`.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
-- No Phase 47 is pre-opened or implied by this README.
 - Fog Harbor remains the canonical demo world; `museum-night` is the minimal transfer world used to prove the pipeline is not single-world-only.
 
 ---

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, the first formal release remains published as `v0.1.0`, and the repo has returned to the intentional `paused` stop-state with no approved successor milestone.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, the first formal release remains published as `v0.1.0`, and Phase 47 is now open as the approved boundary readiness and successor hygiene queue.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -153,12 +153,12 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - `#337` `Phase 46: extract review-scorecard into modular feature slices` is merged and closed via PR `#340`.
 - `#338` `Phase 46: define the default operator path around compare-evidence-eval` is merged and closed via PR `#342`.
 - `#339` `Phase 46: move secondary packet surfaces behind advanced navigation` is merged and closed via PR `#344`.
-- `audit-github-queue` now reports `paused` with no active milestone because no approved successor queue is open.
-- No Phase 47 milestone is approved or open in this round.
+- `audit-github-queue` now reports `ready` with active milestone `Phase 47 - Boundary Readiness and Successor Hygiene`.
+- Phase 47 is approved and open through issues `#365-#369`.
 - The first formal repository release is published as `v0.1.0`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
-- The local Codex queue heartbeat should now remain `paused` until an approved successor milestone is defined.
+- The local Codex queue heartbeat should now consume only the active Phase 47 milestone.
 
 ## Day 0 Bootstrap
 
@@ -211,5 +211,5 @@ Before builder automation is allowed to write code or auto-merge:
 - Long-running execution must run from isolated worktrees rather than the current `main` checkout.
 - Queue pickup order, one-writer ownership, and branch hygiene should follow `docs/plans/long-running-loop-runbook.md`.
 - When the active milestone exists and the queue reports `ready`, the builder may resume against that milestone only.
-- No Phase 47 milestone is approved in this round; reopening the queue after Phase 46 requires a fresh approval round.
+- Phase 47 is the currently approved queue; do not open another successor queue while it remains active.
 - When no open milestone exists and `audit-github-queue` reports `paused`, treat that state as an intentional released stop-state rather than a broken queue.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note is the intentional post-Phase-46 stop-state baseline after the formal `v0.1.0` release closeout, the completed Phase 46 workbench-focus queue, and the absence of an approved Phase 47 successor.
+This note records the transition from the intentional post-Phase-46 `v0.1.0` stop-state into the approved Phase 47 successor queue.
 
 ## Snapshot
 
@@ -214,7 +214,7 @@ This note is the intentional post-Phase-46 stop-state baseline after the formal 
   - `gh api repos/YSCJRH/mirror-sim/releases`
     - release `v0.1.0` exists and matches the committed release notes baseline
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - queue now reports `paused` with no active milestone because no approved successor phase is open
+    - queue now reports `ready` with active milestone `Phase 47 - Boundary Readiness and Successor Hygiene`
 
 ## Trusted Source Of Truth
 
@@ -236,15 +236,17 @@ This note is the intentional post-Phase-46 stop-state baseline after the formal 
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
 - The default workbench path now consumes the canonical compare artifact directly and keeps focused divergent trace surfaces ahead of heavier packet-driven review flows.
 - The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, execution recovery release boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, escalation acknowledgment packets, and escalation closure packets without introducing backend API expansion.
-- The current repository state has now completed the Phase 46 workbench-focus queue and returned to the intentional `paused` stop-state while preserving `v0.1.0` as the latest published release baseline.
+- The current repository state has completed the Phase 46 workbench-focus queue, preserved `v0.1.0` as the latest published release baseline, and opened the Phase 47 successor queue.
 
 ## Next Entry Point
 
-- The repo is now in the intentional `paused` stop-state with no open milestone and no approved Phase 47 successor.
+- The repo has left the intentional `paused` stop-state because the Phase 47 successor milestone is now open and `audit-github-queue` reports `ready`.
 - The Phase 46 unlock order is now fully resolved: the queue-sync issue is closed after successor bootstrap, the review-scorecard modularization issue is closed after merging PR `#340`, the default-operator-path issue is closed after merging PR `#342`, the advanced-navigation issue is closed after merging PR `#344`, and the exit gate closes with the milestone.
-- No Phase 47 milestone is approved or open in this round; any successor beyond Phase 46 requires a fresh decision against the blueprint triggers in `mirror.md`.
-- The public successor-gate proposal now lives in `docs/plans/phase-47-successor-gate-2026-05-16.md`. It is a decision and hygiene baseline, not an execution queue by itself.
+- The approved successor milestone is `Phase 47 - Boundary Readiness and Successor Hygiene`.
+- The open Phase 47 exit gate is `#365` `Phase 47 exit gate`, labeled `lane:protected-core` and `status:blocked`.
+- The initial ready work items are `#366` through `#369`.
+- The public successor-gate baseline lives in `docs/plans/phase-47-successor-gate-2026-05-16.md`.
 - Local untracked private-beta, kernel, and design-system planning files under `docs/plans/...` are candidate inputs only until a PR intentionally promotes them.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
-- The local queue heartbeat remains active as `mirror-queue-heartbeat` but should now report the repo as `paused` until an approved successor milestone exists.
+- The local queue heartbeat remains active as `mirror-queue-heartbeat` and should now consume only the active Phase 47 milestone.

--- a/docs/plans/phase-47-successor-gate-2026-05-16.md
+++ b/docs/plans/phase-47-successor-gate-2026-05-16.md
@@ -2,9 +2,9 @@
 
 Date: 2026-05-16
 
-This note defines the public baseline for deciding whether to reopen Mirror after the
-post-Phase-46 `v0.1.0` stop-state. It does not approve Phase 47 by itself and does not
-create a live execution queue.
+This note defines the public baseline for reopening Mirror after the post-Phase-46
+`v0.1.0` stop-state. The original gate proposal did not approve Phase 47 by itself; the
+GitHub queue is now open after review.
 
 ## Current Direct Evidence
 
@@ -12,12 +12,14 @@ create a live execution queue.
   branch was created.
 - The latest published release remains `v0.1.0`.
 - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports
-  `paused` with no active milestone.
+  `ready` with active milestone `Phase 47 - Boundary Readiness and Successor Hygiene`.
 - `docs/plans/current-state-baseline.md` records the intentional post-Phase-46 stop-state.
 - `README.md` defines the Phase 1 public demo as read-only, anonymous, and
   deterministic-only.
 - `plugins/mirror-codex` defines a read-only, local-first Codex plugin for the deterministic
   public demo.
+- GitHub issue `#365` is the open blocked Phase 47 exit gate.
+- GitHub issues `#366` through `#369` are the initial ready Phase 47 work items.
 
 ## Blueprint Boundary
 
@@ -59,7 +61,7 @@ the first successor hygiene PR.
 
 ## Entry Criteria
 
-Do not resume builder automation until all are true:
+Builder automation may resume only for the active Phase 47 milestone while all remain true:
 
 - Exactly one successor milestone is approved and open in GitHub.
 - One blocked exit-gate issue exists in that milestone.
@@ -109,6 +111,14 @@ Initial work items:
    - Lane: `contract-safe` unless it changes durable artifacts, routes, or contracts.
    - Done when packet-heavy compatibility surfaces remain secondary and the main review path
      stays analysis-first.
+
+Current GitHub mapping:
+
+- `#365` `Phase 47 exit gate`
+- `#366` `Phase 47: sync repo truth to successor queue`
+- `#367` `Phase 47: public/private/plugin boundary regression`
+- `#368` `Phase 47: runtime world safety preflight`
+- `#369` `Phase 47: main-path product containment`
 
 ## Deferred Work
 
@@ -169,8 +179,6 @@ Only run frontend and runtime checks when those surfaces are touched.
 
 ## Open Items
 
-- TODO[verify]: Create the GitHub milestone and exit-gate issue only after this successor
-  gate is reviewed and approved.
 - TODO[verify]: Reconcile the untracked private-beta readiness note before citing it as a
   public source of truth.
 - TODO[verify]: Keep the Mirror Codex interactive UI tool-card acceptance item open until a

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 46 closeout, and the return to the intentional stop-state with no approved successor milestone.
+This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 46 closeout, and the approved Phase 47 successor queue.
 
 ## Current Gate State
 
@@ -50,6 +50,7 @@ This note records the current post-Day-0 execution status for Mirror after the f
 - Phase 44 exit gate: closed
 - Phase 45 exit gate: closed
 - Phase 46 exit gate: closed
+- Phase 47 exit gate: open and blocked
 
 Local phase audits currently report:
 
@@ -57,7 +58,7 @@ Local phase audits currently report:
 - `phase2`: pass
 - `phase3`: pass
 
-## Post-Phase 46 Stop-State
+## Phase 47 Successor Queue
 
 - milestone `Phase 46 - Workbench Focus and Modularity`
   - closed
@@ -76,7 +77,24 @@ Local phase audits currently report:
   - closed
   - merged via PR `#344`
 - `audit-github-queue`
-  - reports `paused` with no active milestone because no approved successor phase is open
+  - reports `ready` with active milestone `Phase 47 - Boundary Readiness and Successor Hygiene`
+- milestone `Phase 47 - Boundary Readiness and Successor Hygiene`
+  - open
+- `#365` `Phase 47 exit gate`
+  - open
+  - labeled `lane:protected-core` and `status:blocked`
+- `#366` `Phase 47: sync repo truth to successor queue`
+  - open
+  - labeled `status:ready`
+- `#367` `Phase 47: public/private/plugin boundary regression`
+  - open
+  - labeled `status:ready`
+- `#368` `Phase 47: runtime world safety preflight`
+  - open
+  - labeled `status:ready`
+- `#369` `Phase 47: main-path product containment`
+  - open
+  - labeled `status:ready`
 - recent closeout
   - milestone `Phase 45 - Branch Generalization and Compare Contracts`
     - closed
@@ -109,8 +127,8 @@ Local phase audits currently report:
     - closed
     - merged via PR `#321`
 - successor posture
-  - no Phase 47 milestone is approved or open in this round
-  - any successor beyond Phase 46 must be decided separately against the trigger conditions in `mirror.md`
+  - Phase 47 is approved as a boundary readiness and successor hygiene round
+  - any work beyond the Phase 47 queue still requires a fresh decision against the trigger conditions in `mirror.md`
 
 ## Closeout Snapshot
 
@@ -568,7 +586,7 @@ Local phase audits currently report:
 - Protected-core changes still require explicit review and must not auto-merge.
 - Long-running execution should assign exactly one writer worktree per issue.
 - When `audit-github-queue` reports `ready`, consume only the currently active milestone and do not parallel-open another execution queue.
-- No Phase 47 milestone is approved in this round; reopening the queue after Phase 46 requires a fresh approval round.
+- Phase 47 is the currently approved queue; do not open another successor queue while it remains active.
 
 ## Historical Branch Status
 


### PR DESCRIPTION
## Summary
- Update README, current-state baseline, phase execution queue, automation roadmap, and Phase 47 gate docs to reflect the approved Phase 47 queue.
- Record milestone `Phase 47 - Boundary Readiness and Successor Hygiene`, exit gate #365, and ready work items #366-#369.
- Preserve the boundary that untracked private-beta/kernel/design-system plans remain candidate inputs only.

## Test Plan
- [x] python scripts/check_no_secrets.py
- [x] python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
- [x] python -m backend.app.cli classify-lane --files README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-47-successor-gate-2026-05-16.md docs/plans/phase-execution-queue.md
- [x] git diff --check
- [ ] npm run build --prefix frontend - not run; docs-only change with no frontend code touched

Fixes #366