### PR TITLE
Sync Phase 48 queue truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,8 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - `v0.1.0` is the formal release baseline.
 - The current stop-state / queue state lives in [docs/plans/current-state-baseline.md](docs/plans/current-state-baseline.md).
 - The completed Phase 47 successor gate lives in [docs/plans/phase-47-successor-gate-2026-05-16.md](docs/plans/phase-47-successor-gate-2026-05-16.md).
-- After Phase 47 closeout, no active successor milestone remains; `audit-github-queue` reports `paused`.
+- The active successor gate lives in [docs/plans/phase-48-successor-gate-2026-05-17.md](docs/plans/phase-48-successor-gate-2026-05-17.md).
+- Phase 48 is the active approved successor queue; `audit-github-queue` reports `ready` with `#375` as the blocked exit gate, `#376` as the initial repo-truth sync item, and `#377` through `#379` as ready follow-up work.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
 - Fog Harbor remains the canonical demo world; `museum-night` is the minimal transfer world used to prove the pipeline is not single-world-only.
 

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, Phase 47 closeout is complete, and the first formal release remains published as `v0.1.0`.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, Phase 47 closeout is complete, Phase 48 is the active approved successor queue, and the first formal release remains published as `v0.1.0`.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -153,18 +153,22 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - `#337` `Phase 46: extract review-scorecard into modular feature slices` is merged and closed via PR `#340`.
 - `#338` `Phase 46: define the default operator path around compare-evidence-eval` is merged and closed via PR `#342`.
 - `#339` `Phase 46: move secondary packet surfaces behind advanced navigation` is merged and closed via PR `#344`.
-- Phase 47 implementation work is complete and the GitHub milestone is ready for closeout.
-- milestone `Phase 47 - Boundary Readiness and Successor Hygiene` remains open until the Phase 47 closeout PR merges.
-- `#365` `Phase 47 exit gate` remains open and blocked until this closeout PR merges.
+- Phase 47 closeout is complete.
+- milestone `Phase 47 - Boundary Readiness and Successor Hygiene` is closed after PR `#374`.
+- `#365` `Phase 47 exit gate` is closed after PR `#374`.
 - `#366` `Phase 47: sync repo truth to successor queue` is merged and closed via PR `#370`.
 - `#367` `Phase 47: public/private/plugin boundary regression` is merged and closed via PR `#371`.
 - `#368` `Phase 47: runtime world safety preflight` is merged and closed via PR `#372`.
 - `#369` `Phase 47: main-path product containment` is merged and closed via PR `#373`.
-- `audit-github-queue` reports `paused` after the Phase 47 work items closed and no ready work items remain.
+- Phase 48 is the active approved successor queue.
+- milestone `Phase 48 - Successor Intake and Boundary Contract Triage` is open.
+- `#375` `Phase 48 exit gate` is open, blocked, and protected-core.
+- `#376` is the initial Phase 48 repo-truth sync item; `#377` through `#379` are ready follow-up work items.
+- `audit-github-queue` reports `ready` with Phase 48 as the active milestone.
 - The first formal repository release is published as `v0.1.0`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
-- The local Codex queue heartbeat should wait for the next explicitly approved successor milestone.
+- The local Codex queue heartbeat should consume only the approved Phase 48 milestone while `audit-github-queue` reports `ready`.
 
 ## Day 0 Bootstrap
 
@@ -217,5 +221,5 @@ Before builder automation is allowed to write code or auto-merge:
 - Long-running execution must run from isolated worktrees rather than the current `main` checkout.
 - Queue pickup order, one-writer ownership, and branch hygiene should follow `docs/plans/long-running-loop-runbook.md`.
 - When the active milestone exists and the queue reports `ready`, the builder may resume against that milestone only.
-- Phase 47 is closed; do not resume builder automation until a new successor queue is explicitly approved.
+- Phase 48 is the active approved successor queue; do not open a parallel execution queue.
 - When no open milestone exists and `audit-github-queue` reports `paused`, treat that state as an intentional released stop-state rather than a broken queue.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note records the completed Phase 47 boundary-readiness closeout and the return to a paused successor queue after the formal `v0.1.0` release baseline.
+This note records the completed Phase 47 boundary-readiness closeout and the approved Phase 48 successor queue after the formal `v0.1.0` release baseline.
 
 ## Snapshot
 
@@ -214,13 +214,19 @@ This note records the completed Phase 47 boundary-readiness closeout and the ret
   - `gh api repos/YSCJRH/mirror-sim/releases`
     - release `v0.1.0` exists and matches the committed release notes baseline
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - queue reports `paused` after the Phase 47 work items closed and no ready work items remain
+    - queue reports `ready` with `Phase 48 - Successor Intake and Boundary Contract Triage` as the active milestone
   - `gh issue list --milestone "Phase 47 - Boundary Readiness and Successor Hygiene" --state all`
-    - `#365` `Phase 47 exit gate` remains open and blocked until the Phase 47 closeout PR merges
+    - `#365` `Phase 47 exit gate` is `closed` after merging PR `#374`
     - `#366` `Phase 47: sync repo truth to successor queue` is `closed` after merging PR `#370`
     - `#367` `Phase 47: public/private/plugin boundary regression` is `closed` after merging PR `#371`
     - `#368` `Phase 47: runtime world safety preflight` is `closed` after merging PR `#372`
     - `#369` `Phase 47: main-path product containment` is `closed` after merging PR `#373`
+  - `gh issue list --milestone "Phase 48 - Successor Intake and Boundary Contract Triage" --state all`
+    - `#375` `Phase 48 exit gate` is `open`, `blocked`, and `lane:protected-core`
+    - `#376` `Phase 48: sync repo truth after Phase 47 closeout` is the initial repo-truth sync item for this baseline update
+    - `#377` `Phase 48: public private plugin boundary acceptance` is `open` and `ready`
+    - `#378` `Phase 48: private beta runtime contract audit` is `open` and `ready`
+    - `#379` `Phase 48: kernel perturbation gap brief` is `open` and `ready`
 
 ## Trusted Source Of Truth
 
@@ -242,16 +248,18 @@ This note records the completed Phase 47 boundary-readiness closeout and the ret
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
 - The default workbench path now consumes the canonical compare artifact directly and keeps focused divergent trace surfaces ahead of heavier packet-driven review flows.
 - The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, execution recovery release boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, escalation acknowledgment packets, and escalation closure packets without introducing backend API expansion.
-- The current repository state has completed the Phase 47 boundary-readiness queue, preserved `v0.1.0` as the latest published release baseline, and returned to a paused successor posture.
+- The current repository state has completed the Phase 47 boundary-readiness queue, preserved `v0.1.0` as the latest published release baseline, and opened the approved Phase 48 successor queue.
 
 ## Next Entry Point
 
-- The repo is back in the intentional `paused` successor posture after Phase 47 closeout; the next build round requires a fresh approved milestone, blocked exit gate, and ready work items.
-- The Phase 47 unlock order is now resolved: the queue-sync issue is closed after PR `#370`, the boundary-regression report is closed after PR `#371`, the runtime-world safety preflight is closed after PR `#372`, the main-path containment report is closed after PR `#373`, and the exit gate is ready to close with the Phase 47 milestone after this closeout merges.
-- The completed successor milestone is `Phase 47 - Boundary Readiness and Successor Hygiene`.
-- The Phase 47 exit gate is `#365` `Phase 47 exit gate`, which remains the open blocked closeout gate until this PR merges.
-- The public successor-gate baseline lives in `docs/plans/phase-47-successor-gate-2026-05-16.md`.
+- Phase 48 is the active approved successor queue; `audit-github-queue` reports `ready`.
+- The Phase 47 unlock order is resolved: the queue-sync issue is closed after PR `#370`, the boundary-regression report is closed after PR `#371`, the runtime-world safety preflight is closed after PR `#372`, the main-path containment report is closed after PR `#373`, and the exit gate is closed after PR `#374`.
+- The active successor milestone is `Phase 48 - Successor Intake and Boundary Contract Triage`.
+- The Phase 48 exit gate is `#375` `Phase 48 exit gate`, which remains the open blocked closeout gate for this phase.
+- `#376` is the initial Phase 48 repo-truth sync item; `#377` through `#379` are the remaining ready follow-up work items after this baseline lands.
+- The completed Phase 47 successor-gate baseline lives in `docs/plans/phase-47-successor-gate-2026-05-16.md`.
+- The active Phase 48 successor-gate baseline lives in `docs/plans/phase-48-successor-gate-2026-05-17.md`.
 - Local untracked private-beta, kernel, and design-system planning files under `docs/plans/...` are candidate inputs only until a PR intentionally promotes them.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
-- The local queue heartbeat remains active as `mirror-queue-heartbeat` but should not consume new work until a new successor milestone is approved.
+- The local queue heartbeat remains active as `mirror-queue-heartbeat` and should consume only the approved Phase 48 milestone while `audit-github-queue` reports `ready`.

--- a/docs/plans/phase-47-successor-gate-2026-05-16.md
+++ b/docs/plans/phase-47-successor-gate-2026-05-16.md
@@ -11,16 +11,19 @@ GitHub queue was opened after review and completed through the closeout gate.
 - At authoring time, local `main` was aligned with `origin/main` before this successor-gate
   branch was created.
 - The latest published release remains `v0.1.0`.
-- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports
-  `paused` after the Phase 47 work items closed and no ready work items remain.
-- `docs/plans/current-state-baseline.md` records the intentional post-Phase-46 stop-state.
+- During Phase 47 closeout, `python -m backend.app.cli audit-github-queue --repo
+  YSCJRH/mirror-sim` reported `paused` after the Phase 47 work items closed and before
+  Phase 48 was opened.
+- At Phase 47 authoring time, `docs/plans/current-state-baseline.md` recorded the
+  intentional post-Phase-46 stop-state.
 - `README.md` defines the Phase 1 public demo as read-only, anonymous, and
   deterministic-only.
 - `plugins/mirror-codex` defines a read-only, local-first Codex plugin for the deterministic
   public demo.
-- GitHub issue `#365` is the protected Phase 47 exit gate that remains open until this
-  closeout PR merges.
+- GitHub issue `#365` was the protected Phase 47 exit gate and is closed after PR `#374`.
 - GitHub issues `#366` through `#369` are closed Phase 47 work items.
+- The current successor queue is superseded by the Phase 48 gate note at
+  `docs/plans/phase-48-successor-gate-2026-05-17.md`.
 
 ## Blueprint Boundary
 
@@ -119,7 +122,7 @@ Executed work items:
 
 Current GitHub mapping:
 
-- `#365` `Phase 47 exit gate` remains open until this closeout PR merges.
+- `#365` `Phase 47 exit gate` closed by PR `#374`.
 - `#366` `Phase 47: sync repo truth to successor queue` closed by PR `#370`.
 - `#367` `Phase 47: public/private/plugin boundary regression` closed by PR `#371`.
 - `#368` `Phase 47: runtime world safety preflight` closed by PR `#372`.
@@ -131,8 +134,8 @@ Current GitHub mapping:
 - `./make.ps1 plugin-release-check` passed during the boundary-regression work.
 - `python -m pytest backend/tests -q` passed after the runtime-world safety preflight.
 - `python scripts/check_no_secrets.py` passed during closeout.
-- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `paused`
-  once the Phase 47 implementation work items are closed.
+- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reported
+  `paused` after the Phase 47 implementation work items closed and before Phase 48 opened.
 - `git diff --check` passed during closeout.
 
 ## Deferred Work

--- a/docs/plans/phase-48-successor-gate-2026-05-17.md
+++ b/docs/plans/phase-48-successor-gate-2026-05-17.md
@@ -1,0 +1,141 @@
+# Phase 48 Successor Gate
+
+Date: 2026-05-17
+
+This note defines the public baseline for Phase 48 after the Phase 47 boundary-readiness
+closeout. Phase 48 is an intake and triage phase: it reconciles repo truth, validates the
+public/private/plugin boundary evidence, audits private-beta runtime contract language, and
+turns kernel and perturbation notes into explicit candidate work for a later phase.
+
+## Current Direct Evidence
+
+- The latest published release remains `v0.1.0`.
+- Phase 47 completed through PRs `#370` through `#374`.
+- Milestone `Phase 47 - Boundary Readiness and Successor Hygiene` is closed.
+- Issue `#365` `Phase 47 exit gate` is closed after PR `#374`.
+- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
+  with `Phase 48 - Successor Intake and Boundary Contract Triage` as the active milestone.
+- Milestone `Phase 48 - Successor Intake and Boundary Contract Triage` is open.
+- Issue `#375` `Phase 48 exit gate` is open, blocked, and protected-core.
+- Issue `#376` is the initial repo-truth sync work item for this baseline update.
+- Issues `#377` through `#379` are open ready Phase 48 follow-up work items.
+- Local untracked planning files under `docs/plans/...` remain candidate inputs only until a
+  reviewed PR intentionally promotes selected facts.
+
+## Blueprint Boundary
+
+Phase 48 must stay aligned with `mirror.md`:
+
+- Mirror is a constrained, evidence-backed, replayable what-if sandbox for fictional or
+  explicitly authorized worlds.
+- Mirror is not a real-world prediction machine.
+- Mirror must not build real-person personas, real-person digital twins, political
+  persuasion systems, law-enforcement scoring, hiring, credit, medical, judicial, or other
+  high-risk decision systems.
+- Claims must preserve both `label` and `evidence_ids`.
+- Durable contract changes require updates to `docs/architecture/contracts.md` and an ADR
+  when the contract is long-lived.
+
+## Successor Decision
+
+Phase 48 title:
+
+```text
+Phase 48 - Successor Intake and Boundary Contract Triage
+```
+
+Phase 48 goal:
+
+```text
+Reconcile repository truth after Phase 47, verify public/private/plugin boundary evidence,
+audit private-beta runtime contracts, and convert kernel/perturbation follow-up material
+into explicit candidate work without expanding the public path or plugin contract.
+```
+
+Phase 48 is deliberately not a runtime expansion phase. It should produce evidence,
+classification, and successor recommendations before implementation work changes core
+contracts.
+
+## Work Item Mapping
+
+- `#375` `Phase 48 exit gate`
+  - Lane: `protected-core`.
+  - Role: blocked closeout gate for this phase.
+- `#376` `Phase 48: sync repo truth after Phase 47 closeout`
+  - Lane: `auto-safe`.
+  - Scope: update tracked docs so they agree on Phase 47 closed and Phase 48 active.
+  - Expected disposition: closes with the PR that introduces this Phase 48 baseline.
+- `#377` `Phase 48: public private plugin boundary acceptance`
+  - Lane: `protected-core`.
+  - Scope: verify the public demo, private route boundary, and Mirror Codex plugin evidence
+    without changing the public API or plugin contract.
+- `#378` `Phase 48: private beta runtime contract audit`
+  - Lane: `protected-core`.
+  - Scope: reconcile private-beta runtime docs, route language, provider-secret handling,
+    and acceptance criteria before any new runtime implementation.
+- `#379` `Phase 48: kernel perturbation gap brief`
+  - Lane: `protected-core`.
+  - Scope: convert kernel and perturbation follow-ups into explicit Phase 49 candidate work.
+
+## Non-Goals
+
+- Do not change `compare.json`, claim/evidence shape, scenario DSL, run trace shape, public
+  demo artifact layout, or plugin MCP tool/resource contract during `#376`.
+- Do not add Hosted GPT, BYOK, upload, auth, billing, database, object storage, or quota
+  behavior on the public path or plugin path.
+- Do not add mutating Mirror Codex MCP tools.
+- Do not promote local untracked planning files as durable truth without a reviewed PR.
+- Do not implement full interactive kernel or perturbation runtime expansion in Phase 48
+  unless a separate protected contract review explicitly approves the boundary.
+
+## Local Plan File Hygiene
+
+The current local worktree may contain untracked planning files under `docs/plans/`. Treat
+them as candidate inputs only until a PR intentionally promotes selected facts.
+
+| Local path | Disposition |
+| --- | --- |
+| `docs/plans/branch-analysis-product-reframe-2026-04/` | Candidate successor input. Do not treat as source of truth until promoted. |
+| `docs/plans/hybrid-linear-main-path-design-system.md` | Design reference only. Do not promote without a frontend/design-system PR. |
+| `docs/plans/hybrid-linear-main-path-manual-review.md` | Design reference only. Do not promote without a frontend/design-system PR. |
+| `docs/plans/interactive-kernel-baseline-2026-04-22.md` | Protected-core candidate. Defer until a kernel contract phase is approved. |
+| `docs/plans/interactive-perturbation-simulator-2026-04/` | Protected-core candidate. Defer until a kernel contract phase is approved. |
+| `docs/plans/private-alpha-baseline-2026-04-22.md` | Historical candidate. Do not use as current stage language. |
+| `docs/plans/private-alpha-launch-ready-2026-04-22.md` | Historical candidate. Do not use as current stage language. |
+| `docs/plans/private-alpha-runbook-2026-04-22.md` | Historical candidate. Do not use as current stage language. |
+| `docs/plans/private-alpha-zh-manual-review-2026-04-22.md` | Historical candidate. Do not use as current stage language. |
+| `docs/plans/private-beta-readiness-2026-04-23.md` | Private-beta candidate input. Requires reconciliation before it becomes public source of truth. |
+| `docs/plans/takeover-audit-2026-04/` | Candidate governance input. Promote only selected, reviewed facts. |
+
+## Validation Gate
+
+For the `#376` repo-truth sync PR, run:
+
+```powershell
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+python -m backend.app.cli classify-lane --files README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-47-successor-gate-2026-05-16.md docs/plans/phase-48-successor-gate-2026-05-17.md docs/plans/phase-execution-queue.md
+git diff --check
+```
+
+For later Phase 48 implementation PRs, add the issue-specific checks:
+
+```powershell
+./make.ps1 public-demo-check
+./make.ps1 plugin-release-check
+python -m pytest backend/tests/test_cli.py -k "create_world or safety"
+python -m pytest backend/tests/test_decision_kernel.py backend/tests/test_cli.py -k "start_session or generate_branch or rollback_session"
+./make.ps1 eval-demo
+./make.ps1 eval-transfer
+```
+
+Run `npm run build --prefix frontend` only for Phase 48 work that touches frontend code.
+
+## Open Items
+
+- TODO[verify]: Codex UI tool-card evidence remains open until a clean Codex app session
+  shows observable MCP tool or resource cards/traces for the Mirror Codex plugin.
+- TODO[verify]: Private-beta runtime route and provider-secret claims must be reconciled
+  against tracked code and docs before candidate planning files become durable truth.
+- TODO[verify]: Kernel and perturbation follow-up work should be converted into Phase 49
+  candidate issues before any core runtime contract expansion.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut and the completed Phase 47 boundary-readiness closeout.
+This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 47 boundary-readiness closeout, and the approved Phase 48 successor queue.
 
 ## Current Gate State
 
@@ -50,7 +50,8 @@ This note records the current post-Day-0 execution status for Mirror after the f
 - Phase 44 exit gate: closed
 - Phase 45 exit gate: closed
 - Phase 46 exit gate: closed
-- Phase 47 exit gate: closing with the closeout PR
+- Phase 47 exit gate: closed
+- Phase 48 exit gate: open and blocked
 
 Local phase audits currently report:
 
@@ -58,31 +59,34 @@ Local phase audits currently report:
 - `phase2`: pass
 - `phase3`: pass
 
+## Phase 48 Successor Queue
+
+- `audit-github-queue`
+  - reports `ready` with `Phase 48 - Successor Intake and Boundary Contract Triage` as the active milestone
+- milestone `Phase 48 - Successor Intake and Boundary Contract Triage`
+  - open
+- `#375` `Phase 48 exit gate`
+  - open and blocked
+  - labeled `lane:protected-core` because it is the protected closeout gate
+- `#376` `Phase 48: sync repo truth after Phase 47 closeout`
+  - first docs-only repo-truth sync work item
+  - expected to close with the PR that introduces this Phase 48 baseline
+- `#377` `Phase 48: public private plugin boundary acceptance`
+  - open and ready
+- `#378` `Phase 48: private beta runtime contract audit`
+  - open and ready
+- `#379` `Phase 48: kernel perturbation gap brief`
+  - open and ready
+- phase gate baseline
+  - active Phase 48 gate note: `docs/plans/phase-48-successor-gate-2026-05-17.md`
+
 ## Phase 47 Closeout
 
-- milestone `Phase 46 - Workbench Focus and Modularity`
-  - closed
-- `Phase 46 exit gate`
-  - closed
-- `Phase 46: sync repo truth to Phase 46 queue`
-  - closed
-  - merged via the Phase 46 queue-sync PR
-- `Phase 46: extract review-scorecard into modular feature slices`
-  - closed
-  - merged via PR `#340`
-- `Phase 46: define the default operator path around compare-evidence-eval`
-  - closed
-  - merged via PR `#342`
-- `Phase 46: move secondary packet surfaces behind advanced navigation`
-  - closed
-  - merged via PR `#344`
-- `audit-github-queue`
-  - reports `paused` after the Phase 47 work items closed and no ready work items remain
 - milestone `Phase 47 - Boundary Readiness and Successor Hygiene`
-  - remains open until the Phase 47 closeout PR merges
+  - closed after PR `#374`
 - `#365` `Phase 47 exit gate`
-  - remains open and blocked until this Phase 47 closeout PR merges
-  - labeled `lane:protected-core` because it is the protected closeout gate
+  - closed after PR `#374`
+  - labeled `lane:protected-core` because it was the protected closeout gate
 - `#366` `Phase 47: sync repo truth to successor queue`
   - closed
   - merged via PR `#370`
@@ -128,7 +132,8 @@ Local phase audits currently report:
     - merged via PR `#321`
 - successor posture
   - Phase 47 completed as a boundary readiness and successor hygiene round
-  - any work beyond the Phase 47 queue requires a fresh decision against the trigger conditions in `mirror.md`
+  - Phase 48 is the active approved successor queue
+  - any work beyond the Phase 48 queue requires a fresh decision against the trigger conditions in `mirror.md`
 
 ## Closeout Snapshot
 
@@ -586,7 +591,7 @@ Local phase audits currently report:
 - Protected-core changes still require explicit review and must not auto-merge.
 - Long-running execution should assign exactly one writer worktree per issue.
 - When `audit-github-queue` reports `ready`, consume only the currently active milestone and do not parallel-open another execution queue.
-- Phase 47 is closed; do not resume builder automation until a new successor queue is explicitly approved.
+- Phase 48 is the active approved successor queue; do not open a parallel execution queue.
 
 ## Historical Branch Status
 


### PR DESCRIPTION
## Summary
- sync tracked repo status docs so Phase 47 is closed and Phase 48 is the active approved successor queue
- add the Phase 48 successor-gate baseline and keep untracked planning files classified as candidate inputs only
- preserve public demo, private-beta, and Mirror Codex plugin boundaries without changing code or contracts

## Validation
- python scripts/check_no_secrets.py
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files README.md docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-47-successor-gate-2026-05-16.md docs/plans/phase-48-successor-gate-2026-05-17.md docs/plans/phase-execution-queue.md
- git diff --check
- git diff --cached --check

Fixes #376