### PR TITLE
[codex] Phase 49 perturbation resolver contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - The completed Phase 48 successor gate lives in [docs/plans/phase-48-successor-gate-2026-05-17.md](docs/plans/phase-48-successor-gate-2026-05-17.md).
 - The active successor gate lives in [docs/plans/phase-49-successor-gate-2026-05-18.md](docs/plans/phase-49-successor-gate-2026-05-18.md).
 - Phase 48 is closed after PR `#382`, issue `#375`, and milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
-- Phase 49 is the active approved successor queue: `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; `audit-github-queue` reports `ready` with `#383` as the blocked exit gate, `#384` closed by PR `#385`, and `#386` as the current ready work item.
+- Phase 49 is the active approved successor queue: `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; `audit-github-queue` reports `ready` with `#383` as the blocked exit gate, `#384` closed by PR `#385`, `#386` closed by PR `#387`, and `#388` as the current ready work item.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
 - Fog Harbor remains the canonical demo world; `museum-night` is the minimal transfer world used to prove the pipeline is not single-world-only.
 

--- a/backend/app/perturbations/service.py
+++ b/backend/app/perturbations/service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import Field
 
@@ -24,8 +24,8 @@ class PerturbationSchema(MirrorBaseModel):
     target_sources: list[str] = Field(default_factory=list)
     actor_sources: list[str] = Field(default_factory=list)
     timing_tokens: list[str] = Field(default_factory=list)
-    required_parameters: dict[str, str] = Field(default_factory=dict)
-    optional_parameters: dict[str, str] = Field(default_factory=dict)
+    required_parameters: dict[str, Literal["int", "float", "bool", "str"]] = Field(default_factory=dict)
+    optional_parameters: dict[str, Literal["int", "float", "bool", "str"]] = Field(default_factory=dict)
 
 
 class DecisionSchema(MirrorBaseModel):
@@ -74,7 +74,7 @@ def load_world_target_catalog(world_id: str, *, repo_root: Path | None = None) -
 
 def _coerce_parameter(name: str, value: Any, expected_type: str) -> Any:
     if expected_type == "int":
-        if not isinstance(value, int):
+        if not isinstance(value, int) or isinstance(value, bool):
             raise ValueError(f"Parameter `{name}` must be an integer.")
         return value
     if expected_type == "float":

--- a/backend/tests/test_decision_kernel.py
+++ b/backend/tests/test_decision_kernel.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from backend.app.decision_kernel import DecisionKernel
 import backend.app.decision_kernel.service as decision_kernel_service
-from backend.app.perturbations import load_decision_schema, resolve_perturbation_payload
+from backend.app.perturbations import DecisionSchema, load_decision_schema, resolve_perturbation_payload
 from backend.app.domain.models import PerturbationPayload
 from backend.app.simulation.rules import StepAction, StepChoice
 
@@ -88,6 +88,168 @@ def test_resolve_perturbation_payload_rejects_invalid_timing() -> None:
         assert "Unsupported timing token" in str(exc)
     else:
         raise AssertionError("invalid timing did not fail resolution")
+
+
+def test_resolve_perturbation_payload_rejects_missing_required_parameter() -> None:
+    try:
+        resolve_perturbation_payload(
+            "fog-harbor-east-gate",
+            PerturbationPayload(
+                kind="delay_document",
+                target_id="doc_ledger_copy",
+                timing="before_publication",
+                summary="Missing the required delay turn count.",
+                parameters={"actor_id": "entity_lin_lan"},
+            ),
+        )
+    except ValueError as exc:
+        assert "Missing required parameter `delay_turns`" in str(exc)
+    else:
+        raise AssertionError("missing required parameter did not fail resolution")
+
+
+def test_resolve_perturbation_payload_rejects_unexpected_parameter() -> None:
+    try:
+        resolve_perturbation_payload(
+            "fog-harbor-east-gate",
+            PerturbationPayload(
+                kind="block_contact",
+                target_id="persona_zhao_ke",
+                timing="first_warning_attempt",
+                summary="Unexpected parameter should be rejected.",
+                parameters={
+                    "actor_id": "persona_chen_yu",
+                    "delay_turns": 2,
+                },
+            ),
+        )
+    except ValueError as exc:
+        assert "Unexpected parameter(s)" in str(exc)
+        assert "delay_turns" in str(exc)
+    else:
+        raise AssertionError("unexpected parameter did not fail resolution")
+
+
+def test_resolve_perturbation_payload_rejects_invalid_actor_source() -> None:
+    try:
+        resolve_perturbation_payload(
+            "fog-harbor-east-gate",
+            PerturbationPayload(
+                kind="block_contact",
+                target_id="persona_zhao_ke",
+                timing="first_warning_attempt",
+                summary="Entity actor is not valid for contact-block perturbations.",
+                parameters={"actor_id": "entity_lin_lan"},
+            ),
+        )
+    except ValueError as exc:
+        assert "does not resolve to an allowed source" in str(exc)
+    else:
+        raise AssertionError("invalid actor source did not fail resolution")
+
+
+def test_resolve_perturbation_payload_rejects_typed_parameter_failure() -> None:
+    try:
+        resolve_perturbation_payload(
+            "museum-night",
+                PerturbationPayload(
+                    kind="resource_failure",
+                    target_id="entity_west_hall_lights",
+                    timing="lighting_window",
+                    summary="Duration must remain numeric.",
+                parameters={
+                    "actor_id": "persona_mina_park",
+                    "duration_turns": "three",
+                },
+            ),
+        )
+    except ValueError as exc:
+        assert "must be an integer" in str(exc)
+    else:
+        raise AssertionError("typed parameter failure did not fail resolution")
+
+
+def test_resolve_perturbation_payload_rejects_bool_for_int_parameter() -> None:
+    try:
+        resolve_perturbation_payload(
+            "fog-harbor-east-gate",
+            PerturbationPayload(
+                kind="delay_document",
+                target_id="doc_ledger_copy",
+                timing="before_publication",
+                summary="Boolean values must not pass as integer turn counts.",
+                parameters={
+                    "actor_id": "entity_lin_lan",
+                    "delay_turns": True,
+                },
+            ),
+        )
+    except ValueError as exc:
+        assert "must be an integer" in str(exc)
+    else:
+        raise AssertionError("boolean int parameter did not fail resolution")
+
+
+def test_decision_schema_rejects_unknown_parameter_type_token() -> None:
+    try:
+        DecisionSchema.model_validate(
+            {
+                "world_id": "test-world",
+                "schema_version": "test",
+                "allowed_action_types": ["inspect"],
+                "timing_tokens": ["before_start"],
+                "perturbations": [
+                    {
+                        "kind": "delay_document",
+                        "target_sources": ["document"],
+                        "actor_sources": [],
+                        "timing_tokens": ["before_start"],
+                        "required_parameters": {"delay_turns": "integer"},
+                        "optional_parameters": {},
+                    }
+                ],
+                "decision_kernel": {
+                    "prompt_version": "rule-bounded-v1",
+                    "fallback_strategy": "first_legal_choice",
+                },
+            }
+        )
+    except ValueError as exc:
+        assert "integer" in str(exc)
+    else:
+        raise AssertionError("unknown parameter type token did not fail schema validation")
+
+
+def test_product_templates_plus_parameters_resolve_to_world_contracts() -> None:
+    product_paths = [
+        Path("data/demo/config/product.json"),
+        Path("data/worlds/museum-night/config/product.json"),
+    ]
+
+    for product_path in product_paths:
+        product = json.loads(product_path.read_text(encoding="utf-8"))
+        for option in product["perturbation_options"]:
+            runtime = option["runtime"]
+            payload = PerturbationPayload(
+                kind=runtime["kind"],
+                target_id=runtime["targetId"],
+                timing=runtime["timing"],
+                summary=option["summary"],
+                parameters={
+                    **runtime["parameters"],
+                    "actor_id": runtime["actorId"],
+                },
+            )
+
+            resolution = resolve_perturbation_payload(product["world_id"], payload)
+
+            assert resolution.schema_version == "2026-04-22"
+            assert resolution.perturbation.kind == runtime["kind"]
+            assert resolution.perturbation.target_id == runtime["targetId"]
+            assert resolution.perturbation.timing == runtime["timing"]
+            assert resolution.perturbation.parameters["actor_id"] == runtime["actorId"]
+            assert resolution.validated_parameters == runtime["parameters"]
+            assert resolution.resolution_hash
 
 
 def test_decision_kernel_replays_cached_choice(tmp_path: Path) -> None:

--- a/backend/tests/test_phase49_successor_gate.py
+++ b/backend/tests/test_phase49_successor_gate.py
@@ -34,6 +34,7 @@ def test_phase49_successor_gate_records_work_packages_and_boundaries() -> None:
         "`#383` `Phase 49 exit gate`",
         "`#384` `Phase 49: sync repo truth and protect runtime core lanes`",
         "`#386` `Phase 49: ratify kernel trace and replay contract`",
+        "`#388` `Phase 49: ratify perturbation schema and resolver authoring contract`",
         "Kernel trace and replay contract",
         "Perturbation schema and resolver contract",
         "Branch generation and compare emission policy",
@@ -66,3 +67,4 @@ def test_active_state_docs_point_to_phase49_queue() -> None:
         assert "`#383`" in text
         assert "`#384`" in text
         assert "`#386`" in text
+        assert "`#388`" in text

--- a/docs/architecture/contracts.md
+++ b/docs/architecture/contracts.md
@@ -117,6 +117,35 @@ All IDs must be serializable, stable across files, and traceable in `artifacts/`
 - `decision_schema.yaml` is the source of truth for perturbation validation.
   - user-facing labels in the frontend are not the execution contract
   - world-local stable IDs and timing tokens are the execution contract
+- The stable top-level `decision_schema.yaml` fields are:
+  - `world_id`
+  - `schema_version`
+  - `allowed_action_types`
+  - `timing_tokens`
+  - `perturbations`
+  - `decision_kernel`
+- Each `perturbations[]` item must declare:
+  - `kind`
+  - `target_sources`
+  - `actor_sources`
+  - `timing_tokens`
+  - `required_parameters`
+  - `optional_parameters`
+- Parameter declarations are typed by scalar token. V1 supported parameter type tokens are
+  `int`, `float`, `bool`, and `str`; unknown parameter type tokens must fail validation.
+- Product-facing perturbation templates may carry localized labels, summaries, and draft text,
+  but executable generation must use only the template-resolved runtime payload:
+  - `kind`
+  - `target_id`
+  - `timing`
+  - `summary`
+  - `parameters`
+  - `evidence_ids`
+- `actor_id`, when needed, is carried inside `parameters` and is resolved separately against
+  the perturbation's allowed `actor_sources`; it must not be treated as a free-form parameter.
+- Resolver output must record the normalized payload, target source class, optional actor
+  source class, resolved actor id, timing token, validated parameters, schema version, notes,
+  and one deterministic `resolution_hash`.
 
 ## Run Contract
 
@@ -306,13 +335,29 @@ All IDs must be serializable, stable across files, and traceable in `artifacts/`
 - `timing` must be deterministic and world-resolved.
   - it may be represented by turn index, named phase, or another bounded world-local timing token
 - `parameters` is the only extensibility bucket for world-specific perturbation detail in v1.
+- `parameters` must be a typed key/value map whose accepted keys are exactly the union of the
+  selected perturbation's required and optional parameter declarations plus the special
+  `actor_id` key.
 - Every perturbation payload must be resolved through the world-local decision schema before execution.
 - Resolution must record:
+  - normalized perturbation payload
   - target source class
   - actor source class when applicable
+  - resolved actor id when applicable
+  - timing token
   - validated parameters
   - schema version
   - resolution hash
+- Resolution must reject:
+  - unsupported perturbation kinds
+  - unsupported timing tokens
+  - targets outside the selected perturbation's allowed source classes
+  - actor ids outside the selected perturbation's allowed source classes
+  - missing required parameters
+  - unexpected parameters
+  - values that do not match declared scalar parameter types
+- `resolution_hash` is computed from the normalized resolved payload and schema context, not
+  from frontend display strings.
 - Free-form user text alone is not an execution contract.
   - it must be mapped into stable world-local IDs and deterministic timing before generation starts
 

--- a/docs/decisions/ADR-0006-interactive-simulator-runtime-v1.md
+++ b/docs/decisions/ADR-0006-interactive-simulator-runtime-v1.md
@@ -77,6 +77,19 @@ This ADR adds the next layer without weakening those contracts.
     - `parameters`
     - `evidence_ids`
   - user-facing composer strings are not themselves the execution contract; they must resolve into stable world-local IDs and deterministic timing before generation.
+  - product-facing templates may provide localized labels and draft summaries, but the runtime
+    contract starts only after the template resolves to `kind`, `target_id`, `timing`,
+    `summary`, typed `parameters`, and optional `evidence_ids`.
+  - `parameters` must be checked against the selected world-local `decision_schema.yaml`
+    perturbation declaration before generation starts.
+  - `actor_id` is a special resolved parameter used only when the perturbation declaration
+    permits the actor's source class.
+  - unknown perturbation kinds, timing tokens, target sources, actor sources, parameter names,
+    and parameter type mismatches must fail before branch generation.
+  - resolver output must persist enough replay context to audit generation: normalized
+    perturbation payload, target source class, optional actor source class, resolved actor id,
+    timing token, validated parameters, schema version, notes, and deterministic
+    `resolution_hash`.
 
 - Store interactive artifacts under a session namespace.
   - canonical root:
@@ -130,6 +143,7 @@ This ADR adds the next layer without weakening those contracts.
 
 - Follow-up work is still required:
   - ratify the LLM-bounded decision kernel contract
-  - expand perturbation resolution beyond preset runtime mappings
+  - expand perturbation authoring beyond preset runtime mappings only after a reviewed contract
+    maps user text to stable world-local IDs and typed parameters
   - decide whether parent-vs-child `compare.json` should always be emitted or only when requested for every runtime path
   - generalize the runtime beyond Fog Harbor-shaped outcomes and payload assumptions

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -165,12 +165,13 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening` is open.
 - `#383` `Phase 49 exit gate` is open, blocked, and protected-core.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
-- `#386` `Phase 49: ratify kernel trace and replay contract` is the current ready work item.
+- `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
+- `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is the current ready work item.
 - `audit-github-queue` reports `ready` with Phase 49 as the active milestone.
 - The first formal repository release is published as `v0.1.0`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
-- The previous local queue follow-up automation has been revoked or left paused per operator request; do not recreate an automation without a new explicit request.
+- The previous local queue follow-up automation and Mirror-specific cron/heartbeat automations have been revoked per operator request; do not recreate an automation without a new explicit request.
 
 ## Day 0 Bootstrap
 

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -232,7 +232,8 @@ This note records the completed Phase 48 successor-intake closeout and the appro
   - `gh issue list --milestone "Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening" --state all`
     - `#383` `Phase 49 exit gate` is `open`, `blocked`, and `lane:protected-core`
     - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is `closed` by PR `#385`
-    - `#386` `Phase 49: ratify kernel trace and replay contract` is the current `status:ready` protected-core work item
+    - `#386` `Phase 49: ratify kernel trace and replay contract` is `closed` by PR `#387`
+    - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is the current `status:ready` protected-core work item
 
 ## Trusted Source Of Truth
 
@@ -264,11 +265,12 @@ This note records the completed Phase 48 successor-intake closeout and the appro
 - The active successor milestone is `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`.
 - The Phase 49 exit gate is `#383` `Phase 49 exit gate`, which remains the open blocked closeout gate for this phase.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
-- `#386` `Phase 49: ratify kernel trace and replay contract` is the current ready work item.
+- `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
+- `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is the current ready work item.
 - The completed Phase 47 successor-gate baseline lives in `docs/plans/phase-47-successor-gate-2026-05-16.md`.
 - The completed Phase 48 successor-gate baseline lives in `docs/plans/phase-48-successor-gate-2026-05-17.md`.
 - The active Phase 49 successor-gate baseline lives in `docs/plans/phase-49-successor-gate-2026-05-18.md`.
 - Local untracked private-beta, kernel, and design-system planning files under `docs/plans/...` are candidate inputs only until a PR intentionally promotes them.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.
-- The previous local queue follow-up automation has been revoked or left paused per operator request; do not recreate an automation without a new explicit request.
+- The previous local queue follow-up automation and Mirror-specific cron/heartbeat automations have been revoked per operator request; do not recreate an automation without a new explicit request.

--- a/docs/plans/phase-48-successor-gate-2026-05-17.md
+++ b/docs/plans/phase-48-successor-gate-2026-05-17.md
@@ -78,8 +78,9 @@ Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening
 ```
 
 The active Phase 49 queue starts with `#383` `Phase 49 exit gate` and `#384`
-`Phase 49: sync repo truth and protect runtime core lanes`; after PR `#385`, the current
-ready work item is `#386` `Phase 49: ratify kernel trace and replay contract`.
+`Phase 49: sync repo truth and protect runtime core lanes`; after PR `#385` and `#386`
+closed through PR `#387`, the current ready work item is `#388`
+`Phase 49: ratify perturbation schema and resolver authoring contract`.
 
 ## Work Item Mapping
 

--- a/docs/plans/phase-49-successor-gate-2026-05-18.md
+++ b/docs/plans/phase-49-successor-gate-2026-05-18.md
@@ -4,7 +4,7 @@ Date: 2026-05-18
 
 Issue: `#384` `Phase 49: sync repo truth and protect runtime core lanes`
 
-Current work item: `#386` `Phase 49: ratify kernel trace and replay contract`
+Current work item: `#388` `Phase 49: ratify perturbation schema and resolver authoring contract`
 
 This note records the post-Phase-48 baseline and opens the Phase 49 successor queue.
 Phase 49 is a protected-core contract-hardening phase for the decision kernel,
@@ -63,13 +63,18 @@ Active GitHub objects:
     implementation PRs rely on automation.
 - `#386` `Phase 49: ratify kernel trace and replay contract`
   - Lane: `protected-core`.
-  - Status: current ready work item.
+  - Status: closed by PR `#387`.
   - Scope: document the v1 `decision_trace.jsonl` contract and harden replay/fallback
     trace privacy tests.
+- `#388` `Phase 49: ratify perturbation schema and resolver authoring contract`
+  - Lane: `protected-core`.
+  - Status: current ready work item.
+  - Scope: promote the world-local perturbation schema and resolver authoring contract,
+    including template-plus-parameters mapping and invalid payload rejection tests.
 
 `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
 with Phase 49 as the only open milestone, `#383` as the protected blocked exit gate, and
-`#386` as the current ready work item.
+`#388` as the current ready work item.
 
 ## Protected-Core Lane Coverage
 
@@ -164,8 +169,9 @@ Phase 49 must stay aligned with `mirror.md` and `AGENTS.md`:
 - Do not add mutating Mirror Codex MCP tools.
 - Do not promote local untracked April/private-beta planning files as durable truth without a
   reviewed PR.
-- Do not implement full perturbation, async worker, or checkpoint semantics inside `#386`;
-  `#386` only ratifies the v1 decision trace/replay contract and hardens trace privacy tests.
+- Do not implement free-form natural-language perturbation execution, async worker, or
+  checkpoint semantics inside `#388`; `#388` only ratifies the perturbation
+  schema/resolver authoring contract and hardens resolver tests.
 
 ## Validation Commands
 
@@ -186,6 +192,18 @@ python -m pytest backend/tests/test_decision_kernel.py -q
 python -m pytest backend/tests/test_cli.py -k "generate_branch or decision_trace" -q
 python -m backend.app.cli classify-lane --files docs/architecture/contracts.md docs/decisions/ADR-0007-rule-bounded-llm-kernel.md backend/app/decision_kernel/service.py backend/tests/test_decision_kernel.py backend/tests/test_cli.py docs/plans/phase-49-successor-gate-2026-05-18.md
 python scripts/check_no_secrets.py
+git diff --check
+```
+
+For `#388`, run:
+
+```powershell
+python -m pytest backend/tests/test_decision_kernel.py -q
+python -m pytest backend/tests/test_cli.py -k "generate_branch or perturbation" -q
+python -m pytest backend/tests/test_phase49_successor_gate.py backend/tests/test_automation.py -q
+python -m backend.app.cli classify-lane --files docs/architecture/contracts.md docs/decisions/ADR-0006-interactive-simulator-runtime-v1.md backend/app/perturbations/service.py backend/tests/test_decision_kernel.py backend/tests/test_cli.py docs/plans/phase-49-successor-gate-2026-05-18.md README.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 git diff --check
 ```
 

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -73,8 +73,11 @@ Local phase audits currently report:
   - first protected-core repo-truth and lane-policy work item
   - closed by PR `#385`
 - `#386` `Phase 49: ratify kernel trace and replay contract`
-  - current protected-core kernel trace/replay contract work item
-  - expected to close with the PR that documents the v1 trace contract and hardens trace privacy tests
+  - closed by PR `#387`
+  - documented the v1 trace contract and hardened trace privacy tests
+- `#388` `Phase 49: ratify perturbation schema and resolver authoring contract`
+  - current protected-core perturbation schema/resolver contract work item
+  - expected to close with the PR that documents the template-plus-parameters contract and hardens resolver tests
 - phase gate baseline
   - active Phase 49 gate note: `docs/plans/phase-49-successor-gate-2026-05-18.md`
 


### PR DESCRIPTION
## Summary

- Ratifies the Phase 49 perturbation schema/resolver authoring contract in `contracts.md` and ADR-0006.
- Hardens resolver/schema validation for strict scalar parameter tokens, bool-as-int rejection, unknown parameter type tokens, source mismatches, and product template mappings across Fog Harbor and `museum-night`.
- Syncs tracked queue docs so `#386` is closed by PR `#387` and `#388` is the current ready protected-core item; records Mirror-specific automations as revoked.

## Validation

- `python -m pytest backend/tests/test_decision_kernel.py -q` -> 16 passed
- `python -m pytest backend/tests/test_cli.py -k "generate_branch or perturbation" -q` -> 4 passed, 22 deselected
- `python -m pytest backend/tests/test_phase49_successor_gate.py backend/tests/test_automation.py -q` -> 12 passed
- `python scripts/check_no_secrets.py` -> passed
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` -> ready, #388 current ready item
- `python -m backend.app.cli classify-lane --files ...` -> lane:protected-core, risk:core-contract
- `git diff --check` -> exit 0 with LF/CRLF warnings only
- `./make.ps1 test` -> 86 passed
- `./make.ps1 eval-demo` -> pass, 23/23
- `./make.ps1 eval-transfer` -> pass, 32/32
- `./make.ps1 public-demo-check` -> passed
- `./make.ps1 plugin-check` -> passed

## Review

- Read-only reviewer found initial scalar-token issues; fixed with failing tests first.
- Final read-only reviewer reported no blocking issues in the tracked diff.

Closes #388