### PR TITLE
[codex] Phase 49 queue sync and lane protection

### DIFF
--- a/.github/automation/lane-policy.json
+++ b/.github/automation/lane-policy.json
@@ -17,9 +17,17 @@
     "docs/decisions/",
     "scripts/bootstrap_github.py",
     "backend/app/automation/",
+    "backend/app/decision_kernel/",
     "backend/app/domain/",
+    "backend/app/model_access/",
+    "backend/app/perturbations/",
     "backend/app/scenarios/",
+    "backend/app/safety/",
+    "backend/app/sessions/",
     "backend/app/simulation/",
-    "backend/app/reports/"
+    "backend/app/reports/",
+    "frontend/src/app/api/runtime/",
+    "frontend/src/app/api/worlds/create/",
+    "frontend/src/app/lib/runtime-cli.ts"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -263,8 +263,10 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - `v0.1.0` is the formal release baseline.
 - The current stop-state / queue state lives in [docs/plans/current-state-baseline.md](docs/plans/current-state-baseline.md).
 - The completed Phase 47 successor gate lives in [docs/plans/phase-47-successor-gate-2026-05-16.md](docs/plans/phase-47-successor-gate-2026-05-16.md).
-- The active successor gate lives in [docs/plans/phase-48-successor-gate-2026-05-17.md](docs/plans/phase-48-successor-gate-2026-05-17.md).
-- Phase 48 is the active approved successor queue; `audit-github-queue` reports `ready` with `#375` as the blocked exit gate and the current ready follow-up work tracked in GitHub.
+- The completed Phase 48 successor gate lives in [docs/plans/phase-48-successor-gate-2026-05-17.md](docs/plans/phase-48-successor-gate-2026-05-17.md).
+- The active successor gate lives in [docs/plans/phase-49-successor-gate-2026-05-18.md](docs/plans/phase-49-successor-gate-2026-05-18.md).
+- Phase 48 is closed after PR `#382`, issue `#375`, and milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
+- Phase 49 is the active approved successor queue: `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; `audit-github-queue` reports `ready` with `#383` as the blocked exit gate and `#384` as the current ready work item.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
 - Fog Harbor remains the canonical demo world; `museum-night` is the minimal transfer world used to prove the pipeline is not single-world-only.
 

--- a/backend/tests/test_automation.py
+++ b/backend/tests/test_automation.py
@@ -38,6 +38,27 @@ def test_classify_paths_marks_bootstrap_and_automation_changes_protected() -> No
     ]
 
 
+def test_classify_paths_marks_phase49_runtime_core_paths_protected() -> None:
+    phase49_core_paths = [
+        "backend/app/decision_kernel/service.py",
+        "backend/app/perturbations/service.py",
+        "backend/app/sessions/service.py",
+        "backend/app/model_access/service.py",
+        "backend/app/safety/service.py",
+        "frontend/src/app/api/runtime/start-session/route.ts",
+        "frontend/src/app/api/runtime/generate-branch/route.ts",
+        "frontend/src/app/api/runtime/rollback-session/route.ts",
+        "frontend/src/app/api/worlds/create/route.ts",
+        "frontend/src/app/lib/runtime-cli.ts",
+    ]
+
+    decision = classify_paths(phase49_core_paths)
+
+    assert decision.lane == "lane:protected-core"
+    assert "risk:core-contract" in decision.labels
+    assert decision.protected_hits == sorted(phase49_core_paths)
+
+
 def test_phase1_and_phase2_audit_pass_with_demo_artifacts(tmp_path: Path) -> None:
     settings = get_settings()
     run_phase0_demo(settings=settings, artifacts_root=tmp_path / "demo")

--- a/backend/tests/test_phase49_successor_gate.py
+++ b/backend/tests/test_phase49_successor_gate.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+PHASE49_GATE_PATH = Path("docs/plans/phase-49-successor-gate-2026-05-18.md")
+
+
+def test_phase49_successor_gate_exists_with_required_sections() -> None:
+    assert PHASE49_GATE_PATH.exists()
+
+    gate = PHASE49_GATE_PATH.read_text(encoding="utf-8")
+    required_sections = [
+        "# Phase 49 Successor Gate",
+        "Issue: `#384` `Phase 49: sync repo truth and protect runtime core lanes`",
+        "## Phase 48 Closeout Evidence",
+        "## Phase 49 Operational Queue",
+        "## Protected-Core Lane Coverage",
+        "## Carried Forward TODO[verify] Items",
+        "## Phase 49 Work Package Map",
+        "## Non-Goals",
+        "## Validation Commands",
+    ]
+    for section in required_sections:
+        assert section in gate
+
+
+def test_phase49_successor_gate_records_work_packages_and_boundaries() -> None:
+    assert PHASE49_GATE_PATH.exists()
+
+    gate = PHASE49_GATE_PATH.read_text(encoding="utf-8")
+    required_phrases = [
+        "Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening",
+        "`#383` `Phase 49 exit gate`",
+        "`#384` `Phase 49: sync repo truth and protect runtime core lanes`",
+        "Kernel trace and replay contract",
+        "Perturbation schema and resolver contract",
+        "Branch generation and compare emission policy",
+        "Rollback, checkpoint, and latest-activity semantics",
+        "Fog Harbor de-specialization and transfer evals",
+        "Runtime orchestration decision",
+        "Every report claim must keep both `label` and `evidence_ids`",
+        "Do not present Mirror as a real-world prediction machine",
+        "Do not build real-person personas or digital doubles",
+        "TODO[verify]: Codex UI tool-card",
+        "TODO[verify]: Latest-session versus latest-activity",
+    ]
+    for phrase in required_phrases:
+        assert phrase in gate
+
+
+def test_active_state_docs_point_to_phase49_queue() -> None:
+    required_docs = [
+        Path("README.md"),
+        Path("docs/plans/current-state-baseline.md"),
+        Path("docs/plans/phase-execution-queue.md"),
+        Path("docs/plans/automation-roadmap.md"),
+        Path("docs/plans/phase-48-successor-gate-2026-05-17.md"),
+    ]
+
+    for path in required_docs:
+        text = path.read_text(encoding="utf-8")
+        assert "Phase 48" in text
+        assert "Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening" in text
+        assert "`#383`" in text
+        assert "`#384`" in text

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, Phase 47 closeout is complete, Phase 48 is the active approved successor queue, and the first formal release remains published as `v0.1.0`.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, Phase 47 closeout is complete, Phase 48 closeout is complete, Phase 49 is the active approved successor queue, and the first formal release remains published as `v0.1.0`.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -160,15 +160,16 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - `#367` `Phase 47: public/private/plugin boundary regression` is merged and closed via PR `#371`.
 - `#368` `Phase 47: runtime world safety preflight` is merged and closed via PR `#372`.
 - `#369` `Phase 47: main-path product containment` is merged and closed via PR `#373`.
-- Phase 48 is the active approved successor queue.
-- milestone `Phase 48 - Successor Intake and Boundary Contract Triage` is open.
-- `#375` `Phase 48 exit gate` is open, blocked, and protected-core.
-- `#376` is the initial Phase 48 repo-truth sync item, `#377` records public/private/plugin boundary acceptance, `#378` records the private-beta runtime contract audit, and `#379` is the remaining ready follow-up work item.
-- `audit-github-queue` reports `ready` with Phase 48 as the active milestone.
+- Phase 48 is closed after PR `#382`, exit gate `#375`, and milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
+- Phase 49 is the active approved successor queue.
+- milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening` is open.
+- `#383` `Phase 49 exit gate` is open, blocked, and protected-core.
+- `#384` `Phase 49: sync repo truth and protect runtime core lanes` is the current ready work item.
+- `audit-github-queue` reports `ready` with Phase 49 as the active milestone.
 - The first formal repository release is published as `v0.1.0`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
-- The local Codex queue heartbeat should consume only the approved Phase 48 milestone while `audit-github-queue` reports `ready`.
+- The previous local queue follow-up automation has been revoked or left paused per operator request; do not recreate an automation without a new explicit request.
 
 ## Day 0 Bootstrap
 
@@ -221,5 +222,5 @@ Before builder automation is allowed to write code or auto-merge:
 - Long-running execution must run from isolated worktrees rather than the current `main` checkout.
 - Queue pickup order, one-writer ownership, and branch hygiene should follow `docs/plans/long-running-loop-runbook.md`.
 - When the active milestone exists and the queue reports `ready`, the builder may resume against that milestone only.
-- Phase 48 is the active approved successor queue; do not open a parallel execution queue.
+- Phase 49 is the active approved successor queue; do not open a parallel execution queue.
 - When no open milestone exists and `audit-github-queue` reports `paused`, treat that state as an intentional released stop-state rather than a broken queue.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note records the completed Phase 47 boundary-readiness closeout and the approved Phase 48 successor queue after the formal `v0.1.0` release baseline.
+This note records the completed Phase 48 successor-intake closeout and the approved Phase 49 successor queue after the formal `v0.1.0` release baseline.
 
 ## Snapshot
 
@@ -214,7 +214,7 @@ This note records the completed Phase 47 boundary-readiness closeout and the app
   - `gh api repos/YSCJRH/mirror-sim/releases`
     - release `v0.1.0` exists and matches the committed release notes baseline
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - queue reports `ready` with `Phase 48 - Successor Intake and Boundary Contract Triage` as the active milestone
+    - queue reports `ready` with `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening` as the active milestone
   - `gh issue list --milestone "Phase 47 - Boundary Readiness and Successor Hygiene" --state all`
     - `#365` `Phase 47 exit gate` is `closed` after merging PR `#374`
     - `#366` `Phase 47: sync repo truth to successor queue` is `closed` after merging PR `#370`
@@ -222,11 +222,16 @@ This note records the completed Phase 47 boundary-readiness closeout and the app
     - `#368` `Phase 47: runtime world safety preflight` is `closed` after merging PR `#372`
     - `#369` `Phase 47: main-path product containment` is `closed` after merging PR `#373`
   - `gh issue list --milestone "Phase 48 - Successor Intake and Boundary Contract Triage" --state all`
-    - `#375` `Phase 48 exit gate` is `open`, `blocked`, and `lane:protected-core`
-    - `#376` `Phase 48: sync repo truth after Phase 47 closeout` is the initial repo-truth sync item for this baseline update
-    - `#377` `Phase 48: public private plugin boundary acceptance` is recorded in `docs/plans/phase-48-boundary-acceptance-2026-05-17.md`
-    - `#378` `Phase 48: private beta runtime contract audit` is recorded in `docs/plans/phase-48-private-beta-runtime-contract-audit-2026-05-18.md`
-    - `#379` `Phase 48: kernel perturbation gap brief` is recorded in `docs/plans/phase-48-kernel-perturbation-gap-brief-2026-05-18.md`
+    - `#375` `Phase 48 exit gate` is `closed` after PR `#382` merged and the post-merge reassessment passed
+    - `#376` `Phase 48: sync repo truth after Phase 47 closeout` is `closed`
+    - `#377` `Phase 48: public private plugin boundary acceptance` is `closed` and recorded in `docs/plans/phase-48-boundary-acceptance-2026-05-17.md`
+    - `#378` `Phase 48: private beta runtime contract audit` is `closed` by PR `#382` and recorded in `docs/plans/phase-48-private-beta-runtime-contract-audit-2026-05-18.md`
+    - `#379` `Phase 48: kernel perturbation gap brief` is `closed` by PR `#382` and recorded in `docs/plans/phase-48-kernel-perturbation-gap-brief-2026-05-18.md`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/48`
+    - milestone `Phase 48 - Successor Intake and Boundary Contract Triage` is `closed`
+  - `gh issue list --milestone "Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening" --state all`
+    - `#383` `Phase 49 exit gate` is `open`, `blocked`, and `lane:protected-core`
+    - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is the first `status:ready` protected-core work item for the new baseline
 
 ## Trusted Source Of Truth
 
@@ -248,18 +253,20 @@ This note records the completed Phase 47 boundary-readiness closeout and the app
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
 - The default workbench path now consumes the canonical compare artifact directly and keeps focused divergent trace surfaces ahead of heavier packet-driven review flows.
 - The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, execution recovery release boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, escalation acknowledgment packets, and escalation closure packets without introducing backend API expansion.
-- The current repository state has completed the Phase 47 boundary-readiness queue, preserved `v0.1.0` as the latest published release baseline, and opened the approved Phase 48 successor queue.
+- The current repository state has completed the Phase 48 successor-intake queue, preserved `v0.1.0` as the latest published release baseline, and opened the approved Phase 49 successor queue.
 
 ## Next Entry Point
 
-- Phase 48 is the active approved successor queue; `audit-github-queue` reports `ready`.
+- Phase 49 is the active approved successor queue; `audit-github-queue` reports `ready`.
 - The Phase 47 unlock order is resolved: the queue-sync issue is closed after PR `#370`, the boundary-regression report is closed after PR `#371`, the runtime-world safety preflight is closed after PR `#372`, the main-path containment report is closed after PR `#373`, and the exit gate is closed after PR `#374`.
-- The active successor milestone is `Phase 48 - Successor Intake and Boundary Contract Triage`.
-- The Phase 48 exit gate is `#375` `Phase 48 exit gate`, which remains the open blocked closeout gate for this phase.
-- `#376` is the initial Phase 48 repo-truth sync item, `#377` is recorded by `docs/plans/phase-48-boundary-acceptance-2026-05-17.md`, `#378` is recorded by `docs/plans/phase-48-private-beta-runtime-contract-audit-2026-05-18.md`, and `#379` is recorded by `docs/plans/phase-48-kernel-perturbation-gap-brief-2026-05-18.md`.
+- The Phase 48 unlock order is resolved: `#376` and `#377` closed through earlier Phase 48 PRs, `#378` and `#379` closed through PR `#382`, and `#375` closed after the post-merge exit-gate reassessment.
+- The active successor milestone is `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`.
+- The Phase 49 exit gate is `#383` `Phase 49 exit gate`, which remains the open blocked closeout gate for this phase.
+- `#384` `Phase 49: sync repo truth and protect runtime core lanes` is the current ready work item.
 - The completed Phase 47 successor-gate baseline lives in `docs/plans/phase-47-successor-gate-2026-05-16.md`.
-- The active Phase 48 successor-gate baseline lives in `docs/plans/phase-48-successor-gate-2026-05-17.md`.
+- The completed Phase 48 successor-gate baseline lives in `docs/plans/phase-48-successor-gate-2026-05-17.md`.
+- The active Phase 49 successor-gate baseline lives in `docs/plans/phase-49-successor-gate-2026-05-18.md`.
 - Local untracked private-beta, kernel, and design-system planning files under `docs/plans/...` are candidate inputs only until a PR intentionally promotes them.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
-- The local queue heartbeat remains active as `mirror-queue-heartbeat` and should consume only the approved Phase 48 milestone while `audit-github-queue` reports `ready`.
+- The previous local queue follow-up automation has been revoked or left paused per operator request; do not recreate an automation without a new explicit request.

--- a/docs/plans/phase-48-successor-gate-2026-05-17.md
+++ b/docs/plans/phase-48-successor-gate-2026-05-17.md
@@ -3,9 +3,9 @@
 Date: 2026-05-17
 
 This note defines the public baseline for Phase 48 after the Phase 47 boundary-readiness
-closeout. Phase 48 is an intake and triage phase: it reconciles repo truth, validates the
-public/private/plugin boundary evidence, audits private-beta runtime contract language, and
-turns kernel and perturbation notes into explicit candidate work for a later phase.
+closeout. Phase 48 was an intake and triage phase: it reconciled repo truth, validated the
+public/private/plugin boundary evidence, audited private-beta runtime contract language, and
+turned kernel and perturbation notes into explicit candidate work for a later phase.
 
 ## Current Direct Evidence
 
@@ -13,14 +13,22 @@ turns kernel and perturbation notes into explicit candidate work for a later pha
 - Phase 47 completed through PRs `#370` through `#374`.
 - Milestone `Phase 47 - Boundary Readiness and Successor Hygiene` is closed.
 - Issue `#365` `Phase 47 exit gate` is closed after PR `#374`.
-- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
-  with `Phase 48 - Successor Intake and Boundary Contract Triage` as the active milestone.
-- Milestone `Phase 48 - Successor Intake and Boundary Contract Triage` is open.
-- Issue `#375` `Phase 48 exit gate` is open, blocked, and protected-core.
-- Issue `#376` is the initial repo-truth sync work item for this baseline update.
-- Issue `#377` records the Phase 48 public/private/plugin boundary acceptance pass.
-- Issue `#378` records the private-beta runtime contract audit.
-- Issue `#379` records the Phase 48 kernel perturbation gap brief.
+- PR `#382` merged the private-beta runtime contract audit and kernel perturbation gap
+  brief into `main`.
+- Milestone `Phase 48 - Successor Intake and Boundary Contract Triage` is closed.
+- Issue `#375` `Phase 48 exit gate` is closed after the post-merge reassessment.
+- Issue `#376` closed the initial repo-truth sync work item for this baseline update.
+- Issue `#377` records the Phase 48 public/private/plugin boundary acceptance pass and is
+  closed.
+- Issue `#378` records the private-beta runtime contract audit and is closed by PR `#382`.
+- Issue `#379` records the Phase 48 kernel perturbation gap brief and is closed by PR
+  `#382`.
+- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` now reports
+  `ready` with `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening` as the
+  active milestone.
+- Issue `#383` `Phase 49 exit gate` is open, blocked, and protected-core.
+- Issue `#384` `Phase 49: sync repo truth and protect runtime core lanes` is the current
+  ready work item.
 - Local untracked planning files under `docs/plans/...` remain candidate inputs only until a
   reviewed PR intentionally promotes selected facts.
 
@@ -57,6 +65,20 @@ into explicit candidate work without expanding the public path or plugin contrac
 Phase 48 is deliberately not a runtime expansion phase. It should produce evidence,
 classification, and successor recommendations before implementation work changes core
 contracts.
+
+## Closeout Disposition
+
+Phase 48 is closed. Its completed successor evidence is superseded by the active Phase 49
+successor gate at `docs/plans/phase-49-successor-gate-2026-05-18.md`.
+
+The approved successor milestone is:
+
+```text
+Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening
+```
+
+The active Phase 49 queue starts with `#383` `Phase 49 exit gate` and `#384`
+`Phase 49: sync repo truth and protect runtime core lanes`.
 
 ## Work Item Mapping
 

--- a/docs/plans/phase-49-successor-gate-2026-05-18.md
+++ b/docs/plans/phase-49-successor-gate-2026-05-18.md
@@ -1,0 +1,179 @@
+# Phase 49 Successor Gate
+
+Date: 2026-05-18
+
+Issue: `#384` `Phase 49: sync repo truth and protect runtime core lanes`
+
+This note records the post-Phase-48 baseline and opens the Phase 49 successor queue.
+Phase 49 is a protected-core contract-hardening phase for the decision kernel,
+perturbation resolver, runtime session semantics, compare emission, rollback behavior, and
+transfer eval posture. It is not a public-demo or plugin expansion phase.
+
+## Phase 48 Closeout Evidence
+
+- PR `#382` merged into `main` at merge commit
+  `3c6fd4f745cf0caf48061c2eb3a15067e096bb87`.
+- PR `#382` closed `#378` `Phase 48: private beta runtime contract audit` and `#379`
+  `Phase 48: kernel perturbation gap brief`.
+- Earlier Phase 48 issues `#376` and `#377` were already closed by reviewed Phase 48 PRs.
+- Issue `#375` `Phase 48 exit gate` is closed after the post-merge reassessment comment.
+- Milestone `Phase 48 - Successor Intake and Boundary Contract Triage` is closed.
+- `docs/plans/phase-48-private-beta-runtime-contract-audit-2026-05-18.md` records the
+  private-beta runtime boundary audit.
+- `docs/plans/phase-48-kernel-perturbation-gap-brief-2026-05-18.md` records the kernel and
+  perturbation successor work packages.
+- The public demo and Mirror Codex plugin remain deterministic/read-only. They do not gain
+  Hosted GPT, BYOK, upload, auth, billing, database, object storage, quota, or mutating MCP
+  behavior.
+
+Post-merge validation evidence:
+
+```powershell
+python scripts/check_no_secrets.py
+./make.ps1 test
+./make.ps1 eval-demo
+./make.ps1 eval-transfer
+./make.ps1 plugin-release-check
+./make.ps1 public-demo-check
+```
+
+The first parallel validation attempt for `public-demo-check` collided with another
+artifact-writing command under `artifacts/demo/`. The sequential rerun passed. Keep
+artifact-writing checks sequential when they share the canonical demo output directory.
+
+## Phase 49 Operational Queue
+
+Phase 49 title:
+
+```text
+Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening
+```
+
+Active GitHub objects:
+
+- `#383` `Phase 49 exit gate`
+  - Lane: `protected-core`.
+  - Status: blocked closeout gate for Phase 49.
+- `#384` `Phase 49: sync repo truth and protect runtime core lanes`
+  - Lane: `protected-core`.
+  - Status: ready first work item.
+  - Scope: sync tracked docs to Phase 49 and update lane policy before Phase 49 runtime-core
+    implementation PRs rely on automation.
+
+`python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
+with Phase 49 as the only open milestone, `#383` as the protected blocked exit gate, and
+`#384` as the current ready work item.
+
+## Protected-Core Lane Coverage
+
+Phase 49 work is protected-core by default because it can affect durable runtime contracts.
+The lane policy must treat these paths as protected before implementation work begins:
+
+- `backend/app/decision_kernel/`
+- `backend/app/perturbations/`
+- `backend/app/sessions/`
+- `backend/app/model_access/`
+- `backend/app/safety/`
+- `frontend/src/app/api/runtime/`
+- `frontend/src/app/api/worlds/create/`
+- `frontend/src/app/lib/runtime-cli.ts`
+
+This protection is operational governance. It does not itself change scenario DSL,
+perturbation payloads, session/node manifests, `decision_trace.jsonl`, compare artifacts,
+public demo artifact layout, or the Mirror Codex MCP contract.
+
+## Carried Forward TODO[verify] Items
+
+- TODO[verify]: Codex UI tool-card evidence remains open until a clean Codex app session
+  shows observable MCP tool or resource cards/traces for the Mirror Codex plugin.
+- TODO[verify]: Latest-session versus latest-activity semantics need a contract decision
+  before more world-card or launch-hub affordances depend on activity ordering.
+- TODO[verify]: Decide which `decision_trace.jsonl` fields are stable contract versus
+  implementation detail before richer provider behavior is added.
+- TODO[verify]: Decide whether every generated runtime node must emit parent-vs-child
+  compare output.
+- TODO[verify]: Decide whether checkpoint rollback exists in Phase 49 or remains deferred.
+- TODO[verify]: Identify which Fog Harbor-shaped report and eval assumptions still block a
+  stronger `museum-night` transfer proof.
+- TODO[verify]: Define what measured generation duration would justify `task_id` and worker
+  semantics instead of keeping the CLI-first synchronous contract.
+
+## Phase 49 Work Package Map
+
+1. Kernel trace and replay contract
+   - Freeze durable `decision_trace.jsonl` fields, replay-cache behavior, provider fallback
+     wording, and validation statuses.
+   - Keep model calls inside the legal-action selection boundary.
+
+2. Perturbation schema and resolver contract
+   - Promote world-local `decision_schema.yaml` into a stable authoring contract.
+   - Define template-plus-parameters before any free-form authoring path.
+
+3. Branch generation and compare emission policy
+   - Decide whether every generated node emits parent-vs-child `compare.json`.
+   - Preserve the existing public `compare.json` contract while extending session-scoped
+     artifacts only through review.
+
+4. Rollback, checkpoint, and latest-activity semantics
+   - Keep v1 rollback as `active_node_id` pointer movement until a new contract says
+     otherwise.
+   - Decide whether a `last_activity_at` field or equivalent runtime metadata is required.
+
+5. Fog Harbor de-specialization and transfer evals
+   - Remove or document remaining Fog Harbor-shaped assumptions before claiming broader
+     transfer strength.
+   - Extend transfer assertions from `museum-night` before adding another world.
+
+6. Runtime orchestration decision
+   - Keep synchronous CLI/API mirroring unless measured generation time requires async work.
+   - If async is justified, ratify `task_id`, worker ownership, retry, status, and cleanup
+     semantics in an ADR before implementation.
+
+## Blueprint Boundary
+
+Phase 49 must stay aligned with `mirror.md` and `AGENTS.md`:
+
+- Mirror is a constrained, evidence-backed, replayable what-if sandbox for fictional or
+  explicitly authorized worlds.
+- Do not present Mirror as a real-world prediction machine.
+- Do not build real-person personas or digital doubles.
+- Do not build political persuasion, law-enforcement scoring, hiring, credit, medical, or
+  judicial decision systems.
+- Every report claim must keep both `label` and `evidence_ids`.
+- Durable contract changes require `docs/architecture/contracts.md` updates and an ADR when
+  the contract is long-lived.
+
+## Non-Goals
+
+- Do not change scenario DSL, claim/evidence shape, run trace shape, public demo artifact
+  layout, or plugin MCP tool/resource contract in the Phase 49 queue-sync issue.
+- Do not add Hosted GPT, BYOK, upload, auth, billing, database, object storage, or quota
+  behavior to the public path or plugin path.
+- Do not add mutating Mirror Codex MCP tools.
+- Do not promote local untracked April/private-beta planning files as durable truth without a
+  reviewed PR.
+- Do not implement full kernel, perturbation, async worker, or checkpoint semantics inside
+  `#384`; `#384` only syncs repo truth and protects runtime-core lanes.
+
+## Validation Commands
+
+For `#384`, run:
+
+```powershell
+python -m pytest backend/tests/test_phase49_successor_gate.py backend/tests/test_automation.py -q
+python -m backend.app.cli classify-lane --files backend/app/decision_kernel/service.py backend/app/perturbations/service.py backend/app/sessions/service.py backend/app/model_access/service.py backend/app/safety/service.py frontend/src/app/api/runtime/start-session/route.ts frontend/src/app/api/runtime/generate-branch/route.ts frontend/src/app/api/runtime/rollback-session/route.ts frontend/src/app/api/worlds/create/route.ts frontend/src/app/lib/runtime-cli.ts
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+git diff --check
+```
+
+For later Phase 49 implementation PRs, add the issue-specific checks:
+
+```powershell
+python -m pytest backend/tests/test_decision_kernel.py
+python -m pytest backend/tests/test_cli.py -k "start_session or generate_branch or rollback_session"
+./make.ps1 eval-demo
+./make.ps1 eval-transfer
+./make.ps1 public-demo-check
+./make.ps1 plugin-release-check
+```

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 47 boundary-readiness closeout, and the approved Phase 48 successor queue.
+This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 48 successor-intake closeout, and the approved Phase 49 successor queue.
 
 ## Current Gate State
 
@@ -51,7 +51,8 @@ This note records the current post-Day-0 execution status for Mirror after the f
 - Phase 45 exit gate: closed
 - Phase 46 exit gate: closed
 - Phase 47 exit gate: closed
-- Phase 48 exit gate: open and blocked
+- Phase 48 exit gate: closed
+- Phase 49 exit gate: open and blocked
 
 Local phase audits currently report:
 
@@ -59,29 +60,39 @@ Local phase audits currently report:
 - `phase2`: pass
 - `phase3`: pass
 
-## Phase 48 Successor Queue
+## Phase 49 Successor Queue
 
 - `audit-github-queue`
-  - reports `ready` with `Phase 48 - Successor Intake and Boundary Contract Triage` as the active milestone
-- milestone `Phase 48 - Successor Intake and Boundary Contract Triage`
+  - reports `ready` with `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening` as the active milestone
+- milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`
   - open
-- `#375` `Phase 48 exit gate`
+- `#383` `Phase 49 exit gate`
   - open and blocked
   - labeled `lane:protected-core` because it is the protected closeout gate
-- `#376` `Phase 48: sync repo truth after Phase 47 closeout`
-  - first docs-only repo-truth sync work item
-  - expected to close with the PR that introduces this Phase 48 baseline
-- `#377` `Phase 48: public private plugin boundary acceptance`
-  - boundary acceptance recorded in `docs/plans/phase-48-boundary-acceptance-2026-05-17.md`
-  - expected to close with the PR that introduces that report
-- `#378` `Phase 48: private beta runtime contract audit`
-  - private-beta runtime contract audit recorded in `docs/plans/phase-48-private-beta-runtime-contract-audit-2026-05-18.md`
-  - expected to close with the PR that introduces that report
-- `#379` `Phase 48: kernel perturbation gap brief`
-  - kernel perturbation gap brief recorded in `docs/plans/phase-48-kernel-perturbation-gap-brief-2026-05-18.md`
-  - expected to close with the PR that introduces that brief
+- `#384` `Phase 49: sync repo truth and protect runtime core lanes`
+  - first protected-core repo-truth and lane-policy work item
+  - expected to close with the PR that introduces the Phase 49 baseline and runtime-core lane protection
 - phase gate baseline
-  - active Phase 48 gate note: `docs/plans/phase-48-successor-gate-2026-05-17.md`
+  - active Phase 49 gate note: `docs/plans/phase-49-successor-gate-2026-05-18.md`
+
+## Phase 48 Closeout
+
+- milestone `Phase 48 - Successor Intake and Boundary Contract Triage`
+  - closed after PR `#382` and the post-merge exit-gate reassessment
+- `#375` `Phase 48 exit gate`
+  - closed after the post-merge reassessment on `main`
+  - labeled `lane:protected-core` because it was the protected closeout gate
+- `#376` `Phase 48: sync repo truth after Phase 47 closeout`
+  - closed
+- `#377` `Phase 48: public private plugin boundary acceptance`
+  - closed
+  - recorded in `docs/plans/phase-48-boundary-acceptance-2026-05-17.md`
+- `#378` `Phase 48: private beta runtime contract audit`
+  - closed by PR `#382`
+  - recorded in `docs/plans/phase-48-private-beta-runtime-contract-audit-2026-05-18.md`
+- `#379` `Phase 48: kernel perturbation gap brief`
+  - closed by PR `#382`
+  - recorded in `docs/plans/phase-48-kernel-perturbation-gap-brief-2026-05-18.md`
 
 ## Phase 47 Closeout
 
@@ -134,9 +145,9 @@ Local phase audits currently report:
     - closed
     - merged via PR `#321`
 - successor posture
-  - Phase 47 completed as a boundary readiness and successor hygiene round
-  - Phase 48 is the active approved successor queue
-  - any work beyond the Phase 48 queue requires a fresh decision against the trigger conditions in `mirror.md`
+  - Phase 48 completed as a successor-intake and boundary contract triage round
+  - Phase 49 is the active approved successor queue
+  - any work beyond the Phase 49 queue requires a fresh decision against the trigger conditions in `mirror.md`
 
 ## Closeout Snapshot
 
@@ -594,7 +605,8 @@ Local phase audits currently report:
 - Protected-core changes still require explicit review and must not auto-merge.
 - Long-running execution should assign exactly one writer worktree per issue.
 - When `audit-github-queue` reports `ready`, consume only the currently active milestone and do not parallel-open another execution queue.
-- Phase 48 is the active approved successor queue; do not open a parallel execution queue.
+- Phase 49 is the active approved successor queue; do not open a parallel execution queue.
+- The previous local queue follow-up automation has been revoked or left paused per operator request; do not recreate an automation without a new explicit request.
 
 ## Historical Branch Status
 


### PR DESCRIPTION
## Summary

- closes Phase 48 in tracked repo truth after PR #382, exit gate #375, and the Phase 48 milestone closeout
- opens the Phase 49 successor baseline around kernel, perturbation, and runtime contract hardening with #383/#384 as the active queue objects
- expands protected-core lane policy so Phase 49 runtime-core paths are not misclassified as auto-safe
- adds regression coverage for the Phase 49 gate note and runtime-core lane classification

## Validation

- `python -m pytest backend/tests/test_phase49_successor_gate.py backend/tests/test_automation.py -q` -> 12 passed
- `python -m backend.app.cli classify-lane --files backend/app/decision_kernel/service.py backend/app/perturbations/service.py backend/app/sessions/service.py backend/app/model_access/service.py backend/app/safety/service.py frontend/src/app/api/runtime/start-session/route.ts frontend/src/app/api/runtime/generate-branch/route.ts frontend/src/app/api/runtime/rollback-session/route.ts frontend/src/app/api/worlds/create/route.ts frontend/src/app/lib/runtime-cli.ts` -> lane:protected-core
- `python scripts/check_no_secrets.py` -> passed
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` -> ready, active milestone Phase 49
- `git diff --cached --check` -> passed before commit
- `./make.ps1 test` -> 75 passed
- `./make.ps1 eval-demo` -> pass, 23/23
- `./make.ps1 eval-transfer` -> pass, 32/32 across 2 worlds
- `./make.ps1 public-demo-check` -> passed sequentially
- `./make.ps1 plugin-check` -> passed

Note: `./make.ps1 plugin-release-check` validated the plugin internals but failed its plugin-PR scope check because this branch intentionally changes repo queue/lane-policy files, not a plugin release PR. No plugin files are changed.

## Review Notes

Protected-core PR. Do not auto-merge. The carried-forward `TODO[verify]` items remain open in the Phase 49 gate note.

Closes #384