### PR TITLE
Phase 49: strengthen transfer eval outcome coverage

### DIFF
--- a/.github/automation/lane-policy.json
+++ b/.github/automation/lane-policy.json
@@ -19,6 +19,7 @@
     "backend/app/automation/",
     "backend/app/decision_kernel/",
     "backend/app/domain/",
+    "backend/app/evals/",
     "backend/app/model_access/",
     "backend/app/perturbations/",
     "backend/app/scenarios/",

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - The completed Phase 48 successor gate lives in [docs/plans/phase-48-successor-gate-2026-05-17.md](docs/plans/phase-48-successor-gate-2026-05-17.md).
 - The active successor gate lives in [docs/plans/phase-49-successor-gate-2026-05-18.md](docs/plans/phase-49-successor-gate-2026-05-18.md).
 - Phase 48 is closed after PR `#382`, issue `#375`, and milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
-- Phase 49 is the active approved successor queue: `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; `audit-github-queue` reports `ready` with `#383` as the blocked exit gate, `#384` closed by PR `#385`, `#386` closed by PR `#387`, `#388` closed by PR `#389`, `#390` closed by PR `#391`, and `#392` as the current ready work item.
+- Phase 49 is the active approved successor queue: `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; `audit-github-queue` reports `ready` with `#383` as the blocked exit gate, `#384` closed by PR `#385`, `#386` closed by PR `#387`, `#388` closed by PR `#389`, `#390` closed by PR `#391`, `#392` closed by PR `#393`, and `#394` as the current ready work item.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
 - Fog Harbor remains the canonical demo world; `museum-night` is the minimal transfer world used to prove the pipeline is not single-world-only.
 

--- a/backend/app/evals/service.py
+++ b/backend/app/evals/service.py
@@ -76,6 +76,33 @@ def _load_run_payloads(artifacts_root: Path) -> dict[str, dict[str, Any]]:
     return run_payloads
 
 
+def _run_has_outcome_field(summary: dict[str, Any], field: str) -> bool:
+    final_state = summary.get("final_state", {})
+    return field in summary or (isinstance(final_state, dict) and field in final_state)
+
+
+def _compare_outcome_fields(compare_payload: dict[str, Any]) -> set[str]:
+    fields: set[str] = set()
+    for delta in compare_payload.get("reference_deltas", []):
+        fields.update(delta.get("outcome_deltas", {}).keys())
+    return fields
+
+
+def _changed_compare_outcome_fields(
+    compare_payload: dict[str, Any],
+    *,
+    branch_id: str | None = None,
+) -> set[str]:
+    fields: set[str] = set()
+    for delta in compare_payload.get("reference_deltas", []):
+        if branch_id is not None and delta.get("branch_id") != branch_id:
+            continue
+        for field, outcome_delta in delta.get("outcome_deltas", {}).items():
+            if outcome_delta.get("reference") != outcome_delta.get("candidate"):
+                fields.add(field)
+    return fields
+
+
 def _redline_texts(artifacts_root: Path) -> dict[str, str]:
     graph_path = artifacts_root / "graph" / "graph.json"
     personas_path = artifacts_root / "personas" / "personas.json"
@@ -397,6 +424,39 @@ def evaluate_transfer_world(world_paths: WorldPaths) -> EvalResult:
     scenario_json_paths = sorted((artifacts_root / "scenario").glob("*.json"))
     run_summary_paths = sorted((artifacts_root / "run").glob("*/summary.json"))
     compare_json_paths = sorted(compare_root.glob("*/compare.json"))
+    plan = load_simulation_plan(world_paths.simulation_rules_path)
+    tracked_outcome_fields = [outcome.field for outcome in plan.tracked_outcomes]
+    tracked_outcome_set = set(tracked_outcome_fields)
+    run_summaries = [read_json(path) for path in run_summary_paths]
+    run_covered_fields = {
+        field
+        for field in tracked_outcome_fields
+        if run_summaries and all(_run_has_outcome_field(summary, field) for summary in run_summaries)
+    }
+    compare_payloads = [read_json(path) for path in compare_json_paths]
+    compare_covered_fields = (
+        set().union(*[_compare_outcome_fields(payload) for payload in compare_payloads])
+        if compare_payloads
+        else set()
+    )
+    changed_fields = (
+        set().union(*[_changed_compare_outcome_fields(payload) for payload in compare_payloads])
+        if compare_payloads
+        else set()
+    )
+    changed_tracked_fields = tracked_outcome_set & changed_fields
+    default_report_branch_id = f"branch_{plan.default_report_scenario}"
+    default_report_changed_fields = (
+        set().union(
+            *[
+                _changed_compare_outcome_fields(payload, branch_id=default_report_branch_id)
+                for payload in compare_payloads
+            ]
+        )
+        if compare_payloads
+        else set()
+    )
+    default_report_changed_tracked_fields = tracked_outcome_set & default_report_changed_fields
 
     failures: list[str] = []
     checks_total = 0
@@ -434,6 +494,28 @@ def evaluate_transfer_world(world_paths: WorldPaths) -> EvalResult:
     record("report_exists", report_path.exists(), f"Missing {report_path}")
     record("claims_exist", claims_path.exists(), f"Missing {claims_path}")
     record("compare_exists", len(compare_json_paths) >= 1, "Expected at least one compare artifact.")
+    missing_run_fields = sorted(tracked_outcome_set - run_covered_fields)
+    record(
+        "tracked_outcomes_in_run_summaries",
+        not missing_run_fields,
+        "Missing tracked outcome fields in run summaries: " + ", ".join(missing_run_fields),
+    )
+    missing_compare_fields = sorted(tracked_outcome_set - compare_covered_fields)
+    record(
+        "tracked_outcomes_in_compare",
+        not missing_compare_fields,
+        "Missing tracked outcome fields in compare deltas: " + ", ".join(missing_compare_fields),
+    )
+    record(
+        "tracked_outcomes_have_semantic_delta",
+        bool(changed_tracked_fields),
+        "No tracked outcome changed in compare deltas.",
+    )
+    record(
+        "default_report_scenario_has_semantic_delta",
+        bool(default_report_changed_tracked_fields),
+        f"`{plan.default_report_scenario}` did not change any tracked outcome against baseline.",
+    )
     record("claims_labeled", all(claim.get("label") for claim in claims), "Every claim must carry a label.")
     record(
         "claims_have_evidence",
@@ -471,6 +553,16 @@ def evaluate_transfer_world(world_paths: WorldPaths) -> EvalResult:
             "checks_total": checks_total,
             "checks_passed": checks_passed,
             "failed_checks": len(failures),
+            "tracked_outcome_count": len(tracked_outcome_fields),
+            "tracked_outcome_fields_covered": len(run_covered_fields),
+            "compare_outcome_fields_covered": len(tracked_outcome_set & compare_covered_fields),
+            "changed_tracked_outcome_count": len(changed_tracked_fields),
+            "default_report_changed_outcome_count": len(default_report_changed_tracked_fields),
+            "transfer_proof_world_local": (
+                len(run_covered_fields) == len(tracked_outcome_fields)
+                and len(tracked_outcome_set & compare_covered_fields) == len(tracked_outcome_fields)
+                and bool(default_report_changed_tracked_fields)
+            ),
         },
         failures=failures,
         notes=[
@@ -526,6 +618,22 @@ def run_transfer_eval(world_ids: list[str] | None = None, *, repo_root: Path | N
             "checks_total": sum(result.metrics.get("checks_total", 0) for result in world_results),
             "checks_passed": sum(result.metrics.get("checks_passed", 0) for result in world_results),
             "failed_checks": len(failures),
+            "tracked_outcome_count": sum(result.metrics.get("tracked_outcome_count", 0) for result in world_results),
+            "tracked_outcome_fields_covered": sum(
+                result.metrics.get("tracked_outcome_fields_covered", 0) for result in world_results
+            ),
+            "compare_outcome_fields_covered": sum(
+                result.metrics.get("compare_outcome_fields_covered", 0) for result in world_results
+            ),
+            "changed_tracked_outcome_count": sum(
+                result.metrics.get("changed_tracked_outcome_count", 0) for result in world_results
+            ),
+            "transfer_worlds_with_default_report_delta": sum(
+                1 for result in world_results if result.metrics.get("default_report_changed_outcome_count", 0) > 0
+            ),
+            "transfer_proof_world_local": all(
+                result.metrics.get("transfer_proof_world_local") is True for result in world_results
+            ),
         },
         failures=failures,
         notes=[f"{result.world_id}: {result.status}" for result in world_results],

--- a/backend/tests/test_automation.py
+++ b/backend/tests/test_automation.py
@@ -41,6 +41,7 @@ def test_classify_paths_marks_bootstrap_and_automation_changes_protected() -> No
 def test_classify_paths_marks_phase49_runtime_core_paths_protected() -> None:
     phase49_core_paths = [
         "backend/app/decision_kernel/service.py",
+        "backend/app/evals/service.py",
         "backend/app/perturbations/service.py",
         "backend/app/sessions/service.py",
         "backend/app/model_access/service.py",

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -991,6 +991,11 @@ def test_cli_eval_transfer_outputs_json(capsys) -> None:
     payload = json.loads(capsys.readouterr().out)
     assert payload["world_id"] == "transfer"
     assert payload["status"] == "pass"
+    assert payload["metrics"]["tracked_outcome_count"] == 13
+    assert payload["metrics"]["tracked_outcome_fields_covered"] == 13
+    assert payload["metrics"]["compare_outcome_fields_covered"] == 13
+    assert payload["metrics"]["transfer_worlds_with_default_report_delta"] == 2
+    assert payload["metrics"]["transfer_proof_world_local"] is True
 
 
 def test_safety_blocks_redline_payload() -> None:

--- a/backend/tests/test_phase49_successor_gate.py
+++ b/backend/tests/test_phase49_successor_gate.py
@@ -37,6 +37,7 @@ def test_phase49_successor_gate_records_work_packages_and_boundaries() -> None:
         "`#388` `Phase 49: ratify perturbation schema and resolver authoring contract`",
         "`#390` `Phase 49: ratify runtime parent-child compare emission policy`",
         "`#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope`",
+        "`#394` `Phase 49: strengthen transfer eval outcome coverage`",
         "Kernel trace and replay contract",
         "Perturbation schema and resolver contract",
         "Branch generation and compare emission policy",
@@ -49,6 +50,7 @@ def test_phase49_successor_gate_records_work_packages_and_boundaries() -> None:
         "TODO[verify]: Codex UI tool-card",
         "Latest-session versus latest-activity semantics are now ratified",
         "Checkpoint rollback remains deferred",
+        "Fog Harbor-shaped report and eval assumptions are now inventoried",
     ]
     for phrase in required_phrases:
         assert phrase in gate
@@ -73,3 +75,4 @@ def test_active_state_docs_point_to_phase49_queue() -> None:
         assert "`#388`" in text
         assert "`#390`" in text
         assert "`#392`" in text
+        assert "`#394`" in text

--- a/backend/tests/test_worlds.py
+++ b/backend/tests/test_worlds.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import json
+from dataclasses import replace
 from pathlib import Path
 
-from backend.app.evals.service import run_world_eval
+from backend.app.evals.service import evaluate_transfer_world, run_world_eval
 from backend.app.simulation.rules import load_simulation_plan
 from backend.app.worlds import CANONICAL_DEMO_WORLD_ID, resolve_world_paths
+
+
+def _museum_world_paths(artifacts_root: Path):
+    return replace(resolve_world_paths("museum-night"), artifacts_root=artifacts_root)
 
 
 def test_resolve_world_paths_supports_canonical_and_transfer_world() -> None:
@@ -31,5 +37,50 @@ def test_museum_night_world_eval_passes(tmp_path: Path) -> None:
     assert result.status == "pass"
     assert result.world_id == "museum-night"
     assert result.metrics["scenario_count"] == 2
+    assert result.metrics["tracked_outcome_count"] == 5
+    assert result.metrics["tracked_outcome_fields_covered"] == 5
+    assert result.metrics["compare_outcome_fields_covered"] == 5
+    assert result.metrics["changed_tracked_outcome_count"] >= 1
+    assert result.metrics["default_report_changed_outcome_count"] >= 1
+    assert result.metrics["transfer_proof_world_local"] is True
     assert Path(result.artifact_paths["report"]).exists()
     assert Path(result.artifact_paths["eval"]).exists()
+
+
+def test_transfer_world_eval_fails_when_tracked_outcome_missing_from_runs(tmp_path: Path) -> None:
+    artifacts_root = tmp_path / "museum-night"
+    run_world_eval("museum-night", artifacts_root=artifacts_root)
+
+    for summary_path in artifacts_root.glob("run/*/summary.json"):
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        summary.get("final_state", {}).pop("opening_status", None)
+        summary.pop("opening_status", None)
+        summary_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+    result = evaluate_transfer_world(_museum_world_paths(artifacts_root))
+
+    assert result.status == "fail"
+    assert result.metrics["tracked_outcome_fields_covered"] == 4
+    assert any("tracked_outcomes_in_run_summaries" in failure for failure in result.failures)
+
+
+def test_transfer_world_eval_fails_when_tracked_outcomes_do_not_change(tmp_path: Path) -> None:
+    artifacts_root = tmp_path / "museum-night"
+    run_world_eval("museum-night", artifacts_root=artifacts_root)
+
+    compare_path = artifacts_root / "compare" / "scenario_museum_night_matrix" / "compare.json"
+    compare_payload = json.loads(compare_path.read_text(encoding="utf-8"))
+    for delta in compare_payload["reference_deltas"]:
+        for outcome_delta in delta["outcome_deltas"].values():
+            outcome_delta["candidate"] = outcome_delta["reference"]
+            outcome_delta["delta"] = 0
+    compare_path.write_text(json.dumps(compare_payload, indent=2) + "\n", encoding="utf-8")
+
+    result = evaluate_transfer_world(_museum_world_paths(artifacts_root))
+
+    assert result.status == "fail"
+    assert result.metrics["changed_tracked_outcome_count"] == 0
+    assert result.metrics["default_report_changed_outcome_count"] == 0
+    assert result.metrics["transfer_proof_world_local"] is False
+    assert any("tracked_outcomes_have_semantic_delta" in failure for failure in result.failures)
+    assert any("default_report_scenario_has_semantic_delta" in failure for failure in result.failures)

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -168,7 +168,8 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.
 - `#390` `Phase 49: ratify runtime parent-child compare emission policy` is closed by PR `#391`.
-- `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope` is the current ready work item.
+- `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope` is closed by PR `#393`.
+- `#394` `Phase 49: strengthen transfer eval outcome coverage` is the current ready work item.
 - `audit-github-queue` reports `ready` with Phase 49 as the active milestone.
 - The first formal repository release is published as `v0.1.0`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -235,7 +235,8 @@ This note records the completed Phase 48 successor-intake closeout and the appro
     - `#386` `Phase 49: ratify kernel trace and replay contract` is `closed` by PR `#387`
     - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is `closed` by PR `#389`
     - `#390` `Phase 49: ratify runtime parent-child compare emission policy` is `closed` by PR `#391`
-    - `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope` is the current `status:ready` protected-core work item
+    - `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope` is `closed` by PR `#393`
+    - `#394` `Phase 49: strengthen transfer eval outcome coverage` is the current `status:ready` protected-core work item
 
 ## Trusted Source Of Truth
 
@@ -270,7 +271,8 @@ This note records the completed Phase 48 successor-intake closeout and the appro
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.
 - `#390` `Phase 49: ratify runtime parent-child compare emission policy` is closed by PR `#391`.
-- `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope` is the current ready work item.
+- `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope` is closed by PR `#393`.
+- `#394` `Phase 49: strengthen transfer eval outcome coverage` is the current ready work item.
 - The completed Phase 47 successor-gate baseline lives in `docs/plans/phase-47-successor-gate-2026-05-16.md`.
 - The completed Phase 48 successor-gate baseline lives in `docs/plans/phase-48-successor-gate-2026-05-17.md`.
 - The active Phase 49 successor-gate baseline lives in `docs/plans/phase-49-successor-gate-2026-05-18.md`.

--- a/docs/plans/phase-48-successor-gate-2026-05-17.md
+++ b/docs/plans/phase-48-successor-gate-2026-05-17.md
@@ -79,9 +79,9 @@ Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening
 
 The active Phase 49 queue starts with `#383` `Phase 49 exit gate` and `#384`
 `Phase 49: sync repo truth and protect runtime core lanes`; after PR `#385`, `#386`
-closed through PR `#387`, `#388` closed through PR `#389`, and `#390` closed
-through PR `#391`, the current ready work item is `#392`
-`Phase 49: ratify runtime latest-activity metadata and rollback scope`.
+closed through PR `#387`, `#388` closed through PR `#389`, `#390` closed
+through PR `#391`, and `#392` closed through PR `#393`, the current ready work
+item is `#394` `Phase 49: strengthen transfer eval outcome coverage`.
 
 ## Work Item Mapping
 

--- a/docs/plans/phase-49-successor-gate-2026-05-18.md
+++ b/docs/plans/phase-49-successor-gate-2026-05-18.md
@@ -4,7 +4,7 @@ Date: 2026-05-18
 
 Issue: `#384` `Phase 49: sync repo truth and protect runtime core lanes`
 
-Current work item: `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope`
+Current work item: `#394` `Phase 49: strengthen transfer eval outcome coverage`
 
 This note records the post-Phase-48 baseline and opens the Phase 49 successor queue.
 Phase 49 is a protected-core contract-hardening phase for the decision kernel,
@@ -78,13 +78,18 @@ Active GitHub objects:
     parent-vs-child compare artifact without changing scenario-level compare contracts.
 - `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope`
   - Lane: `protected-core`.
-  - Status: current ready work item.
+  - Status: closed by PR `#393`.
   - Scope: ratify `last_activity_at` as the product-facing session ordering timestamp and
     preserve v1 rollback as active-pointer movement without deleting or rewriting artifacts.
+- `#394` `Phase 49: strengthen transfer eval outcome coverage`
+  - Lane: `protected-core`.
+  - Status: current ready work item.
+  - Scope: strengthen two-world transfer eval assertions by checking world-local tracked
+    outcome coverage and recording remaining Fog Harbor-shaped assumptions.
 
 `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
 with Phase 49 as the only open milestone, `#383` as the protected blocked exit gate, and
-`#392` as the current ready work item.
+`#394` as the current ready work item.
 
 ## Protected-Core Lane Coverage
 
@@ -92,6 +97,7 @@ Phase 49 work is protected-core by default because it can affect durable runtime
 The lane policy must treat these paths as protected before implementation work begins:
 
 - `backend/app/decision_kernel/`
+- `backend/app/evals/`
 - `backend/app/perturbations/`
 - `backend/app/sessions/`
 - `backend/app/model_access/`
@@ -124,8 +130,10 @@ public demo artifact layout, or the Mirror Codex MCP contract.
 - Checkpoint rollback remains deferred; v1 rollback only moves `active_node_id`.
   TODO[verify]: re-open contract review before adding deletion, mutation, retry, or restore
   semantics beyond pointer movement.
-- TODO[verify]: Identify which Fog Harbor-shaped report and eval assumptions still block a
-  stronger `museum-night` transfer proof.
+- Fog Harbor-shaped report and eval assumptions are now inventoried in
+  `docs/plans/phase-49-transfer-assumption-inventory-2026-05-18.md`; TODO[verify]:
+  re-open contract review before removing legacy `RunTrace` fields or claiming transfer
+  beyond the two-world proof.
 - TODO[verify]: Define what measured generation duration would justify `task_id` and worker
   semantics instead of keeping the CLI-first synchronous contract.
 
@@ -153,8 +161,8 @@ public demo artifact layout, or the Mirror Codex MCP contract.
      affordances, with fallback for older manifests that only have `created_at`.
 
 5. Fog Harbor de-specialization and transfer evals
-   - Remove or document remaining Fog Harbor-shaped assumptions before claiming broader
-     transfer strength.
+   - Inventory remaining Fog Harbor-shaped assumptions before claiming broader transfer
+     strength.
    - Extend transfer assertions from `museum-night` before adding another world.
 
 6. Runtime orchestration decision
@@ -186,8 +194,9 @@ Phase 49 must stay aligned with `mirror.md` and `AGENTS.md`:
 - Do not promote local untracked April/private-beta planning files as durable truth without a
   reviewed PR.
 - Do not implement free-form natural-language perturbation execution, async worker,
-  checkpoint mutation/deletion semantics, transfer expansion, or frontend compare UI inside
-  `#392`; `#392` only ratifies latest-activity metadata and pointer-only rollback scope.
+  checkpoint mutation/deletion semantics, third-world expansion, report rewrites, or frontend
+  compare UI inside `#394`; `#394` only strengthens transfer eval outcome coverage and records
+  the current transfer assumption inventory.
 
 ## Validation Commands
 
@@ -244,6 +253,19 @@ python -m backend.app.cli classify-lane --files docs/architecture/contracts.md d
 python scripts/check_no_secrets.py
 python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
 git diff --check
+```
+
+For `#394`, run:
+
+```powershell
+python -m pytest backend/tests/test_worlds.py -q
+python -m pytest backend/tests/test_cli.py -k "eval_world or eval_transfer" -q
+python -m pytest backend/tests/test_phase49_successor_gate.py backend/tests/test_automation.py -q
+python -m backend.app.cli classify-lane --files .github/automation/lane-policy.json backend/app/evals/service.py backend/tests/test_worlds.py backend/tests/test_cli.py backend/tests/test_phase49_successor_gate.py backend/tests/test_automation.py docs/plans/phase-49-transfer-assumption-inventory-2026-05-18.md docs/plans/phase-49-successor-gate-2026-05-18.md README.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+git diff --check
+./make.ps1 eval-transfer
 ```
 
 For later Phase 49 implementation PRs, add the issue-specific checks:

--- a/docs/plans/phase-49-transfer-assumption-inventory-2026-05-18.md
+++ b/docs/plans/phase-49-transfer-assumption-inventory-2026-05-18.md
@@ -1,0 +1,56 @@
+# Phase 49 Transfer Assumption Inventory
+
+Date: 2026-05-18
+
+Issue: `#394` `Phase 49: strengthen transfer eval outcome coverage`
+
+This note records the current Fog Harbor-shaped assumptions before Phase 49 claims any stronger
+transfer posture. It does not add a third world and does not change scenario DSL, compare shape,
+claim shape, public demo artifact layout, plugin behavior, or runtime orchestration.
+
+## Transfer Baseline
+
+- Fog Harbor remains the canonical public demo world and keeps `eval-demo` as its regression
+  command.
+- `museum-night` remains the second bounded fictional world used by `eval-transfer`.
+- `eval-transfer` is still a two-world proof, not a general claim that every future world will
+  work without additional contracts.
+- Transfer checks must be driven by each world's `config/simulation_rules.yaml`, not by
+  Fog Harbor object IDs or field names.
+
+## Intentional Compatibility
+
+- `RunTrace` still carries nullable top-level Fog Harbor-era fields such as
+  `ledger_public_turn`, `budget_exposed_turn`, and `evacuation_turn`.
+  - These fields remain compatibility surface for the canonical demo and older readers.
+  - Transfer worlds must be evaluated through `final_state` plus world-local tracked outcomes
+    when those top-level fields do not apply.
+- `eval-demo` may keep Fog Harbor-specific object IDs, event IDs, and expected outcomes because
+  it is the canonical demo regression.
+- Report generation is intentionally generic at the transfer layer: report claims are selected
+  from world-local tracked outcomes in `simulation_rules.yaml`.
+- Transfer redline checks sample world-local graph, persona, and event IDs rather than fixed
+  Fog Harbor IDs.
+
+## Remaining Blockers
+
+- Do not remove or rename legacy `RunTrace` top-level fields without a dedicated contract
+  decision and migration plan.
+- Do not claim transfer beyond the current two-world proof until another reviewed issue adds
+  either a third world or a stronger compatibility contract.
+- Do not add world-specific Python constants for `museum-night`; a transfer regression should
+  fail because generic rule-driven checks fail, not because a hardcoded museum field is missing.
+- Do not widen runtime orchestration into `task_id`, workers, retries, status states, or cleanup
+  as part of transfer hardening.
+
+## Ratified Phase 49 Check
+
+`evaluate_transfer_world` now verifies:
+
+- every world-local tracked outcome appears in each run summary or `final_state`;
+- every world-local tracked outcome appears in compare outcome deltas;
+- the default report scenario changes at least one tracked outcome against baseline;
+- claim labels, `evidence_ids`, evidence resolution, and redline checks still run.
+
+This keeps the proof stronger than artifact existence while remaining bounded to fictional,
+authorized worlds.

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -82,8 +82,11 @@ Local phase audits currently report:
   - closed by PR `#391`
   - ratified unconditional session-scoped parent-vs-child compare emission for generated runtime nodes
 - `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope`
-  - current protected-core runtime activity and rollback scope work item
-  - expected to close with the PR that ratifies `last_activity_at` and pointer-only rollback scope
+  - closed by PR `#393`
+  - ratified `last_activity_at` and pointer-only rollback scope
+- `#394` `Phase 49: strengthen transfer eval outcome coverage`
+  - current protected-core transfer eval outcome coverage work item
+  - expected to close with the PR that strengthens world-local tracked-outcome coverage and records Fog Harbor-shaped transfer assumptions
 - phase gate baseline
   - active Phase 49 gate note: `docs/plans/phase-49-successor-gate-2026-05-18.md`
 


### PR DESCRIPTION
## Summary
- Strengthen transfer evals so each world-local tracked outcome must appear in run summaries/final_state and compare deltas.
- Require semantic tracked-outcome movement for the default report scenario, with aggregate transfer metrics.
- Add the Phase 49 transfer assumption inventory and protect `backend/app/evals/` in lane classification.

Closes #394

## Validation
- `python -m pytest backend/tests/test_worlds.py -q` -> 5 passed
- `python -m pytest backend/tests/test_cli.py -k "eval_world or eval_transfer" -q` -> 2 passed, 24 deselected
- `python -m pytest backend/tests/test_phase49_successor_gate.py backend/tests/test_automation.py -q` -> 12 passed
- `python scripts/check_no_secrets.py` -> passed
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` -> ready for #394
- `python -m backend.app.cli classify-lane --files ...` -> lane:protected-core
- `git diff --check` / `git diff --cached --check` -> no whitespace errors
- `./make.ps1 test` -> 90 passed
- `./make.ps1 eval-demo` -> pass (23/23)
- `./make.ps1 eval-transfer` -> pass (40/40), 13 tracked outcomes covered
- `./make.ps1 public-demo-check` -> pass
- `./make.ps1 plugin-check` -> pass

## Protected-core note
This PR changes transfer eval contract checks and lane governance. It does not change scenario DSL, compare artifact shape, claim/evidence shape, public demo artifact layout, plugin behavior, or runtime orchestration semantics.