### PR TITLE
Phase 48 runtime audit and kernel gap brief

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ This keeps the private-beta runtime replayable while still allowing explicitly c
 
 Current private-beta candidate entrypoints:
 
-- `/` -> launch hub
+- `/` -> current tracked root remains the guided public Fog Harbor demo
 - `/worlds/<world_id>` -> world home
 - `/worlds/new` -> bounded-world creation wizard
 - `/worlds/<world_id>/perturb` -> main operator path
@@ -232,6 +232,10 @@ Current private-beta candidate entrypoints:
 - `/worlds/<world_id>/runtime/<session_id>/explain` -> live explain workspace
 - `/worlds/<world_id>/runtime/<session_id>/report` -> live report workspace
 - `/worlds/<world_id>/review` -> world-scoped review surface
+
+TODO[verify]: Decide whether a future private-beta launch hub should conditionally replace
+`/`, live at a separate route, or remain a planning-only concept. Current tracked code keeps
+`/` as the public demo.
 
 ---
 

--- a/backend/tests/test_frontend_runtime_error_redaction.py
+++ b/backend/tests/test_frontend_runtime_error_redaction.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+MUTATION_ROUTE_FILES = [
+    REPO_ROOT / "frontend/src/app/api/runtime/start-session/route.ts",
+    REPO_ROOT / "frontend/src/app/api/runtime/generate-branch/route.ts",
+    REPO_ROOT / "frontend/src/app/api/runtime/rollback-session/route.ts",
+    REPO_ROOT / "frontend/src/app/api/worlds/create/route.ts",
+]
+
+FORBIDDEN_RAW_ERROR_PATTERNS = [
+    "error.message",
+    "String(error)",
+    "error.cause",
+]
+
+FORBIDDEN_CLIENT_ERROR_PHRASES = [
+    "Hosted model access is disabled.",
+    "Hosted model access is missing a server-side API key.",
+    "Hosted model access is missing a configured model.",
+    "Hosted model access requires a configured beta access code.",
+    "Hosted model access code is invalid.",
+    "decisionApiKey is required for openai_compatible sessions.",
+    "server-side API key",
+    "configured model",
+    "beta access code",
+]
+
+
+def _catch_block(source: str) -> str:
+    marker = "} catch (error) {"
+    assert marker in source
+    return source.split(marker, maxsplit=1)[1]
+
+
+def test_private_beta_mutation_routes_do_not_return_raw_errors() -> None:
+    for route_path in MUTATION_ROUTE_FILES:
+        source = route_path.read_text(encoding="utf-8")
+        catch_block = _catch_block(source)
+
+        for raw_error_pattern in FORBIDDEN_RAW_ERROR_PATTERNS:
+            assert raw_error_pattern not in catch_block, route_path.as_posix()
+
+
+def test_private_beta_routes_do_not_expose_provider_config_in_client_errors() -> None:
+    client_error_route_files = [
+        REPO_ROOT / "frontend/src/app/api/runtime/start-session/route.ts",
+        REPO_ROOT / "frontend/src/app/api/runtime/generate-branch/route.ts",
+    ]
+
+    for route_path in client_error_route_files:
+        source = route_path.read_text(encoding="utf-8")
+        for phrase in FORBIDDEN_CLIENT_ERROR_PHRASES:
+            assert phrase not in source, f"{phrase} leaked in {route_path.as_posix()}"
+
+
+def test_openai_compatible_preflight_does_not_branch_on_server_provider_env() -> None:
+    start_route = (REPO_ROOT / "frontend/src/app/api/runtime/start-session/route.ts").read_text(
+        encoding="utf-8"
+    )
+    generate_route = (REPO_ROOT / "frontend/src/app/api/runtime/generate-branch/route.ts").read_text(
+        encoding="utf-8"
+    )
+
+    assert "!process.env.MIRROR_DECISION_MODEL" not in start_route
+    assert "!process.env.OPENAI_API_KEY" not in generate_route
+
+
+def test_openai_compatible_preflight_rejects_whitespace_only_request_values() -> None:
+    start_route = (REPO_ROOT / "frontend/src/app/api/runtime/start-session/route.ts").read_text(
+        encoding="utf-8"
+    )
+    generate_route = (REPO_ROOT / "frontend/src/app/api/runtime/generate-branch/route.ts").read_text(
+        encoding="utf-8"
+    )
+
+    assert "body.decisionModel?.trim()" in start_route
+    assert "body.decisionApiKey?.trim()" in generate_route
+
+
+def test_runtime_routes_normalize_provider_before_preflight() -> None:
+    start_route = (REPO_ROOT / "frontend/src/app/api/runtime/start-session/route.ts").read_text(
+        encoding="utf-8"
+    )
+    generate_route = (REPO_ROOT / "frontend/src/app/api/runtime/generate-branch/route.ts").read_text(
+        encoding="utf-8"
+    )
+
+    assert "body.decisionProvider?.trim()" in start_route
+    assert "body.decisionProvider?.trim()" in generate_route
+    assert "decisionProvider === \"openai_compatible\"" in start_route
+    assert "decisionProvider === \"openai_compatible\"" in generate_route
+
+
+def test_runtime_cli_clears_request_scoped_provider_env_when_missing() -> None:
+    source = (REPO_ROOT / "frontend/src/app/lib/runtime-cli.ts").read_text(encoding="utf-8")
+
+    assert "OPENAI_API_KEY: credentials?.apiKey ?? \"\"" in source
+    assert "OPENAI_BASE_URL: credentials?.baseUrl ?? \"\"" in source
+    assert ".filter((entry): entry is [string, string] => entry[1] !== undefined)" in source
+
+
+def test_runtime_cli_wrapper_does_not_rethrow_raw_exec_error_message() -> None:
+    source = (REPO_ROOT / "frontend/src/app/lib/runtime-cli.ts").read_text(encoding="utf-8")
+
+    assert "throw new Error(message)" not in source

--- a/backend/tests/test_phase48_kernel_perturbation_gap_brief.py
+++ b/backend/tests/test_phase48_kernel_perturbation_gap_brief.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+BRIEF_PATH = Path("docs/plans/phase-48-kernel-perturbation-gap-brief-2026-05-18.md")
+
+
+def test_phase48_kernel_perturbation_gap_brief_exists_with_required_sections() -> None:
+    assert BRIEF_PATH.exists()
+
+    brief = BRIEF_PATH.read_text(encoding="utf-8")
+    required_sections = [
+        "# Phase 48 Kernel Perturbation Gap Brief",
+        "Issue: `#379`",
+        "## Purpose",
+        "## Direct Evidence",
+        "## Current Contract Boundaries",
+        "## Phase 49 Candidate Work Packages",
+        "## Required Gates Before Implementation",
+        "## Non-Goals",
+        "## Open Questions",
+        "## Validation Commands",
+    ]
+    for section in required_sections:
+        assert section in brief
+
+
+def test_phase48_kernel_perturbation_gap_brief_keeps_boundary_language() -> None:
+    assert BRIEF_PATH.exists()
+
+    brief = BRIEF_PATH.read_text(encoding="utf-8")
+    required_boundaries = [
+        "planning and triage only",
+        "Do not implement kernel expansion",
+        "Do not add free-form natural-language perturbation as an execution contract",
+        "Do not change scenario DSL, run trace, artifact layout, plugin MCP contract, or public API",
+        "Every report claim must keep both `label` and `evidence_ids`",
+        "TODO[verify]:",
+    ]
+    for boundary in required_boundaries:
+        assert boundary in brief
+
+
+def test_phase48_kernel_perturbation_gap_brief_lists_contract_gates() -> None:
+    assert BRIEF_PATH.exists()
+
+    brief = BRIEF_PATH.read_text(encoding="utf-8")
+    required_gates = [
+        "docs/architecture/contracts.md",
+        "ADR",
+        "ADR-0007",
+        "decision_schema.yaml",
+        "decision_trace.jsonl",
+        "task_id",
+        "eval-demo",
+        "eval-transfer",
+    ]
+    for gate in required_gates:
+        assert gate in brief

--- a/docs/architecture/contracts.md
+++ b/docs/architecture/contracts.md
@@ -349,6 +349,9 @@ All IDs must be serializable, stable across files, and traceable in `artifacts/`
 - Public API responses must not expose absolute repository paths, runtime paths, provider secrets, or arbitrary path lookup results.
 - Public API responses must strip artifact-internal path fields before returning content, including `artifact_paths`, `summary_path`, `trace_path`, `snapshot_dir`, and document `source_path`.
 - Public demo mutation routes must be disabled when `MIRROR_PUBLIC_DEMO_MODE=1` and `MIRROR_ALLOW_ANONYMOUS_RUNS` is not `1`.
+- `MIRROR_ALLOW_ANONYMOUS_RUNS=1` is a private-preview/runtime override for local or
+  explicitly authorized deployments. It is not part of the Phase 1 public demo release
+  profile.
 - Phase 1 public demo mode does not start sessions, generate branches, upload corpus data, create worlds, enable Hosted GPT, accept BYOK, or call the OpenAI API.
 
 ## Artifact Contract

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -163,7 +163,7 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 48 is the active approved successor queue.
 - milestone `Phase 48 - Successor Intake and Boundary Contract Triage` is open.
 - `#375` `Phase 48 exit gate` is open, blocked, and protected-core.
-- `#376` is the initial Phase 48 repo-truth sync item, `#377` records public/private/plugin boundary acceptance, and `#378` through `#379` are ready follow-up work items.
+- `#376` is the initial Phase 48 repo-truth sync item, `#377` records public/private/plugin boundary acceptance, `#378` records the private-beta runtime contract audit, and `#379` is the remaining ready follow-up work item.
 - `audit-github-queue` reports `ready` with Phase 48 as the active milestone.
 - The first formal repository release is published as `v0.1.0`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -225,8 +225,8 @@ This note records the completed Phase 47 boundary-readiness closeout and the app
     - `#375` `Phase 48 exit gate` is `open`, `blocked`, and `lane:protected-core`
     - `#376` `Phase 48: sync repo truth after Phase 47 closeout` is the initial repo-truth sync item for this baseline update
     - `#377` `Phase 48: public private plugin boundary acceptance` is recorded in `docs/plans/phase-48-boundary-acceptance-2026-05-17.md`
-    - `#378` `Phase 48: private beta runtime contract audit` is `open` and `ready`
-    - `#379` `Phase 48: kernel perturbation gap brief` is `open` and `ready`
+    - `#378` `Phase 48: private beta runtime contract audit` is recorded in `docs/plans/phase-48-private-beta-runtime-contract-audit-2026-05-18.md`
+    - `#379` `Phase 48: kernel perturbation gap brief` is recorded in `docs/plans/phase-48-kernel-perturbation-gap-brief-2026-05-18.md`
 
 ## Trusted Source Of Truth
 
@@ -256,7 +256,7 @@ This note records the completed Phase 47 boundary-readiness closeout and the app
 - The Phase 47 unlock order is resolved: the queue-sync issue is closed after PR `#370`, the boundary-regression report is closed after PR `#371`, the runtime-world safety preflight is closed after PR `#372`, the main-path containment report is closed after PR `#373`, and the exit gate is closed after PR `#374`.
 - The active successor milestone is `Phase 48 - Successor Intake and Boundary Contract Triage`.
 - The Phase 48 exit gate is `#375` `Phase 48 exit gate`, which remains the open blocked closeout gate for this phase.
-- `#376` is the initial Phase 48 repo-truth sync item, `#377` is recorded by `docs/plans/phase-48-boundary-acceptance-2026-05-17.md`, and `#378` through `#379` are the remaining ready follow-up work items after this acceptance pass lands.
+- `#376` is the initial Phase 48 repo-truth sync item, `#377` is recorded by `docs/plans/phase-48-boundary-acceptance-2026-05-17.md`, `#378` is recorded by `docs/plans/phase-48-private-beta-runtime-contract-audit-2026-05-18.md`, and `#379` is recorded by `docs/plans/phase-48-kernel-perturbation-gap-brief-2026-05-18.md`.
 - The completed Phase 47 successor-gate baseline lives in `docs/plans/phase-47-successor-gate-2026-05-16.md`.
 - The active Phase 48 successor-gate baseline lives in `docs/plans/phase-48-successor-gate-2026-05-17.md`.
 - Local untracked private-beta, kernel, and design-system planning files under `docs/plans/...` are candidate inputs only until a PR intentionally promotes them.

--- a/docs/plans/phase-48-kernel-perturbation-gap-brief-2026-05-18.md
+++ b/docs/plans/phase-48-kernel-perturbation-gap-brief-2026-05-18.md
@@ -1,0 +1,199 @@
+# Phase 48 Kernel Perturbation Gap Brief
+
+Date: 2026-05-18
+
+Issue: `#379` `Phase 48: kernel perturbation gap brief`
+
+## Purpose
+
+Convert interactive kernel and perturbation follow-up gaps into Phase 49 candidate work with
+required contracts, evals, and safety gates. This issue is planning and triage only. It does
+not implement kernel expansion, change the public demo, or widen the plugin MCP contract.
+
+## Direct Evidence
+
+- `gh issue view 379 --repo YSCJRH/mirror-sim` reports issue `#379` open, ready, in
+  milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
+- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
+  with Phase 48 as the active milestone and `#375` as the protected exit gate.
+- `docs/decisions/ADR-0006-interactive-simulator-runtime-v1.md` is accepted and freezes the
+  v1 session runtime shape:
+  - CLI-first entrypoints are `start-session`, `inspect-session`, `generate-branch`, and
+    `rollback-session`.
+  - `session_id` and `node_id` are stable IDs.
+  - rollback changes only `active_node_id`; it does not delete nodes or rewrite artifacts.
+  - task queues, `task_id`, worker semantics, and heartbeats are explicitly deferred.
+- `docs/architecture/contracts.md` defines the current protected runtime boundaries:
+  - `decision_schema.yaml` is the source of truth for perturbation validation.
+  - every perturbation payload must resolve through the world-local decision schema before
+    execution.
+  - the interactive layer must not weaken compare truth, scenario validation, run
+    determinism, claim labels, or `evidence_ids`.
+  - V1 does not introduce a separate `task_id` contract.
+- `docs/decisions/ADR-0007-rule-bounded-llm-kernel.md` is accepted and freezes the rule-
+  bounded model boundary:
+  - the model may choose only among legal actions produced by world rules.
+  - invalid proposals, unavailable models, and exhausted retries must fall back
+    deterministically.
+  - evals need to cover invalid proposal rejection, fallback activation, replay correctness,
+    and multi-world decision-schema compliance.
+- `backend/app/perturbations/service.py` implements a narrow world-aware resolver that
+  validates perturbation kind, target source, actor source, timing, and typed parameters.
+- `backend/app/decision_kernel/service.py` implements a rule-bounded decision kernel that
+  records `decision_trace.jsonl`, replays cached decisions by input hash, optionally asks a
+  configured model to choose among legal actions, and falls back deterministically.
+- `backend/app/sessions/service.py` materializes generated runtime nodes with run, compare,
+  report, claims, resolution, and decision trace references under a session namespace.
+- `backend/tests/test_decision_kernel.py` covers world-local perturbation resolution for Fog
+  Harbor and museum-night plus cached decision replay.
+- `backend/tests/test_cli.py` covers session start, branch generation, rollback, generated
+  node claims, resolution, and decision trace paths.
+- `docs/plans/interactive-kernel-baseline-2026-04-22.md` and
+  `docs/plans/interactive-perturbation-simulator-2026-04/README.md` are candidate inputs.
+  They describe the desired interactive product direction, but they are not durable source of
+  truth until selected facts are promoted through review.
+
+## Current Contract Boundaries
+
+- Phase 48 remains intake and triage. Do not implement kernel expansion in this issue.
+- Do not add free-form natural-language perturbation as an execution contract.
+- Do not change scenario DSL, run trace, artifact layout, plugin MCP contract, or public API
+  in this issue.
+- Do not present Mirror as a real-world prediction machine or expand it into real-person
+  personas, political persuasion, law-enforcement scoring, hiring, credit, medical, judicial,
+  or other high-risk decision workflows.
+- Every report claim must keep both `label` and `evidence_ids`.
+- `compare.json` remains the durable contract for pre-authored scenario comparison sets.
+  Interactive runtime compare artifacts stay session-scoped and must not replace the public
+  demo compare contract without a later contract review.
+- `rollback-session` remains pointer movement through `active_node_id`; destructive rollback
+  or artifact rewriting is out of scope.
+- Any long-lived change to perturbation payload shape, decision trace shape, session/node
+  manifest fields, compare emission rules, or task orchestration requires
+  `docs/architecture/contracts.md` updates and an ADR.
+
+## Gap Summary
+
+- Perturbation resolution is real but narrow. It supports world-local schemas and typed
+  parameter validation, but it has not been promoted into a broader authoring contract for
+  editable templates, admissibility UX, or multi-world parameter catalogs.
+- The decision kernel is implemented for the current runtime, but the trace is still a young
+  contract. Phase 49 should decide which `decision_trace.jsonl` fields are durable and which
+  are implementation detail before adding richer provider behavior, and should add the
+  ADR-0007 fallback/rejection tests that are not yet covered directly.
+- Branch generation emits useful node artifacts, but parent-child compare emission policy is
+  still not a clear product contract for every runtime path.
+- Rollback is correctly narrow as pointer movement. Checkpoint-level rollback and latest
+  activity semantics remain undecided and should not be inferred from current `created_at`
+  sorting.
+- The second world proves transfer viability, but outcomes, report framing, and evals still
+  carry Fog Harbor-shaped assumptions in places.
+- Web-triggered runtime generation is still synchronous. If generation becomes long-running,
+  `task_id` and worker semantics need a dedicated ADR before implementation.
+
+## Phase 49 Candidate Work Packages
+
+1. Kernel trace and replay contract
+   - Freeze durable `decision_trace.jsonl` fields, replay-cache behavior, provider fallback
+     wording, and validation statuses.
+   - Keep model calls inside the legal-action selection boundary.
+   - Add regression coverage for deterministic replay, invalid model output fallback, and
+     trace privacy.
+
+2. Perturbation schema and resolver contract
+   - Promote the world-local `decision_schema.yaml` role into a stable authoring contract.
+   - Define template-plus-parameters as the first editable path before any free-form authoring.
+   - Add schema tests for required parameters, optional parameters, actor/target source
+     mismatches, and transfer-world parity.
+
+3. Branch generation and compare emission policy
+   - Decide whether every generated node must emit parent-vs-child `compare.json` or whether
+     compare emission can remain conditional.
+   - Define which compare fields are required for runtime nodes versus pre-authored scenario
+     matrices.
+   - Preserve the existing public `compare.json` contract while extending session-scoped
+     artifacts.
+
+4. Rollback, checkpoint, and latest-activity semantics
+   - Keep v1 rollback as `active_node_id` pointer movement.
+   - Decide whether checkpoint rollback exists in Phase 49 or remains deferred.
+   - Decide whether world/product surfaces sort by latest session creation or latest runtime
+     activity, and define the field that carries that behavior.
+
+5. Fog Harbor de-specialization and transfer evals
+   - Identify remaining Fog Harbor-shaped outcome, report, and eval assumptions.
+   - Extend transfer checks with museum-night before adding another world.
+   - Keep every new world fictional or explicitly authorized.
+
+6. Runtime orchestration decision
+   - Keep synchronous CLI/API mirroring unless measured generation time requires an async path.
+   - If async generation is needed, ratify `task_id`, status states, worker ownership, retry
+     policy, and cleanup behavior in a dedicated ADR.
+
+## Required Gates Before Implementation
+
+- Contract gate:
+  - update `docs/architecture/contracts.md` for any accepted change to perturbation payloads,
+    `decision_schema.yaml`, session/node manifests, compare emission, `decision_trace.jsonl`,
+    rollback/checkpoint behavior, or `task_id`.
+  - add an ADR for any long-lived kernel, perturbation, or orchestration contract.
+- Test gate:
+  - `python -m pytest backend/tests/test_decision_kernel.py`
+  - `python -m pytest backend/tests/test_cli.py -k "start_session or generate_branch or rollback_session"`
+  - add focused tests before changing resolver, trace, branch, rollback, or compare behavior.
+  - cover ADR-0007 invalid proposal rejection, fallback activation, replay correctness, and
+    multi-world decision-schema compliance before claiming the kernel contract is stronger.
+- Eval gate:
+  - `./make.ps1 eval-demo`
+  - `./make.ps1 eval-transfer`
+  - add transfer assertions before claiming a kernel change generalizes beyond Fog Harbor.
+- Boundary gate:
+  - `./make.ps1 public-demo-check`
+  - `./make.ps1 plugin-release-check`
+  - verify public demo and Mirror Codex plugin behavior remain read-only where required.
+- Secret and hygiene gate:
+  - `python scripts/check_no_secrets.py`
+  - `git diff --check`
+
+## Non-Goals
+
+- Do not implement kernel expansion.
+- Do not add free-form natural-language perturbation as an execution contract.
+- Do not change scenario DSL, run trace, artifact layout, plugin MCP contract, or public API.
+- Do not add Hosted GPT, BYOK, upload, auth, billing, database, object storage, or quota
+  behavior to the public path or plugin path.
+- Do not create real-world prediction, real-person persona, political persuasion,
+  law-enforcement scoring, hiring, credit, medical, judicial, or high-risk decision workflows.
+- Do not promote local April planning notes wholesale; promote only selected, reviewed facts.
+
+## Open Questions
+
+- TODO[verify]: Which `decision_trace.jsonl` fields should be stable contract versus
+  implementation detail before richer provider behavior is added?
+- TODO[verify]: Should Phase 49 require parent-vs-child compare output for every generated
+  runtime node?
+- TODO[verify]: Should checkpoint rollback exist in the next phase, or should runtime remain
+  branch/node-only until another ADR?
+- TODO[verify]: Should latest-session versus latest-activity semantics be resolved in the
+  kernel phase, or split into a narrower product/runtime metadata issue first?
+- TODO[verify]: Which Fog Harbor-shaped report and eval assumptions still block a stronger
+  museum-night transfer proof?
+- TODO[verify]: What measured generation duration would justify introducing `task_id`
+  instead of keeping the CLI-first synchronous contract?
+
+## Recommended Disposition
+
+- Treat `#379` as satisfied when this brief lands through review with the required validation.
+- Open Phase 49 candidate issues from the six work packages above only after the Phase 48 exit
+  gate accepts the intake evidence.
+- Keep Phase 49 protected-core by default unless a specific slice is classified safe after
+  contracts and tests are ratified.
+
+## Validation Commands
+
+```powershell
+python -m pytest backend/tests/test_phase48_kernel_perturbation_gap_brief.py -q
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+git diff --check
+```

--- a/docs/plans/phase-48-private-beta-runtime-contract-audit-2026-05-18.md
+++ b/docs/plans/phase-48-private-beta-runtime-contract-audit-2026-05-18.md
@@ -1,0 +1,137 @@
+# Phase 48 Private-Beta Runtime Contract Audit
+
+Date: 2026-05-18
+
+Issue: `#378` `Phase 48: private beta runtime contract audit`
+
+## Purpose
+
+Audit the private-beta runtime contract surface before any new runtime implementation phase.
+This report reconciles tracked README, contracts, ADRs, backend code, frontend routes, and
+tests. It does not change runtime behavior, public API shape, scenario DSL, claim/evidence
+shape, run trace shape, artifact layout, or provider-secret handling.
+
+## Direct Evidence
+
+- `README.md` keeps Phase 1 public demo separate from the private-beta candidate path:
+  - public demo visitors cannot upload a corpus, create worlds, start runtime sessions,
+    generate branches, enable Hosted GPT or BYOK, or call the OpenAI API.
+  - the private-beta candidate web path is available only when public demo flags are
+    disabled.
+  - hosted private-beta GPT access is server-side only, disabled by default, beta-gated, and
+    quota-limited before a model call.
+- `docs/architecture/contracts.md` defines the runtime as CLI-first in v1:
+  - `start-session`, `inspect-session`, `generate-branch`, and `rollback-session` are the
+    canonical entrypoints.
+  - `start-session` may pin one provider and one model.
+  - `hosted_openai` uses server-side environment secrets and never accepts a browser-submitted
+    OpenAI API key.
+  - `generate-branch` may receive request-scoped BYOK credentials, but raw credentials must
+    not be written into `session.json`, `node.json`, reports, claims, or decision traces.
+  - hosted quota ledgers live under ignored `state/usage/` and must store hashed user
+    identities only.
+  - rollback only changes `active_node_id`; it does not delete nodes or rewrite run artifacts.
+- `docs/decisions/ADR-0006-interactive-simulator-runtime-v1.md` is accepted and freezes the
+  v1 runtime shape:
+  - session/node IDs are durable.
+  - generated nodes live under a session namespace.
+  - rollback is pointer movement.
+  - task queues and `task_id` are explicitly deferred.
+- `docs/decisions/ADR-0008-hosted-model-access-and-key-safety.md` is accepted and freezes the
+  hosted provider safety boundary:
+  - `hosted_openai` reads the OpenAI API key only from `MIRROR_HOSTED_OPENAI_API_KEY`.
+  - the browser never receives the hosted OpenAI API key.
+  - the beta access code is an interim identity gate, not a long-term account system.
+  - quota identities are hashed before storage.
+- `backend/app/sessions/service.py` implements the v1 contract:
+  - `start_session` rejects non-baseline or multi-branch scenarios and persists provider/model
+    metadata in `decision_config`.
+  - `generate_branch` validates hosted access and quota before generation when the session
+    provider is `hosted_openai`.
+  - generated child nodes write run, compare, report, claims, resolution, and decision trace
+    references under the session namespace.
+  - `rollback_session` only changes `active_node_id` after checking the target exists.
+- `backend/app/model_access/service.py` implements hosted provider gating and quota:
+  - hosted access requires `MIRROR_HOSTED_MODEL_ENABLED`, `MIRROR_HOSTED_OPENAI_API_KEY`, and a
+    hosted or default decision model.
+  - usage files are written under `state/usage/hosted-openai-YYYY-MM-DD.json`.
+  - user identity is hashed before storage.
+- `frontend/src/app/api/runtime/start-session/route.ts`,
+  `frontend/src/app/api/runtime/generate-branch/route.ts`, and
+  `frontend/src/app/api/runtime/rollback-session/route.ts` block runtime mutations in public
+  demo mode through `publicDemoMutationsDisabled()`.
+- `frontend/src/app/api/runtime/start-session/route.ts` and
+  `frontend/src/app/api/runtime/generate-branch/route.ts` require hosted beta access code,
+  hosted enablement, server-side hosted key, and configured hosted/default model before
+  hosted runtime calls proceed.
+- `frontend/src/app/lib/runtime-cli.ts` passes BYOK values as request-scoped environment
+  variables to the local Python CLI and does not add them to CLI args.
+- `backend/tests/test_model_access.py` verifies hosted access requires enablement, a server
+  secret, and a model; hosted session manifests do not write the hosted key; quota stores a
+  hash rather than the raw identity.
+- Targeted runtime/provider validation passed:
+
+```powershell
+python -m pytest backend/tests/test_model_access.py backend/tests/test_cli.py -k "start_session or generate_branch or rollback_session or hosted" -q
+```
+
+Result: `11 passed, 18 deselected`.
+
+## Reasonable Inference
+
+- The tracked runtime contract is internally consistent: private-beta runtime work can proceed
+  only as a local/private path and must not widen Phase 1 public demo behavior.
+- Hosted provider secrets are intended to remain server-side or local-only. The browser sends
+  only beta access code for `hosted_openai`, while the hosted OpenAI key is loaded from server
+  environment.
+- BYOK remains request-scoped for web `openai_compatible`. The current browser UI stores BYOK
+  values in `sessionStorage`, sends explicit model/key values to the private runtime API, and
+  does not use server provider env as a client-visible fallback. This is consistent with
+  ADR-0008 as a private-beta path, but it is not appropriate for the public demo path.
+- The current world/product surfaces use "latest session" semantics based on
+  `session.created_at`, not "latest activity" semantics based on node generation or rollback.
+- Route-level runtime error redaction is now covered by
+  `backend/tests/test_frontend_runtime_error_redaction.py`; private-beta mutation routes return
+  generic localized client errors instead of raw provider/runtime exception text, and
+  `openai_compatible` web preflight trims provider/model/key input, no longer branches on server
+  provider env presence, and clears inherited provider env when request-scoped BYOK is absent.
+
+## Open Questions
+
+- TODO[verify]: Decide whether the product should surface the latest created session or the
+  latest active/modified session. Current code sorts session locators by `session.created_at`;
+  rollback and branch generation update `active_node_id` but do not update a `last_activity_at`
+  field.
+- TODO[verify]: If web-triggered generation becomes long-running, ratify a `task_id`/worker
+  contract in a follow-up ADR instead of widening ADR-0006 implicitly.
+- TODO[verify]: Reconcile local untracked private-beta planning files only by promoting
+  selected, reviewed facts through a future PR; they are not source of truth for this audit.
+
+## Follow-Up Recommendations
+
+- Open a protected-core Phase 49 candidate for the latest-session versus latest-activity
+  decision before adding more launch-hub or world-card affordances.
+- Keep the provider-error redaction regression in the runtime route validation set before any
+  broader private-beta Hosted GPT trial.
+- Keep `MIRROR_HOSTED_OPENAI_API_KEY`, real BYOK values, beta access codes, usage ledgers, and
+  local `.env` files out of tracked source, frontend bundles, generated artifacts, build logs,
+  and error pages.
+- Do not change `session.json`, `node.json`, `decision_trace.jsonl`, perturbation payloads,
+  or public API route behavior without updating `docs/architecture/contracts.md` and an ADR
+  when the contract is long-lived.
+
+## Validation Commands
+
+```powershell
+python -m pytest backend/tests/test_frontend_runtime_error_redaction.py -q
+python -m pytest backend/tests/test_model_access.py backend/tests/test_cli.py -k "start_session or generate_branch or rollback_session or hosted" -q
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+git diff --check
+```
+
+## Remaining Phase 48 Work
+
+- `#379` should convert kernel and perturbation follow-up material into explicit Phase 49
+  candidate work.
+- `#375` remains the blocked exit gate until Phase 48 work satisfies its exit criteria.

--- a/docs/plans/phase-48-successor-gate-2026-05-17.md
+++ b/docs/plans/phase-48-successor-gate-2026-05-17.md
@@ -19,7 +19,8 @@ turns kernel and perturbation notes into explicit candidate work for a later pha
 - Issue `#375` `Phase 48 exit gate` is open, blocked, and protected-core.
 - Issue `#376` is the initial repo-truth sync work item for this baseline update.
 - Issue `#377` records the Phase 48 public/private/plugin boundary acceptance pass.
-- Issues `#378` through `#379` are open ready Phase 48 follow-up work items.
+- Issue `#378` records the private-beta runtime contract audit.
+- Issue `#379` records the Phase 48 kernel perturbation gap brief.
 - Local untracked planning files under `docs/plans/...` remain candidate inputs only until a
   reviewed PR intentionally promotes selected facts.
 
@@ -76,9 +77,15 @@ contracts.
   - Lane: `protected-core`.
   - Scope: reconcile private-beta runtime docs, route language, provider-secret handling,
     and acceptance criteria before any new runtime implementation.
+  - Disposition: recorded by
+    `docs/plans/phase-48-private-beta-runtime-contract-audit-2026-05-18.md` and expected to
+    close with the PR that introduces that report.
 - `#379` `Phase 48: kernel perturbation gap brief`
   - Lane: `protected-core`.
   - Scope: convert kernel and perturbation follow-ups into explicit Phase 49 candidate work.
+  - Disposition: recorded by
+    `docs/plans/phase-48-kernel-perturbation-gap-brief-2026-05-18.md` and expected to close
+    with the PR that introduces that brief.
 
 ## Non-Goals
 
@@ -138,7 +145,5 @@ Run `npm run build --prefix frontend` only for Phase 48 work that touches fronte
 
 - TODO[verify]: Codex UI tool-card evidence remains open until a clean Codex app session
   shows observable MCP tool or resource cards/traces for the Mirror Codex plugin.
-- TODO[verify]: Private-beta runtime route and provider-secret claims must be reconciled
-  against tracked code and docs before candidate planning files become durable truth.
-- TODO[verify]: Kernel and perturbation follow-up work should be converted into Phase 49
-  candidate issues before any core runtime contract expansion.
+- TODO[verify]: Latest-session versus latest-activity semantics remain a follow-up candidate
+  after the Phase 48 private-beta runtime audit.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -75,9 +75,11 @@ Local phase audits currently report:
   - boundary acceptance recorded in `docs/plans/phase-48-boundary-acceptance-2026-05-17.md`
   - expected to close with the PR that introduces that report
 - `#378` `Phase 48: private beta runtime contract audit`
-  - open and ready
+  - private-beta runtime contract audit recorded in `docs/plans/phase-48-private-beta-runtime-contract-audit-2026-05-18.md`
+  - expected to close with the PR that introduces that report
 - `#379` `Phase 48: kernel perturbation gap brief`
-  - open and ready
+  - kernel perturbation gap brief recorded in `docs/plans/phase-48-kernel-perturbation-gap-brief-2026-05-18.md`
+  - expected to close with the PR that introduces that brief
 - phase gate baseline
   - active Phase 48 gate note: `docs/plans/phase-48-successor-gate-2026-05-17.md`
 

--- a/frontend/src/app/README.md
+++ b/frontend/src/app/README.md
@@ -20,6 +20,7 @@ Phase 1 public demo routes:
 Phase 1 public demo mutation rules:
 
 - `/api/runtime/start-session`, `/api/runtime/generate-branch`, `/api/runtime/rollback-session`, and `/api/worlds/create` return 403 when `MIRROR_PUBLIC_DEMO_MODE=1` and `MIRROR_ALLOW_ANONYMOUS_RUNS` is not `1`
+- `MIRROR_ALLOW_ANONYMOUS_RUNS=1` is a private-preview/runtime override, not the Phase 1 public demo release profile
 - `/worlds/new` shows a disabled explanation in public mode
 - Hosted GPT, BYOK, corpus upload, auth, billing, object storage, database-backed worlds, and quotas are reserved for later phases
 
@@ -27,7 +28,7 @@ Artifact access uses `ArtifactSource` and logical ids such as `demo.report`, `de
 
 Private-beta candidate product routes:
 
-- `/` is the `Launch Hub`
+- `/` is not currently the private-beta Launch Hub; current tracked code keeps `/` as the guided public Fog Harbor demo
 - `/worlds/new` creates one bounded incident world under the runtime state root
 - `/worlds/new` now includes quick-start presets and a clearer data-authorization note so first-time users do not have to author every field from scratch
 - `/worlds/[worldId]` is the world home
@@ -36,9 +37,8 @@ Private-beta candidate product routes:
 - `/worlds/[worldId]/runtime/[sessionId]/explain` is the world-scoped live explain view
 - `/worlds/[worldId]/runtime/[sessionId]/report` is the world-scoped live report view
 - `/worlds/[worldId]/review` is the world-scoped review surface, with scorecard + inline branch digest + report/claims previews
-- world home, perturb, and review automatically pick up the latest live session for the world when no explicit session query is present
-- Launch Hub now also surfaces the latest live node per world and links directly into the current runtime and review entrypoints
-- Launch Hub now prioritizes fast return paths: continue the latest session when available, otherwise create a world or open perturb
+- world home, perturb, and review automatically pick up the latest session by `session.created_at` for the world when no explicit session query is present, then use that session's `active_node_id`
+- TODO[verify]: Decide whether a future Launch Hub should use latest session creation time, latest activity time, or a separate `last_activity_at` contract
 - canonical product metadata now supports locale-aware world names, summaries, baselines, and perturbation labels; self-serve worlds continue to display the language the user entered
 - main product-shell terms on the private-beta candidate path are being normalized alongside locale-aware world metadata, so Chinese mode no longer mixes core route labels with obvious English operator wording
 - runtime result cards now prefer world-defined outcome labels from product metadata instead of exposing raw outcome field keys directly
@@ -55,7 +55,9 @@ Key runtime behavior:
 - hosted generation passes a hashed beta identity into the backend so quota state can be recorded under ignored runtime `state/usage/*`
 - the perturbation workspace restores the last browser-session provider/model choice to reduce repeat setup for returning users
 - live runtime surfaces expose the active decision-model summary, including provider mode, model id, fallback count, and replay count
-- `openai_compatible` now requires a concrete model id unless `MIRROR_DECISION_MODEL` is already supplied on the server
+- web `openai_compatible` now requires request-scoped model/API-key input instead of using
+  server provider env as a client-visible fallback; use `hosted_openai` for the server-held
+  key path
 
 Legacy/demo routes kept for reference:
 

--- a/frontend/src/app/api/runtime/generate-branch/route.ts
+++ b/frontend/src/app/api/runtime/generate-branch/route.ts
@@ -21,23 +21,18 @@ function hostedUserHash(body: { betaAccessCode?: string }, request: Request) {
     .slice(0, 24);
 }
 
-function validateHostedAccess(body: { betaAccessCode?: string }) {
-  if (process.env.MIRROR_HOSTED_MODEL_ENABLED !== "1") {
-    return "Hosted model access is disabled.";
-  }
-  if (!process.env.MIRROR_HOSTED_OPENAI_API_KEY) {
-    return "Hosted model access is missing a server-side API key.";
-  }
-  if (!process.env.MIRROR_HOSTED_DECISION_MODEL && !process.env.MIRROR_DECISION_MODEL) {
-    return "Hosted model access is missing a configured model.";
-  }
-  if (!process.env.MIRROR_BETA_ACCESS_CODE) {
-    return "Hosted model access requires a configured beta access code.";
-  }
-  if (body.betaAccessCode !== process.env.MIRROR_BETA_ACCESS_CODE) {
-    return "Hosted model access code is invalid.";
-  }
-  return null;
+function hostedAccessAllowed(body: { betaAccessCode?: string }) {
+  return (
+    process.env.MIRROR_HOSTED_MODEL_ENABLED === "1" &&
+    Boolean(process.env.MIRROR_HOSTED_OPENAI_API_KEY) &&
+    Boolean(process.env.MIRROR_HOSTED_DECISION_MODEL || process.env.MIRROR_DECISION_MODEL) &&
+    Boolean(process.env.MIRROR_BETA_ACCESS_CODE) &&
+    body.betaAccessCode === process.env.MIRROR_BETA_ACCESS_CODE
+  );
+}
+
+function hostedAccessError(locale: "en" | "zh-CN") {
+  return locale === "zh-CN" ? "托管模型访问当前不可用。" : "Hosted model access is unavailable.";
 }
 
 export async function POST(request: Request) {
@@ -72,45 +67,51 @@ export async function POST(request: Request) {
       );
     }
 
-    if (body.decisionProvider === "hosted_openai") {
-      const hostedError = validateHostedAccess(body);
-      if (hostedError) {
-        return NextResponse.json({ error: hostedError }, { status: 403 });
-      }
-    }
+    const decisionApiKey = body.decisionApiKey?.trim();
+    const decisionBaseUrl = body.decisionBaseUrl?.trim();
+    const decisionProvider = body.decisionProvider?.trim();
 
-    if (
-      body.decisionProvider === "openai_compatible" &&
-      !body.decisionApiKey &&
-      !process.env.OPENAI_API_KEY
-    ) {
+    if (!decisionProvider) {
       return NextResponse.json(
         {
           error:
             locale === "zh-CN"
-              ? "使用 OpenAI 兼容接口时，必须提供模型接口密钥。"
-              : "decisionApiKey is required for openai_compatible sessions.",
+              ? "必须提供运行时决策模式。"
+              : "Runtime decision provider is required.",
+        },
+        { status: 400 }
+      );
+    }
+
+    if (decisionProvider === "hosted_openai") {
+      if (!hostedAccessAllowed(body)) {
+        return NextResponse.json({ error: hostedAccessError(locale) }, { status: 403 });
+      }
+    }
+
+    if (decisionProvider === "openai_compatible" && !decisionApiKey) {
+      return NextResponse.json(
+        {
+          error:
+            locale === "zh-CN"
+              ? "模型驱动分支生成当前不可用。"
+              : "Model-driven branch generation is unavailable.",
         },
         { status: 400 }
       );
     }
 
     const payload = await generateRuntimeBranch(body.worldId, body.sessionId, body.fromNode, body.perturbation, {
-      apiKey: body.decisionApiKey,
-      baseUrl: body.decisionBaseUrl,
-      betaUserId: body.decisionProvider === "hosted_openai" ? hostedUserHash(body, request) : undefined,
+      apiKey: decisionApiKey,
+      baseUrl: decisionBaseUrl,
+      betaUserId: decisionProvider === "hosted_openai" ? hostedUserHash(body, request) : undefined,
     });
     return NextResponse.json(payload);
   } catch (error) {
     const locale = resolveLocale(body, request);
     return NextResponse.json(
       {
-        error:
-          error instanceof Error
-            ? error.message
-            : locale === "zh-CN"
-              ? "生成分支失败。"
-              : "Failed to generate runtime branch.",
+        error: locale === "zh-CN" ? "生成分支失败。" : "Failed to generate runtime branch.",
       },
       { status: 500 }
     );

--- a/frontend/src/app/api/runtime/rollback-session/route.ts
+++ b/frontend/src/app/api/runtime/rollback-session/route.ts
@@ -44,12 +44,7 @@ export async function POST(request: Request) {
     const locale = resolveLocale(body, request);
     return NextResponse.json(
       {
-        error:
-          error instanceof Error
-            ? error.message
-            : locale === "zh-CN"
-              ? "回退当前实验失败。"
-              : "Failed to rollback runtime session.",
+        error: locale === "zh-CN" ? "回退当前实验失败。" : "Failed to rollback runtime session.",
       },
       { status: 500 }
     );

--- a/frontend/src/app/api/runtime/start-session/route.ts
+++ b/frontend/src/app/api/runtime/start-session/route.ts
@@ -11,23 +11,18 @@ function resolveLocale(body: { locale?: string }, request: Request) {
   return normalizeLocale(body.locale) ?? normalizeLocale(request.headers.get("accept-language")) ?? "zh-CN";
 }
 
-function validateHostedAccess(body: { betaAccessCode?: string }) {
-  if (process.env.MIRROR_HOSTED_MODEL_ENABLED !== "1") {
-    return "Hosted model access is disabled.";
-  }
-  if (!process.env.MIRROR_HOSTED_OPENAI_API_KEY) {
-    return "Hosted model access is missing a server-side API key.";
-  }
-  if (!process.env.MIRROR_HOSTED_DECISION_MODEL && !process.env.MIRROR_DECISION_MODEL) {
-    return "Hosted model access is missing a configured model.";
-  }
-  if (!process.env.MIRROR_BETA_ACCESS_CODE) {
-    return "Hosted model access requires a configured beta access code.";
-  }
-  if (body.betaAccessCode !== process.env.MIRROR_BETA_ACCESS_CODE) {
-    return "Hosted model access code is invalid.";
-  }
-  return null;
+function hostedAccessAllowed(body: { betaAccessCode?: string }) {
+  return (
+    process.env.MIRROR_HOSTED_MODEL_ENABLED === "1" &&
+    Boolean(process.env.MIRROR_HOSTED_OPENAI_API_KEY) &&
+    Boolean(process.env.MIRROR_HOSTED_DECISION_MODEL || process.env.MIRROR_DECISION_MODEL) &&
+    Boolean(process.env.MIRROR_BETA_ACCESS_CODE) &&
+    body.betaAccessCode === process.env.MIRROR_BETA_ACCESS_CODE
+  );
+}
+
+function hostedAccessError(locale: "en" | "zh-CN") {
+  return locale === "zh-CN" ? "托管模型访问当前不可用。" : "Hosted model access is unavailable.";
 }
 
 export async function POST(request: Request) {
@@ -59,24 +54,22 @@ export async function POST(request: Request) {
       );
     }
 
-    if (body.decisionProvider === "hosted_openai") {
-      const hostedError = validateHostedAccess(body);
-      if (hostedError) {
-        return NextResponse.json({ error: hostedError }, { status: 403 });
+    const decisionProvider = body.decisionProvider?.trim() || "openai_compatible";
+    const decisionModel = body.decisionModel?.trim();
+
+    if (decisionProvider === "hosted_openai") {
+      if (!hostedAccessAllowed(body)) {
+        return NextResponse.json({ error: hostedAccessError(locale) }, { status: 403 });
       }
     }
 
-    if (
-      body.decisionProvider === "openai_compatible" &&
-      !body.decisionModel &&
-      !process.env.MIRROR_DECISION_MODEL
-    ) {
+    if (decisionProvider === "openai_compatible" && !decisionModel) {
       return NextResponse.json(
         {
           error:
             locale === "zh-CN"
-              ? "使用模型驱动模式时，必须提供模型名称。"
-              : "A decision model is required for openai_compatible sessions.",
+              ? "模型驱动模式当前不可用。"
+              : "Model-driven sessions are unavailable.",
         },
         { status: 400 }
       );
@@ -85,20 +78,15 @@ export async function POST(request: Request) {
     const payload = await startRuntimeSession(
       body.worldId,
       body.scenarioId,
-      body.decisionProvider,
-      body.decisionModel
+      decisionProvider,
+      decisionModel
     );
     return NextResponse.json(payload);
   } catch (error) {
     const locale = resolveLocale(body, request);
     return NextResponse.json(
       {
-        error:
-          error instanceof Error
-            ? error.message
-            : locale === "zh-CN"
-              ? "启动实验失败。"
-              : "Failed to start runtime session.",
+        error: locale === "zh-CN" ? "启动实验失败。" : "Failed to start runtime session.",
       },
       { status: 500 }
     );

--- a/frontend/src/app/api/worlds/create/route.ts
+++ b/frontend/src/app/api/worlds/create/route.ts
@@ -30,12 +30,7 @@ export async function POST(request: Request) {
     const locale = resolveLocale(body, request);
     return NextResponse.json(
       {
-        error:
-          error instanceof Error
-            ? error.message
-            : locale === "zh-CN"
-              ? "创建受约束世界失败。"
-              : "Failed to create bounded incident world.",
+        error: locale === "zh-CN" ? "创建受约束世界失败。" : "Failed to create bounded incident world.",
       },
       { status: 500 }
     );

--- a/frontend/src/app/lib/runtime-cli.ts
+++ b/frontend/src/app/lib/runtime-cli.ts
@@ -22,18 +22,14 @@ async function runMirrorCli(
         env: {
           ...process.env,
           ...Object.fromEntries(
-            Object.entries(runtimeEnv).filter((entry): entry is [string, string] => Boolean(entry[1]))
+            Object.entries(runtimeEnv).filter((entry): entry is [string, string] => entry[1] !== undefined)
           ),
         },
       }
     );
     return JSON.parse(stdout);
-  } catch (error) {
-    const message =
-      error instanceof Error
-        ? error.message
-        : "Failed to execute Mirror runtime command.";
-    throw new Error(message);
+  } catch {
+    throw new Error("Mirror runtime command failed.");
   }
 }
 
@@ -93,8 +89,8 @@ export async function generateRuntimeBranch(
     args.push("--beta-user-id", credentials.betaUserId);
   }
   return runMirrorCli(args, {
-    OPENAI_API_KEY: credentials?.apiKey,
-    OPENAI_BASE_URL: credentials?.baseUrl,
+    OPENAI_API_KEY: credentials?.apiKey ?? "",
+    OPENAI_BASE_URL: credentials?.baseUrl ?? "",
     MIRROR_BETA_USER_ID: credentials?.betaUserId,
   });
 }


### PR DESCRIPTION
## Summary
- Add Phase 48 private-beta runtime contract audit and route/provider redaction regression coverage.
- Redact runtime/world mutation route errors and prevent web openai_compatible from falling back to server provider env.
- Add Phase 48 kernel/perturbation gap brief that converts follow-ups into Phase 49 candidate work packages and gates.

Closes #378.
Closes #379.

## Validation
- python -m pytest backend/tests/test_frontend_runtime_error_redaction.py backend/tests/test_phase48_kernel_perturbation_gap_brief.py -q
- ./make.ps1 test
- npm run build --prefix frontend
- python scripts/check_no_secrets.py
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
- git diff --cached --check
- gh pr checks 382 --repo YSCJRH/mirror-sim --watch

## Notes
- Protected-core review required.
- Local untracked April/private-alpha/takeover planning inputs remain unstaged candidate material.