### PR TITLE
Phase 49 latest activity rollback contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - The completed Phase 48 successor gate lives in [docs/plans/phase-48-successor-gate-2026-05-17.md](docs/plans/phase-48-successor-gate-2026-05-17.md).
 - The active successor gate lives in [docs/plans/phase-49-successor-gate-2026-05-18.md](docs/plans/phase-49-successor-gate-2026-05-18.md).
 - Phase 48 is closed after PR `#382`, issue `#375`, and milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
-- Phase 49 is the active approved successor queue: `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; `audit-github-queue` reports `ready` with `#383` as the blocked exit gate, `#384` closed by PR `#385`, `#386` closed by PR `#387`, `#388` closed by PR `#389`, and `#390` as the current ready work item.
+- Phase 49 is the active approved successor queue: `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; `audit-github-queue` reports `ready` with `#383` as the blocked exit gate, `#384` closed by PR `#385`, `#386` closed by PR `#387`, `#388` closed by PR `#389`, `#390` closed by PR `#391`, and `#392` as the current ready work item.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
 - Fog Harbor remains the canonical demo world; `museum-night` is the minimal transfer world used to prove the pipeline is not single-world-only.
 

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 ClaimLabel = Literal["evidence_backed", "inferred", "speculative"]
@@ -211,9 +211,16 @@ class SimulationSessionManifest(MirrorBaseModel):
     active_node_id: str
     decision_config: SessionDecisionConfig = Field(default_factory=SessionDecisionConfig)
     created_at: str
+    last_activity_at: str | None = None
     scenario_path: str | None = None
     session_path: str | None = None
     nodes: list[SessionNodeRecord] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def fill_last_activity_at(self):
+        if self.last_activity_at is None:
+            self.last_activity_at = self.created_at
+        return self
 
 
 class PerturbationResolution(MirrorBaseModel):

--- a/backend/app/sessions/service.py
+++ b/backend/app/sessions/service.py
@@ -137,9 +137,10 @@ def _write_root_node(
     world_id: str,
     scenario_id: str,
     artifacts_root: Path,
+    created_at: str | None = None,
 ) -> tuple[str, SessionNodeManifest, SessionNodeRecord]:
     node_id = "node_root"
-    created_at = _created_at()
+    created_at = created_at or _created_at()
     node_path = _session_root(session_id, artifacts_root) / "nodes" / node_id / "node.json"
     node_manifest = SessionNodeManifest(
         node_id=node_id,
@@ -342,11 +343,13 @@ def start_session(
         )
     if resolved_provider == "deterministic_only":
         resolved_decision_model = None
+    created_at = _created_at()
     root_node_id, _, root_record = _write_root_node(
         session_id=session_id,
         world_id=world_id,
         scenario_id=scenario_id,
         artifacts_root=resolved_artifacts_root,
+        created_at=created_at,
     )
     session_manifest = SimulationSessionManifest(
         session_id=session_id,
@@ -358,7 +361,8 @@ def start_session(
             provider=resolved_provider,
             model_id=resolved_decision_model,
         ),
-        created_at=_created_at(),
+        created_at=created_at,
+        last_activity_at=created_at,
         nodes=[root_record],
     )
     payload = session_manifest.model_dump()
@@ -517,6 +521,7 @@ def generate_branch(
 
     session.active_node_id = child_node.node_id
     session.nodes.append(_record_for_node(child_node, resolved_artifacts_root))
+    session.last_activity_at = _created_at()
     _write_session_manifest(session, resolved_artifacts_root)
     return session
 
@@ -538,6 +543,8 @@ def rollback_session(
     _ = repo_root
     if not any(node.node_id == node_id for node in session.nodes):
         raise ValueError(f"Unknown rollback target `{node_id}` in session `{session_id}`.")
-    session.active_node_id = node_id
+    if session.active_node_id != node_id:
+        session.active_node_id = node_id
+        session.last_activity_at = _created_at()
     _write_session_manifest(session, resolved_artifacts_root)
     return session

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 import backend.app.cli as cli_module
+import backend.app.sessions.service as sessions_service
 from backend.app.cli import main
 from backend.app.config import Settings
 from backend.app.automation.service import GitHubQueueAudit, AuditCheck
@@ -29,6 +30,15 @@ def _runtime_settings(runtime_root: Path) -> Settings:
         expectations_path=settings.expectations_path,
         redlines_path=settings.redlines_path,
     )
+
+
+def _fixed_clock(*values: str):
+    remaining = iter(values)
+
+    def next_value() -> str:
+        return next(remaining)
+
+    return next_value
 
 
 def _safe_world_template_spec() -> dict:
@@ -95,10 +105,19 @@ def test_cli_start_session_outputs_json_and_writes_artifacts(tmp_path: Path, cap
     assert payload["scenario_id"] == "scenario_baseline"
     assert payload["root_node_id"] == "node_root"
     assert payload["active_node_id"] == "node_root"
+    assert payload["last_activity_at"] == payload["created_at"]
     assert payload["decision_config"]["provider"] == "openai_compatible"
     session_id = payload["session_id"]
-    assert (tmp_path / "sessions" / session_id / "session.json").exists()
+    session_path = tmp_path / "sessions" / session_id / "session.json"
+    assert session_path.exists()
     assert (tmp_path / "sessions" / session_id / "nodes" / "node_root" / "node.json").exists()
+    legacy_payload = json.loads(session_path.read_text(encoding="utf-8"))
+    legacy_payload.pop("last_activity_at")
+    session_path.write_text(json.dumps(legacy_payload, indent=2), encoding="utf-8")
+
+    assert main(["inspect-session", "--session", session_id, "--artifacts-root", str(tmp_path)]) == 0
+    inspect_payload = json.loads(capsys.readouterr().out)
+    assert inspect_payload["last_activity_at"] == inspect_payload["created_at"]
 
 
 def test_cli_create_world_writes_runtime_world_pack(tmp_path: Path, capsys, monkeypatch) -> None:
@@ -724,7 +743,20 @@ def test_cli_generate_branch_from_existing_child_node(tmp_path: Path, capsys) ->
     assert (tmp_path / second_child["decision_trace_path"]).exists()
 
 
-def test_cli_rollback_session_moves_active_pointer(tmp_path: Path, capsys) -> None:
+def test_cli_rollback_session_moves_active_pointer(tmp_path: Path, capsys, monkeypatch) -> None:
+    monkeypatch.setattr(
+        sessions_service,
+        "_created_at",
+        _fixed_clock(
+            "2026-05-18T00:00:00+00:00",
+            "2026-05-18T00:00:01+00:00",
+            "2026-05-18T00:00:02+00:00",
+            "2026-05-18T00:00:03+00:00",
+            "2026-05-18T00:00:04+00:00",
+            "2026-05-18T00:00:05+00:00",
+            "2026-05-18T00:00:06+00:00",
+        ),
+    )
     settings = get_settings()
     assert main(["ingest", str(settings.manifest_path), "--out", str(tmp_path / "ingest")]) == 0
     assert main(["build-graph", str(tmp_path / "ingest" / "chunks.jsonl"), "--out", str(tmp_path / "graph")]) == 0
@@ -747,6 +779,7 @@ def test_cli_rollback_session_moves_active_pointer(tmp_path: Path, capsys) -> No
     )
     session_payload = json.loads(capsys.readouterr().out)
     session_id = session_payload["session_id"]
+    assert session_payload["last_activity_at"] == session_payload["created_at"]
     perturbation = json.dumps(
         {
             "kind": "delay_document",
@@ -777,7 +810,16 @@ def test_cli_rollback_session_moves_active_pointer(tmp_path: Path, capsys) -> No
         == 0
     )
     generated_payload = json.loads(capsys.readouterr().out)
-    assert generated_payload["active_node_id"] != "node_root"
+    generated_child_id = generated_payload["active_node_id"]
+    assert generated_child_id != "node_root"
+    assert generated_payload["last_activity_at"] > session_payload["last_activity_at"]
+    generated_child = json.loads(
+        (tmp_path / "sessions" / session_id / "nodes" / generated_child_id / "node.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    generated_report_path = tmp_path / generated_child["report_path"]
+    generated_compare_path = tmp_path / generated_child["compare_path"]
 
     assert (
         main(
@@ -795,6 +837,66 @@ def test_cli_rollback_session_moves_active_pointer(tmp_path: Path, capsys) -> No
     )
     rollback_payload = json.loads(capsys.readouterr().out)
     assert rollback_payload["active_node_id"] == "node_root"
+    assert rollback_payload["last_activity_at"] > generated_payload["last_activity_at"]
+    assert any(node["node_id"] == generated_child_id for node in rollback_payload["nodes"])
+    assert generated_report_path.exists()
+    assert generated_compare_path.exists()
+
+    assert (
+        main(
+            [
+                "rollback-session",
+                "--session",
+                session_id,
+                "--to",
+                "node_root",
+                "--artifacts-root",
+                str(tmp_path),
+            ]
+        )
+        == 0
+    )
+    repeated_rollback_payload = json.loads(capsys.readouterr().out)
+    assert repeated_rollback_payload["active_node_id"] == "node_root"
+    assert repeated_rollback_payload["last_activity_at"] == rollback_payload["last_activity_at"]
+
+    sibling_perturbation = json.dumps(
+        {
+            "kind": "block_contact",
+            "target_id": "persona_zhao_ke",
+            "timing": "first_warning_attempt",
+            "summary": "Block the deputy-mayor escalation path after rollback to the baseline.",
+            "parameters": {
+                "actor_id": "persona_chen_yu",
+                "cause": "signal_scramble",
+            },
+        }
+    )
+    assert (
+        main(
+            [
+                "generate-branch",
+                "--session",
+                session_id,
+                "--from",
+                "node_root",
+                "--perturbation",
+                sibling_perturbation,
+                "--artifacts-root",
+                str(tmp_path),
+            ]
+        )
+        == 0
+    )
+    sibling_payload = json.loads(capsys.readouterr().out)
+    assert sibling_payload["active_node_id"] != generated_child_id
+    assert sibling_payload["last_activity_at"] > rollback_payload["last_activity_at"]
+    assert len(sibling_payload["nodes"]) == 3
+    assert {node["node_id"] for node in sibling_payload["nodes"]} >= {
+        "node_root",
+        generated_child_id,
+        sibling_payload["active_node_id"],
+    }
 
 
 def _load_fixture(name: str) -> dict:

--- a/backend/tests/test_frontend_runtime_activity.py
+++ b/backend/tests/test_frontend_runtime_activity.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_frontend_runtime_locator_uses_last_activity_with_created_at_fallback() -> None:
+    source = (REPO_ROOT / "frontend/src/app/lib/runtime-session-data.ts").read_text(encoding="utf-8")
+
+    assert "last_activity_at?: string | null;" in source
+    assert "lastActivityAt: session.last_activity_at ?? session.created_at" in source
+    assert "new Date(right.lastActivityAt).getTime() - new Date(left.lastActivityAt).getTime()" in source
+
+
+def test_world_cards_sort_by_latest_activity_not_creation_time() -> None:
+    source = (REPO_ROOT / "frontend/src/app/lib/world-product-data.ts").read_text(encoding="utf-8")
+
+    assert "lastActivityAt: latestSession.lastActivityAt" in source
+    assert "left.latestSession.lastActivityAt" in source
+    assert "right.latestSession.lastActivityAt" in source

--- a/backend/tests/test_phase49_successor_gate.py
+++ b/backend/tests/test_phase49_successor_gate.py
@@ -36,6 +36,7 @@ def test_phase49_successor_gate_records_work_packages_and_boundaries() -> None:
         "`#386` `Phase 49: ratify kernel trace and replay contract`",
         "`#388` `Phase 49: ratify perturbation schema and resolver authoring contract`",
         "`#390` `Phase 49: ratify runtime parent-child compare emission policy`",
+        "`#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope`",
         "Kernel trace and replay contract",
         "Perturbation schema and resolver contract",
         "Branch generation and compare emission policy",
@@ -46,7 +47,8 @@ def test_phase49_successor_gate_records_work_packages_and_boundaries() -> None:
         "Do not present Mirror as a real-world prediction machine",
         "Do not build real-person personas or digital doubles",
         "TODO[verify]: Codex UI tool-card",
-        "TODO[verify]: Latest-session versus latest-activity",
+        "Latest-session versus latest-activity semantics are now ratified",
+        "Checkpoint rollback remains deferred",
     ]
     for phrase in required_phrases:
         assert phrase in gate
@@ -70,3 +72,4 @@ def test_active_state_docs_point_to_phase49_queue() -> None:
         assert "`#386`" in text
         assert "`#388`" in text
         assert "`#390`" in text
+        assert "`#392`" in text

--- a/docs/architecture/contracts.md
+++ b/docs/architecture/contracts.md
@@ -316,6 +316,12 @@ All IDs must be serializable, stable across files, and traceable in `artifacts/`
   - rollback does not delete nodes
   - rollback does not rewrite run artifacts
   - rollback to baseline means setting `active_node_id` back to the root node
+- `last_activity_at` is the session ordering timestamp for product surfaces.
+  - new sessions set `last_activity_at` equal to `created_at`
+  - successful `generate-branch` updates `last_activity_at` after the child node and artifacts are materialized
+  - successful `rollback-session` updates `last_activity_at` after the active pointer changes
+  - rollback to the current active node leaves `last_activity_at` unchanged
+  - failed generation or rollback does not ratify a v1 activity update
 - V1 does not introduce task queues or a separate `task_id` contract.
   - TODO[verify]: if web-triggered generation needs long-running worker semantics, ratify `task_id` in a follow-up ADR instead of widening v1 now.
 
@@ -388,11 +394,14 @@ All IDs must be serializable, stable across files, and traceable in `artifacts/`
   - `root_node_id`
   - `active_node_id`
   - `decision_config`
+  - `created_at`
+  - `last_activity_at`
   - `nodes`
 - `decision_config` must publish:
   - `provider`
   - `model_id`
 - `active_node_id` is the only rollback-sensitive field.
+- Readers of older session manifests without `last_activity_at` must fall back to `created_at`.
 - Re-perturbing from any node creates a new sibling or child node; it never overwrites prior descendants.
 
 ## Interactive Artifact Contract

--- a/docs/decisions/ADR-0006-interactive-simulator-runtime-v1.md
+++ b/docs/decisions/ADR-0006-interactive-simulator-runtime-v1.md
@@ -67,6 +67,13 @@ This ADR adds the next layer without weakening those contracts.
   - rollback does not rewrite prior run artifacts
   - re-perturbing from any node creates a new child node
 
+- Freeze session activity ordering.
+  - `created_at` records session creation time
+  - `last_activity_at` records the latest successful generated branch or rollback activity
+  - new sessions initialize `last_activity_at` from `created_at`
+  - older session manifests without `last_activity_at` remain readable by falling back to `created_at`
+  - rollback to the current active node does not update activity time because no pointer moved
+
 - Freeze the minimum perturbation execution payload.
   - required:
     - `kind`

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -167,7 +167,8 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.
-- `#390` `Phase 49: ratify runtime parent-child compare emission policy` is the current ready work item.
+- `#390` `Phase 49: ratify runtime parent-child compare emission policy` is closed by PR `#391`.
+- `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope` is the current ready work item.
 - `audit-github-queue` reports `ready` with Phase 49 as the active milestone.
 - The first formal repository release is published as `v0.1.0`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -234,7 +234,8 @@ This note records the completed Phase 48 successor-intake closeout and the appro
     - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is `closed` by PR `#385`
     - `#386` `Phase 49: ratify kernel trace and replay contract` is `closed` by PR `#387`
     - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is `closed` by PR `#389`
-    - `#390` `Phase 49: ratify runtime parent-child compare emission policy` is the current `status:ready` protected-core work item
+    - `#390` `Phase 49: ratify runtime parent-child compare emission policy` is `closed` by PR `#391`
+    - `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope` is the current `status:ready` protected-core work item
 
 ## Trusted Source Of Truth
 
@@ -268,7 +269,8 @@ This note records the completed Phase 48 successor-intake closeout and the appro
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.
-- `#390` `Phase 49: ratify runtime parent-child compare emission policy` is the current ready work item.
+- `#390` `Phase 49: ratify runtime parent-child compare emission policy` is closed by PR `#391`.
+- `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope` is the current ready work item.
 - The completed Phase 47 successor-gate baseline lives in `docs/plans/phase-47-successor-gate-2026-05-16.md`.
 - The completed Phase 48 successor-gate baseline lives in `docs/plans/phase-48-successor-gate-2026-05-17.md`.
 - The active Phase 49 successor-gate baseline lives in `docs/plans/phase-49-successor-gate-2026-05-18.md`.

--- a/docs/plans/phase-48-successor-gate-2026-05-17.md
+++ b/docs/plans/phase-48-successor-gate-2026-05-17.md
@@ -79,8 +79,9 @@ Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening
 
 The active Phase 49 queue starts with `#383` `Phase 49 exit gate` and `#384`
 `Phase 49: sync repo truth and protect runtime core lanes`; after PR `#385`, `#386`
-closed through PR `#387`, and `#388` closed through PR `#389`, the current ready work
-item is `#390` `Phase 49: ratify runtime parent-child compare emission policy`.
+closed through PR `#387`, `#388` closed through PR `#389`, and `#390` closed
+through PR `#391`, the current ready work item is `#392`
+`Phase 49: ratify runtime latest-activity metadata and rollback scope`.
 
 ## Work Item Mapping
 

--- a/docs/plans/phase-49-successor-gate-2026-05-18.md
+++ b/docs/plans/phase-49-successor-gate-2026-05-18.md
@@ -4,7 +4,7 @@ Date: 2026-05-18
 
 Issue: `#384` `Phase 49: sync repo truth and protect runtime core lanes`
 
-Current work item: `#390` `Phase 49: ratify runtime parent-child compare emission policy`
+Current work item: `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope`
 
 This note records the post-Phase-48 baseline and opens the Phase 49 successor queue.
 Phase 49 is a protected-core contract-hardening phase for the decision kernel,
@@ -73,13 +73,18 @@ Active GitHub objects:
     including template-plus-parameters mapping and invalid payload rejection tests.
 - `#390` `Phase 49: ratify runtime parent-child compare emission policy`
   - Lane: `protected-core`.
-  - Status: current ready work item.
+  - Status: closed by PR `#391`.
   - Scope: ratify that every successful generated runtime child node emits a session-scoped
     parent-vs-child compare artifact without changing scenario-level compare contracts.
+- `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope`
+  - Lane: `protected-core`.
+  - Status: current ready work item.
+  - Scope: ratify `last_activity_at` as the product-facing session ordering timestamp and
+    preserve v1 rollback as active-pointer movement without deleting or rewriting artifacts.
 
 `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
 with Phase 49 as the only open milestone, `#383` as the protected blocked exit gate, and
-`#390` as the current ready work item.
+`#392` as the current ready work item.
 
 ## Protected-Core Lane Coverage
 
@@ -103,8 +108,9 @@ public demo artifact layout, or the Mirror Codex MCP contract.
 
 - TODO[verify]: Codex UI tool-card evidence remains open until a clean Codex app session
   shows observable MCP tool or resource cards/traces for the Mirror Codex plugin.
-- TODO[verify]: Latest-session versus latest-activity semantics need a contract decision
-  before more world-card or launch-hub affordances depend on activity ordering.
+- Latest-session versus latest-activity semantics are now ratified as `last_activity_at`
+  ordering with `created_at` fallback; TODO[verify]: re-open contract review before adding
+  other activity sources or changing failed-operation activity behavior.
 - The first `decision_trace.jsonl` v1 field set is now ratified in
   `docs/architecture/contracts.md`; TODO[verify]: re-open contract review before adding new
   trace fields, changing validation status values, or widening provider output persistence.
@@ -115,7 +121,9 @@ public demo artifact layout, or the Mirror Codex MCP contract.
 - Every successful generated non-root runtime node now emits a session-scoped parent-vs-child
   compare output; TODO[verify]: re-open contract review before making runtime compare
   emission optional or changing reference-branch selection away from the immediate parent.
-- TODO[verify]: Decide whether checkpoint rollback exists in Phase 49 or remains deferred.
+- Checkpoint rollback remains deferred; v1 rollback only moves `active_node_id`.
+  TODO[verify]: re-open contract review before adding deletion, mutation, retry, or restore
+  semantics beyond pointer movement.
 - TODO[verify]: Identify which Fog Harbor-shaped report and eval assumptions still block a
   stronger `museum-night` transfer proof.
 - TODO[verify]: Define what measured generation duration would justify `task_id` and worker
@@ -141,7 +149,8 @@ public demo artifact layout, or the Mirror Codex MCP contract.
 4. Rollback, checkpoint, and latest-activity semantics
    - Keep v1 rollback as `active_node_id` pointer movement until a new contract says
      otherwise.
-   - Decide whether a `last_activity_at` field or equivalent runtime metadata is required.
+   - Ratify `last_activity_at` as the runtime metadata used to order product session
+     affordances, with fallback for older manifests that only have `created_at`.
 
 5. Fog Harbor de-specialization and transfer evals
    - Remove or document remaining Fog Harbor-shaped assumptions before claiming broader
@@ -177,8 +186,8 @@ Phase 49 must stay aligned with `mirror.md` and `AGENTS.md`:
 - Do not promote local untracked April/private-beta planning files as durable truth without a
   reviewed PR.
 - Do not implement free-form natural-language perturbation execution, async worker,
-  checkpoint semantics, or frontend compare UI inside `#390`; `#390` only ratifies runtime
-  compare emission policy and hardens CLI/session artifact tests.
+  checkpoint mutation/deletion semantics, transfer expansion, or frontend compare UI inside
+  `#392`; `#392` only ratifies latest-activity metadata and pointer-only rollback scope.
 
 ## Validation Commands
 
@@ -220,6 +229,18 @@ For `#390`, run:
 python -m pytest backend/tests/test_cli.py -k "generate_branch or compare" -q
 python -m pytest backend/tests/test_phase49_successor_gate.py backend/tests/test_automation.py -q
 python -m backend.app.cli classify-lane --files docs/architecture/contracts.md docs/decisions/ADR-0006-interactive-simulator-runtime-v1.md backend/app/sessions/service.py backend/tests/test_cli.py docs/plans/phase-49-successor-gate-2026-05-18.md README.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+git diff --check
+```
+
+For `#392`, run:
+
+```powershell
+python -m pytest backend/tests/test_cli.py -k "start_session or generate_branch or rollback_session" -q
+python -m pytest backend/tests/test_frontend_runtime_activity.py -q
+python -m pytest backend/tests/test_phase49_successor_gate.py backend/tests/test_automation.py -q
+python -m backend.app.cli classify-lane --files docs/architecture/contracts.md docs/decisions/ADR-0006-interactive-simulator-runtime-v1.md backend/app/domain/models.py backend/app/sessions/service.py backend/tests/test_cli.py backend/tests/test_frontend_runtime_activity.py frontend/src/app/lib/runtime-session-data.ts frontend/src/app/lib/world-product-data.ts docs/plans/phase-49-successor-gate-2026-05-18.md README.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
 python scripts/check_no_secrets.py
 python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 git diff --check

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -79,8 +79,11 @@ Local phase audits currently report:
   - closed by PR `#389`
   - documented the template-plus-parameters contract and hardened resolver tests
 - `#390` `Phase 49: ratify runtime parent-child compare emission policy`
-  - current protected-core runtime compare emission work item
-  - expected to close with the PR that ratifies unconditional session-scoped parent-vs-child compare emission for generated runtime nodes
+  - closed by PR `#391`
+  - ratified unconditional session-scoped parent-vs-child compare emission for generated runtime nodes
+- `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope`
+  - current protected-core runtime activity and rollback scope work item
+  - expected to close with the PR that ratifies `last_activity_at` and pointer-only rollback scope
 - phase gate baseline
   - active Phase 49 gate note: `docs/plans/phase-49-successor-gate-2026-05-18.md`
 

--- a/frontend/src/app/README.md
+++ b/frontend/src/app/README.md
@@ -37,8 +37,8 @@ Private-beta candidate product routes:
 - `/worlds/[worldId]/runtime/[sessionId]/explain` is the world-scoped live explain view
 - `/worlds/[worldId]/runtime/[sessionId]/report` is the world-scoped live report view
 - `/worlds/[worldId]/review` is the world-scoped review surface, with scorecard + inline branch digest + report/claims previews
-- world home, perturb, and review automatically pick up the latest session by `session.created_at` for the world when no explicit session query is present, then use that session's `active_node_id`
-- TODO[verify]: Decide whether a future Launch Hub should use latest session creation time, latest activity time, or a separate `last_activity_at` contract
+- world home, perturb, and review automatically pick up the latest session by `session.last_activity_at ?? session.created_at` for the world when no explicit session query is present, then use that session's `active_node_id`
+- `last_activity_at` is updated only after successful branch generation or rollback; older manifests fall back to `created_at`
 - canonical product metadata now supports locale-aware world names, summaries, baselines, and perturbation labels; self-serve worlds continue to display the language the user entered
 - main product-shell terms on the private-beta candidate path are being normalized alongside locale-aware world metadata, so Chinese mode no longer mixes core route labels with obvious English operator wording
 - runtime result cards now prefer world-defined outcome labels from product metadata instead of exposing raw outcome field keys directly

--- a/frontend/src/app/lib/runtime-session-data.ts
+++ b/frontend/src/app/lib/runtime-session-data.ts
@@ -43,6 +43,7 @@ export type RuntimeSessionManifest = {
     model_id: string | null;
   };
   created_at: string;
+  last_activity_at?: string | null;
   scenario_path?: string | null;
   session_path?: string | null;
   nodes: RuntimeSessionNodeRecord[];
@@ -142,6 +143,7 @@ export type RuntimeSessionLocator = {
   sessionId: string;
   activeNodeId: string;
   createdAt: string;
+  lastActivityAt: string;
 };
 
 export type RuntimeClaimDrilldown = {
@@ -191,6 +193,7 @@ async function listRuntimeSessionLocatorsForWorld(
               sessionId: session.session_id,
               activeNodeId: session.active_node_id,
               createdAt: session.created_at,
+              lastActivityAt: session.last_activity_at ?? session.created_at,
             } satisfies RuntimeSessionLocator;
           } catch {
             return null;
@@ -202,7 +205,7 @@ async function listRuntimeSessionLocatorsForWorld(
       .filter((manifest): manifest is RuntimeSessionLocator => Boolean(manifest))
       .sort(
         (left, right) =>
-          new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime()
+          new Date(right.lastActivityAt).getTime() - new Date(left.lastActivityAt).getTime()
       );
   } catch {
     return [];

--- a/frontend/src/app/lib/world-product-data.ts
+++ b/frontend/src/app/lib/world-product-data.ts
@@ -65,6 +65,7 @@ export type ProductWorldSummary = {
     runtimeHref: string;
     reviewHref: string;
     createdAt: string;
+    lastActivityAt: string;
   } | null;
 };
 
@@ -254,14 +255,15 @@ export async function listProductWorlds(locale: AppLocale = "en"): Promise<Produ
               runtimeHref: `/worlds/${worldId}/runtime/${latestSession.sessionId}?node=${encodeURIComponent(latestWorkspace.selectedNode.node_id)}`,
               reviewHref: `/worlds/${worldId}/review?session=${encodeURIComponent(latestSession.sessionId)}&node=${encodeURIComponent(latestWorkspace.selectedNode.node_id)}`,
               createdAt: latestSession.createdAt,
+              lastActivityAt: latestSession.lastActivityAt,
             }
           : null,
       };
     })
   );
   return summaries.sort((left, right) => {
-    const leftTime = left.latestSession ? new Date(left.latestSession.createdAt).getTime() : 0;
-    const rightTime = right.latestSession ? new Date(right.latestSession.createdAt).getTime() : 0;
+    const leftTime = left.latestSession ? new Date(left.latestSession.lastActivityAt).getTime() : 0;
+    const rightTime = right.latestSession ? new Date(right.latestSession.lastActivityAt).getTime() : 0;
     return rightTime - leftTime;
   });
 }


### PR DESCRIPTION
## Summary
- Adds the v1 `session.last_activity_at` contract, initialized from `created_at` and normalized for legacy manifests that lack the field.
- Updates successful `generate-branch` and pointer-changing `rollback-session` flows to refresh activity ordering while preserving pointer-only rollback scope.
- Updates frontend session/world-card selection to sort by `last_activity_at ?? created_at`.
- Syncs Phase 49 queue docs after #390 closed and marks #392 as current.

Closes #392

## Review notes
- Red tests first failed on missing backend `last_activity_at` and frontend sorting contract.
- Read-only review found a backend legacy fallback gap and an open question around rollback to the current node.
- Fixed by normalizing `last_activity_at` in `SimulationSessionManifest` and preserving timestamp on repeated rollback to the already active node.
- Focused re-review found no blocking issues.

## Protected-core evidence
- Lane classification: `lane:protected-core`, `risk:core-contract`.
- Protected hits: `backend/app/domain/models.py`, `backend/app/sessions/service.py`, `docs/architecture/contracts.md`, `docs/decisions/ADR-0006-interactive-simulator-runtime-v1.md`.

## Validation
- `python -m pytest backend/tests/test_cli.py -k "start_session or generate_branch or rollback_session" -q` -> 8 passed, 18 deselected
- `python -m pytest backend/tests/test_frontend_runtime_activity.py -q` -> 2 passed
- `python -m pytest backend/tests/test_phase49_successor_gate.py backend/tests/test_automation.py -q` -> 12 passed
- `python scripts/check_no_secrets.py` -> Secret scan passed
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` -> ready with #392 current
- `python -m backend.app.cli classify-lane --files ...` -> protected-core
- `git diff --check` -> exit 0; only LF/CRLF warnings
- `./make.ps1 test` -> 88 passed
- `./make.ps1 eval-demo` -> pass 23/23
- `./make.ps1 eval-transfer` -> pass 32/32
- `./make.ps1 public-demo-check` -> passed
- `./make.ps1 plugin-check` -> passed