### PR TITLE
[codex] Phase 49 kernel trace contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - The completed Phase 48 successor gate lives in [docs/plans/phase-48-successor-gate-2026-05-17.md](docs/plans/phase-48-successor-gate-2026-05-17.md).
 - The active successor gate lives in [docs/plans/phase-49-successor-gate-2026-05-18.md](docs/plans/phase-49-successor-gate-2026-05-18.md).
 - Phase 48 is closed after PR `#382`, issue `#375`, and milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
-- Phase 49 is the active approved successor queue: `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; `audit-github-queue` reports `ready` with `#383` as the blocked exit gate and `#384` as the current ready work item.
+- Phase 49 is the active approved successor queue: `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; `audit-github-queue` reports `ready` with `#383` as the blocked exit gate, `#384` closed by PR `#385`, and `#386` as the current ready work item.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
 - Fog Harbor remains the canonical demo world; `museum-night` is the minimal transfer world used to prove the pipeline is not single-world-only.
 

--- a/backend/app/decision_kernel/service.py
+++ b/backend/app/decision_kernel/service.py
@@ -14,6 +14,9 @@ from backend.app.simulation.rules import StepChoice
 from backend.app.utils import ensure_dir, read_jsonl
 
 
+_TRACE_FIELD_UNSET = object()
+
+
 def _hash_json(payload: Any) -> str:
     return hashlib.sha256(
         json.dumps(payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
@@ -175,6 +178,7 @@ class DecisionKernel:
         state: dict[str, Any],
         choices: list[StepChoice],
     ) -> StepChoice:
+        self._validate_choices(choices)
         available_choices = [
             {
                 "index": index,
@@ -207,6 +211,8 @@ class DecisionKernel:
                 output_hash=replay_entry.output_hash,
                 fallback_used=replay_entry.fallback_used,
                 validation_status="accepted_from_replay",
+                model_id=replay_entry.model_id,
+                prompt_version=replay_entry.prompt_version,
             )
 
         if len(choices) == 1:
@@ -247,15 +253,12 @@ class DecisionKernel:
                             fallback_used=False,
                             validation_status=f"accepted_after_attempt_{attempt + 1}",
                         )
-                except Exception as exc:  # noqa: BLE001
-                    last_error = str(exc)
+                except Exception:  # noqa: BLE001
                     continue
             fallback_rationale = (
                 f"LLM proposal was unavailable or invalid; fallback strategy "
                 f"`{self.schema.decision_kernel.fallback_strategy}` selected the first legal choice."
             )
-            if "last_error" in locals():
-                fallback_rationale += f" Last error: {last_error}"
         elif self.provider in {"openai_compatible", HOSTED_PROVIDER}:
             fallback_rationale = (
                 "No model or API credential is configured for the selected provider; "
@@ -293,15 +296,27 @@ class DecisionKernel:
         output_hash: str | None,
         fallback_used: bool,
         validation_status: str,
+        model_id: str | None | object = _TRACE_FIELD_UNSET,
+        prompt_version: str | None | object = _TRACE_FIELD_UNSET,
     ) -> StepChoice:
         selected = choices[selected_choice_index]
+        trace_model_id = (
+            self.model_id if model_id is _TRACE_FIELD_UNSET else model_id
+        )
+        trace_prompt_version = (
+            self.schema.decision_kernel.prompt_version
+            if prompt_version is _TRACE_FIELD_UNSET
+            else prompt_version
+        )
         entry = DecisionTraceEntry(
             run_id=self.run_id,
             turn_index=turn_index,
             actor_id=actor_id,
             provider_mode=provider_mode,
-            model_id=self.model_id,
-            prompt_version=self.schema.decision_kernel.prompt_version,
+            model_id=trace_model_id if isinstance(trace_model_id, str) else None,
+            prompt_version=(
+                trace_prompt_version if isinstance(trace_prompt_version, str) else None
+            ),
             input_hash=input_hash,
             output_hash=output_hash,
             available_choices=[_choice_summary(choice) for choice in choices],
@@ -316,3 +331,18 @@ class DecisionKernel:
             _append_trace(self.decision_trace_path, entry)
         self.replay_cache[input_hash] = entry
         return selected
+
+    def _validate_choices(self, choices: list[StepChoice]) -> None:
+        allowed_action_types = set(self.schema.allowed_action_types)
+        invalid_action_types = sorted(
+            {
+                choice.action.action_type
+                for choice in choices
+                if choice.action.action_type not in allowed_action_types
+            }
+        )
+        if invalid_action_types:
+            raise ValueError(
+                "Choice action type(s) not allowed by decision schema: "
+                + ", ".join(invalid_action_types)
+            )

--- a/backend/tests/test_decision_kernel.py
+++ b/backend/tests/test_decision_kernel.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from backend.app.decision_kernel import DecisionKernel
+import backend.app.decision_kernel.service as decision_kernel_service
 from backend.app.perturbations import load_decision_schema, resolve_perturbation_payload
 from backend.app.domain.models import PerturbationPayload
 from backend.app.simulation.rules import StepAction, StepChoice
@@ -140,3 +142,202 @@ def test_decision_kernel_replays_cached_choice(tmp_path: Path) -> None:
         choices=choices,
     )
     assert replayed.action.action_type == "inspect"
+
+
+def test_decision_kernel_replay_uses_cached_choice_without_provider_call(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    schema = load_decision_schema(Path("data/demo/config/decision_schema.yaml"))
+    trace_path = tmp_path / "decision_trace.jsonl"
+    first_kernel = DecisionKernel(
+        world_id="fog-harbor-east-gate",
+        schema=schema,
+        run_id="run_demo",
+        decision_trace_path=trace_path,
+        provider_override="deterministic_only",
+    )
+    choices = _kernel_test_choices()
+
+    first_selected = _choose_with_kernel(first_kernel, choices)
+    assert first_selected.action.action_type == "inspect"
+
+    def fail_if_called(**_: object) -> tuple[int, str, str]:
+        raise AssertionError("provider should not be called for replay cache hits")
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-replay")
+    monkeypatch.setenv("MIRROR_DECISION_MODEL", "gpt-replay-new")
+    monkeypatch.setattr(decision_kernel_service, "_openai_choose_choice", fail_if_called)
+    replay_kernel = DecisionKernel(
+        world_id="fog-harbor-east-gate",
+        schema=schema,
+        run_id="run_demo_replay",
+        decision_trace_path=trace_path,
+    )
+
+    replayed = _choose_with_kernel(replay_kernel, choices)
+
+    assert replayed.action.action_type == "inspect"
+    rows = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 2
+    original, replay = rows
+    assert original["provider_mode"] == "deterministic_fallback"
+    assert replay["provider_mode"] == "replay_cache"
+    assert replay["validation_status"] == "accepted_from_replay"
+    assert replay["selected_choice_index"] == original["selected_choice_index"]
+    assert replay["output_hash"] == original["output_hash"]
+    assert replay["rationale"] == original["rationale"]
+    assert replay["model_id"] == original["model_id"]
+    assert replay["prompt_version"] == original["prompt_version"]
+
+
+def test_decision_kernel_rejects_choice_outside_world_decision_schema(tmp_path: Path) -> None:
+    schema = load_decision_schema(Path("data/demo/config/decision_schema.yaml"))
+    kernel = DecisionKernel(
+        world_id="fog-harbor-east-gate",
+        schema=schema,
+        run_id="run_demo",
+        decision_trace_path=tmp_path / "decision_trace.jsonl",
+        provider_override="deterministic_only",
+    )
+    choices = [
+        StepChoice(
+            action=StepAction(
+                action_type="invent_state_patch",
+                target_id="entity_east_gate",
+                rationale="Illegal action outside the world schema.",
+                updates=[],
+            )
+        )
+    ]
+
+    try:
+        _choose_with_kernel(kernel, choices)
+    except ValueError as exc:
+        assert "not allowed by decision schema" in str(exc)
+    else:
+        raise AssertionError("kernel accepted an action outside the decision schema")
+
+
+def _kernel_test_choices() -> list[StepChoice]:
+    return [
+        StepChoice(
+            action=StepAction(
+                action_type="inspect",
+                target_id="entity_east_gate",
+                rationale="Inspect the gate.",
+                updates=[],
+            )
+        ),
+        StepChoice(
+            action=StepAction(
+                action_type="inform",
+                target_id="persona_zhao_ke",
+                rationale="Inform the deputy mayor.",
+                updates=[],
+            )
+        ),
+    ]
+
+
+def _choose_with_kernel(kernel: DecisionKernel, choices: list[StepChoice]) -> StepChoice:
+    return kernel.choose(
+        scenario_id="scenario_baseline",
+        turn_index=2,
+        actor_id="persona_chen_yu",
+        state={"communications_down_until": 0, "blocked_contacts": []},
+        choices=choices,
+    )
+
+
+def test_decision_kernel_invalid_model_output_falls_back_with_contract_trace(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    schema = load_decision_schema(Path("data/demo/config/decision_schema.yaml"))
+    trace_path = tmp_path / "decision_trace.jsonl"
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-invalid-output")
+    monkeypatch.setenv("MIRROR_DECISION_MODEL", "gpt-test")
+
+    def choose_invalid_index(**_: object) -> tuple[int, str, str]:
+        return 99, "Invalid out-of-range proposal.", "invalid-output-hash"
+
+    monkeypatch.setattr(decision_kernel_service, "_openai_choose_choice", choose_invalid_index)
+    kernel = DecisionKernel(
+        world_id="fog-harbor-east-gate",
+        schema=schema,
+        run_id="run_demo",
+        decision_trace_path=trace_path,
+    )
+
+    selected = _choose_with_kernel(kernel, _kernel_test_choices())
+
+    assert selected.action.action_type == "inspect"
+    rows = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 1
+    trace = rows[0]
+    assert set(trace) == {
+        "run_id",
+        "turn_index",
+        "actor_id",
+        "provider_mode",
+        "model_id",
+        "prompt_version",
+        "input_hash",
+        "output_hash",
+        "available_choices",
+        "selected_choice_index",
+        "selected_action_type",
+        "selected_target_id",
+        "rationale",
+        "validation_status",
+        "fallback_used",
+    }
+    assert trace["provider_mode"] == "deterministic_fallback"
+    assert trace["model_id"] == "gpt-test"
+    assert trace["selected_choice_index"] == 0
+    assert trace["selected_action_type"] == "inspect"
+    assert trace["fallback_used"] is True
+    assert trace["validation_status"] == "accepted_via_fallback"
+    assert trace["available_choices"] == [
+        "inspect -> entity_east_gate: Inspect the gate.",
+        "inform -> persona_zhao_ke: Inform the deputy mayor.",
+    ]
+
+
+def test_decision_kernel_provider_error_fallback_redacts_raw_error_and_secret(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    schema = load_decision_schema(Path("data/demo/config/decision_schema.yaml"))
+    trace_path = tmp_path / "decision_trace.jsonl"
+    secret = "sk-test-secret"
+    monkeypatch.setenv("OPENAI_API_KEY", secret)
+    monkeypatch.setenv("MIRROR_DECISION_MODEL", "gpt-test")
+
+    def raise_provider_error(**_: object) -> tuple[int, str, str]:
+        raise RuntimeError(f"provider exploded with {secret} from OPENAI_API_KEY")
+
+    monkeypatch.setattr(decision_kernel_service, "_openai_choose_choice", raise_provider_error)
+    kernel = DecisionKernel(
+        world_id="fog-harbor-east-gate",
+        schema=schema,
+        run_id="run_demo",
+        decision_trace_path=trace_path,
+    )
+
+    selected = _choose_with_kernel(kernel, _kernel_test_choices())
+
+    assert selected.action.action_type == "inspect"
+    trace_text = trace_path.read_text(encoding="utf-8")
+    assert secret not in trace_text
+    assert "OPENAI_API_KEY" not in trace_text
+    assert "provider exploded" not in trace_text
+    trace = json.loads(trace_text)
+    assert trace["provider_mode"] == "deterministic_fallback"
+    assert trace["fallback_used"] is True
+    assert trace["validation_status"] == "accepted_via_fallback"
+    assert trace["rationale"] == (
+        "LLM proposal was unavailable or invalid; fallback strategy "
+        "`first_legal_choice` selected the first legal choice."
+    )

--- a/backend/tests/test_phase49_successor_gate.py
+++ b/backend/tests/test_phase49_successor_gate.py
@@ -33,6 +33,7 @@ def test_phase49_successor_gate_records_work_packages_and_boundaries() -> None:
         "Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening",
         "`#383` `Phase 49 exit gate`",
         "`#384` `Phase 49: sync repo truth and protect runtime core lanes`",
+        "`#386` `Phase 49: ratify kernel trace and replay contract`",
         "Kernel trace and replay contract",
         "Perturbation schema and resolver contract",
         "Branch generation and compare emission policy",
@@ -64,3 +65,4 @@ def test_active_state_docs_point_to_phase49_queue() -> None:
         assert "Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening" in text
         assert "`#383`" in text
         assert "`#384`" in text
+        assert "`#386`" in text

--- a/docs/architecture/contracts.md
+++ b/docs/architecture/contracts.md
@@ -141,12 +141,66 @@ All IDs must be serializable, stable across files, and traceable in `artifacts/`
   - write arbitrary world state directly
   - bypass validator checks
   - bypass replay persistence
+- Kernel entry must reject any candidate `StepChoice` whose `action_type` is not listed in
+  the world-local `decision_schema.yaml` `allowed_action_types`; this is a defense-in-depth
+  guard in addition to upstream scenario and simulation rule validation.
 - Deterministic fallback is mandatory when:
   - the model is unavailable
   - the output is invalid
   - retries are exhausted
 - Replayability is mandatory.
   - the same world state plus the same legal choice set must be able to replay the same selected action through stored decision artifacts
+- `decision_trace.jsonl` is the durable v1 decision audit artifact. Each line is a
+  `DecisionTraceEntry` with these stable fields:
+  - `run_id`
+  - `turn_index`
+  - `actor_id`
+  - `provider_mode`
+  - `model_id`
+  - `prompt_version`
+  - `input_hash`
+  - `output_hash`
+  - `available_choices`
+  - `selected_choice_index`
+  - `selected_action_type`
+  - `selected_target_id`
+  - `rationale`
+  - `validation_status`
+  - `fallback_used`
+- Stable `provider_mode` values are:
+  - `openai_compatible` when a configured request-scoped compatible provider returns a
+    validated legal choice.
+  - `hosted_openai` when the hosted private-beta provider returns a validated legal choice.
+  - `deterministic_fallback` when model configuration is absent, provider execution fails,
+    model output is invalid, or retry attempts are exhausted.
+  - `single_choice` when only one legal action exists.
+  - `replay_cache` when the selection is copied from an existing trace entry for the same
+    `input_hash`.
+- Stable `validation_status` values are:
+  - `accepted_after_attempt_<n>` for validated provider output.
+  - `accepted_via_fallback` for deterministic fallback after invalid/unavailable provider
+    output or missing provider configuration.
+  - `accepted_single_choice` for a one-choice legal action set.
+  - `accepted_from_replay` for replay-cache reuse.
+- Replay uses `input_hash`, which is computed from the world id, scenario id, turn index,
+  actor id, current state, and legal choice summaries. If a cached trace entry has the same
+  hash and its `selected_choice_index` is still legal, the kernel must select that cached
+  index without re-querying a provider.
+- Decision traces are append-only audit history for a concrete run/node artifact. A replay
+  cache hit appends a new trace row with `provider_mode` set to `replay_cache` and
+  `validation_status` set to `accepted_from_replay` rather than rewriting the original row.
+- Replay-cache rows preserve the cached decision provenance for `model_id`, `prompt_version`,
+  `rationale`, and `output_hash`, while the new row's `run_id`, `turn_index`, and `actor_id`
+  describe the current replay context.
+- Fallback traces must not fail open. They must select the deterministic fallback action,
+  set `fallback_used` to `true`, set `provider_mode` to `deterministic_fallback`, and set
+  `validation_status` to `accepted_via_fallback`.
+- Trace privacy is part of the contract:
+  - `input_hash` and `output_hash` are hashes, not raw prompt or raw provider output.
+  - raw provider credentials, beta access codes, request headers, provider exception text,
+    and local filesystem paths must not be written into `decision_trace.jsonl`.
+  - `rationale` may summarize accepted model rationale or deterministic fallback reason, but
+    must not include raw provider errors.
 
 ## Compare Contract
 

--- a/docs/decisions/ADR-0007-rule-bounded-llm-kernel.md
+++ b/docs/decisions/ADR-0007-rule-bounded-llm-kernel.md
@@ -50,6 +50,9 @@ The blueprint and safety boundaries still require:
   - bypass state preconditions
   - bypass replay/audit persistence
   - expand beyond the bounded world contract
+- The decision kernel must also enforce the world-local `allowed_action_types` list at its
+  own boundary. This keeps the kernel from accepting a caller-supplied `StepChoice` that
+  skipped upstream scenario or simulation validation.
 
 - Replayability is a hard requirement.
   - every decision point must persist:
@@ -61,6 +64,33 @@ The blueprint and safety boundaries still require:
     - validation result
     - fallback flag
   - replay must prefer stored decisions over re-sampling
+  - replay rows are append-only audit entries: they record the current replay context while
+    preserving the cached decision's model identifier, prompt version, rationale, and output
+    hash.
+  - the stable v1 `decision_trace.jsonl` fields are:
+    - `run_id`
+    - `turn_index`
+    - `actor_id`
+    - `provider_mode`
+    - `model_id`
+    - `prompt_version`
+    - `input_hash`
+    - `output_hash`
+    - `available_choices`
+    - `selected_choice_index`
+    - `selected_action_type`
+    - `selected_target_id`
+    - `rationale`
+    - `validation_status`
+    - `fallback_used`
+  - stable `provider_mode` values are `openai_compatible`, `hosted_openai`,
+    `deterministic_fallback`, `single_choice`, and `replay_cache`.
+  - stable `validation_status` values are `accepted_after_attempt_<n>`,
+    `accepted_via_fallback`, `accepted_single_choice`, and `accepted_from_replay`.
+  - trace privacy is part of replayability: `input_hash` and `output_hash` are hashes, and
+    raw provider credentials, beta access codes, request headers, provider exception text,
+    local filesystem paths, raw prompts, and raw provider outputs must not be written into
+    `decision_trace.jsonl`.
 
 - Deterministic fallback is mandatory.
   - if the model is unavailable

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -164,7 +164,8 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 49 is the active approved successor queue.
 - milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening` is open.
 - `#383` `Phase 49 exit gate` is open, blocked, and protected-core.
-- `#384` `Phase 49: sync repo truth and protect runtime core lanes` is the current ready work item.
+- `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
+- `#386` `Phase 49: ratify kernel trace and replay contract` is the current ready work item.
 - `audit-github-queue` reports `ready` with Phase 49 as the active milestone.
 - The first formal repository release is published as `v0.1.0`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -231,7 +231,8 @@ This note records the completed Phase 48 successor-intake closeout and the appro
     - milestone `Phase 48 - Successor Intake and Boundary Contract Triage` is `closed`
   - `gh issue list --milestone "Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening" --state all`
     - `#383` `Phase 49 exit gate` is `open`, `blocked`, and `lane:protected-core`
-    - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is the first `status:ready` protected-core work item for the new baseline
+    - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is `closed` by PR `#385`
+    - `#386` `Phase 49: ratify kernel trace and replay contract` is the current `status:ready` protected-core work item
 
 ## Trusted Source Of Truth
 
@@ -262,7 +263,8 @@ This note records the completed Phase 48 successor-intake closeout and the appro
 - The Phase 48 unlock order is resolved: `#376` and `#377` closed through earlier Phase 48 PRs, `#378` and `#379` closed through PR `#382`, and `#375` closed after the post-merge exit-gate reassessment.
 - The active successor milestone is `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`.
 - The Phase 49 exit gate is `#383` `Phase 49 exit gate`, which remains the open blocked closeout gate for this phase.
-- `#384` `Phase 49: sync repo truth and protect runtime core lanes` is the current ready work item.
+- `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
+- `#386` `Phase 49: ratify kernel trace and replay contract` is the current ready work item.
 - The completed Phase 47 successor-gate baseline lives in `docs/plans/phase-47-successor-gate-2026-05-16.md`.
 - The completed Phase 48 successor-gate baseline lives in `docs/plans/phase-48-successor-gate-2026-05-17.md`.
 - The active Phase 49 successor-gate baseline lives in `docs/plans/phase-49-successor-gate-2026-05-18.md`.

--- a/docs/plans/phase-48-successor-gate-2026-05-17.md
+++ b/docs/plans/phase-48-successor-gate-2026-05-17.md
@@ -78,7 +78,8 @@ Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening
 ```
 
 The active Phase 49 queue starts with `#383` `Phase 49 exit gate` and `#384`
-`Phase 49: sync repo truth and protect runtime core lanes`.
+`Phase 49: sync repo truth and protect runtime core lanes`; after PR `#385`, the current
+ready work item is `#386` `Phase 49: ratify kernel trace and replay contract`.
 
 ## Work Item Mapping
 

--- a/docs/plans/phase-49-successor-gate-2026-05-18.md
+++ b/docs/plans/phase-49-successor-gate-2026-05-18.md
@@ -4,6 +4,8 @@ Date: 2026-05-18
 
 Issue: `#384` `Phase 49: sync repo truth and protect runtime core lanes`
 
+Current work item: `#386` `Phase 49: ratify kernel trace and replay contract`
+
 This note records the post-Phase-48 baseline and opens the Phase 49 successor queue.
 Phase 49 is a protected-core contract-hardening phase for the decision kernel,
 perturbation resolver, runtime session semantics, compare emission, rollback behavior, and
@@ -56,13 +58,18 @@ Active GitHub objects:
   - Status: blocked closeout gate for Phase 49.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes`
   - Lane: `protected-core`.
-  - Status: ready first work item.
+  - Status: closed by PR `#385`.
   - Scope: sync tracked docs to Phase 49 and update lane policy before Phase 49 runtime-core
     implementation PRs rely on automation.
+- `#386` `Phase 49: ratify kernel trace and replay contract`
+  - Lane: `protected-core`.
+  - Status: current ready work item.
+  - Scope: document the v1 `decision_trace.jsonl` contract and harden replay/fallback
+    trace privacy tests.
 
 `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
 with Phase 49 as the only open milestone, `#383` as the protected blocked exit gate, and
-`#384` as the current ready work item.
+`#386` as the current ready work item.
 
 ## Protected-Core Lane Coverage
 
@@ -88,8 +95,13 @@ public demo artifact layout, or the Mirror Codex MCP contract.
   shows observable MCP tool or resource cards/traces for the Mirror Codex plugin.
 - TODO[verify]: Latest-session versus latest-activity semantics need a contract decision
   before more world-card or launch-hub affordances depend on activity ordering.
-- TODO[verify]: Decide which `decision_trace.jsonl` fields are stable contract versus
-  implementation detail before richer provider behavior is added.
+- The first `decision_trace.jsonl` v1 field set is now ratified in
+  `docs/architecture/contracts.md`; TODO[verify]: re-open contract review before adding new
+  trace fields, changing validation status values, or widening provider output persistence.
+- Kernel boundary action-type validation is now ratified in
+  `docs/decisions/ADR-0007-rule-bounded-llm-kernel.md` and
+  `docs/architecture/contracts.md`; TODO[verify]: re-open contract review before accepting
+  any caller-supplied action outside a world-local `allowed_action_types` list.
 - TODO[verify]: Decide whether every generated runtime node must emit parent-vs-child
   compare output.
 - TODO[verify]: Decide whether checkpoint rollback exists in Phase 49 or remains deferred.
@@ -152,8 +164,8 @@ Phase 49 must stay aligned with `mirror.md` and `AGENTS.md`:
 - Do not add mutating Mirror Codex MCP tools.
 - Do not promote local untracked April/private-beta planning files as durable truth without a
   reviewed PR.
-- Do not implement full kernel, perturbation, async worker, or checkpoint semantics inside
-  `#384`; `#384` only syncs repo truth and protects runtime-core lanes.
+- Do not implement full perturbation, async worker, or checkpoint semantics inside `#386`;
+  `#386` only ratifies the v1 decision trace/replay contract and hardens trace privacy tests.
 
 ## Validation Commands
 
@@ -164,6 +176,16 @@ python -m pytest backend/tests/test_phase49_successor_gate.py backend/tests/test
 python -m backend.app.cli classify-lane --files backend/app/decision_kernel/service.py backend/app/perturbations/service.py backend/app/sessions/service.py backend/app/model_access/service.py backend/app/safety/service.py frontend/src/app/api/runtime/start-session/route.ts frontend/src/app/api/runtime/generate-branch/route.ts frontend/src/app/api/runtime/rollback-session/route.ts frontend/src/app/api/worlds/create/route.ts frontend/src/app/lib/runtime-cli.ts
 python scripts/check_no_secrets.py
 python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+git diff --check
+```
+
+For `#386`, run:
+
+```powershell
+python -m pytest backend/tests/test_decision_kernel.py -q
+python -m pytest backend/tests/test_cli.py -k "generate_branch or decision_trace" -q
+python -m backend.app.cli classify-lane --files docs/architecture/contracts.md docs/decisions/ADR-0007-rule-bounded-llm-kernel.md backend/app/decision_kernel/service.py backend/tests/test_decision_kernel.py backend/tests/test_cli.py docs/plans/phase-49-successor-gate-2026-05-18.md
+python scripts/check_no_secrets.py
 git diff --check
 ```
 

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -71,7 +71,10 @@ Local phase audits currently report:
   - labeled `lane:protected-core` because it is the protected closeout gate
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes`
   - first protected-core repo-truth and lane-policy work item
-  - expected to close with the PR that introduces the Phase 49 baseline and runtime-core lane protection
+  - closed by PR `#385`
+- `#386` `Phase 49: ratify kernel trace and replay contract`
+  - current protected-core kernel trace/replay contract work item
+  - expected to close with the PR that documents the v1 trace contract and hardens trace privacy tests
 - phase gate baseline
   - active Phase 49 gate note: `docs/plans/phase-49-successor-gate-2026-05-18.md`
 


### PR DESCRIPTION
## Summary

- ratifies the v1 `decision_trace.jsonl` field set, provider/status vocabulary, replay semantics, fallback semantics, and trace privacy constraints in contracts and ADR-0007
- hardens the decision kernel so caller-supplied choices must be allowed by the world-local decision schema
- prevents raw provider exception text from being persisted into fallback trace rationale
- adds tests for invalid model output fallback, provider-error redaction, replay-cache provenance, no provider call on replay, and illegal action-type rejection
- syncs Phase 49 docs so #386 is the current ready work item after #384/#385

## Validation

- `python -m pytest backend/tests/test_decision_kernel.py -q` -> 9 passed
- `python -m pytest backend/tests/test_cli.py -k "generate_branch or decision_trace" -q` -> 4 passed, 22 deselected
- `python -m pytest backend/tests/test_phase49_successor_gate.py backend/tests/test_automation.py -q` -> 12 passed
- `python scripts/check_no_secrets.py` -> passed
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` -> ready, active Phase 49, ready issue #386
- `python -m backend.app.cli classify-lane --files docs/architecture/contracts.md docs/decisions/ADR-0007-rule-bounded-llm-kernel.md backend/app/decision_kernel/service.py backend/tests/test_decision_kernel.py backend/tests/test_cli.py docs/plans/phase-49-successor-gate-2026-05-18.md README.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md docs/plans/automation-roadmap.md docs/plans/phase-48-successor-gate-2026-05-17.md backend/tests/test_phase49_successor_gate.py` -> lane:protected-core
- `git diff --check` -> passed
- `./make.ps1 test` -> 79 passed
- `./make.ps1 eval-demo` -> pass, 23/23
- `./make.ps1 eval-transfer` -> pass, 32/32 across 2 worlds
- `./make.ps1 public-demo-check` -> passed sequentially
- `./make.ps1 plugin-check` -> passed

## Review Notes

Protected-core PR. Do not auto-merge. This does not change scenario DSL, perturbation payloads, compare artifacts, rollback semantics, async `task_id`, public demo artifact layout, or plugin MCP behavior.

Closes #386