### PR TITLE
Phase 50 product boundary decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,9 +233,10 @@ Current private-beta candidate entrypoints:
 - `/worlds/<world_id>/runtime/<session_id>/report` -> live report workspace
 - `/worlds/<world_id>/review` -> world-scoped review surface
 
-TODO[verify]: Decide whether a future private-beta launch hub should conditionally replace
-`/`, live at a separate route, or remain a planning-only concept. Current tracked code keeps
-`/` as the public demo.
+Phase 50 Product Boundary Decision (`#401`): the private-beta launch hub remains planning-only for now.
+Current tracked code keeps `/` as the public demo, and any future private-beta launch hub route
+requires a separate reviewed route contract before replacing `/` or widening public/plugin
+behavior. See `docs/plans/phase-50-product-boundary-2026-05-18.md`.
 
 ---
 
@@ -268,7 +269,7 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - The active successor gate lives in [docs/plans/phase-50-successor-gate-2026-05-18.md](docs/plans/phase-50-successor-gate-2026-05-18.md).
 - Phase 48 is closed after PR `#382`, issue `#375`, and milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
 - Phase 49 is closed after PR `#395`, issue `#383`, and milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; completed work items were `#384`, `#386`, `#388`, `#390`, `#392`, and `#394`.
-- Phase 50 is the active approved successor queue: `Phase 50 - Runtime Orchestration Measurement and Product Boundary`; `audit-github-queue` reports `ready` with `#396` as the blocked exit gate, `#397` as the current ready repo-truth sync item, and `#398` blocked until the Phase 50 baseline lands. Phase 50 measures before any `task_id` or worker contract is introduced.
+- Phase 50 is the active approved successor queue: `Phase 50 - Runtime Orchestration Measurement and Product Boundary`; `audit-github-queue` reports `ready` with `#396` as the blocked exit gate, `#397` closed by PR `#399`, `#398` closed by PR `#400`, and `#401` as the current ready product-boundary item. Phase 50 measures before any `task_id` or worker contract is introduced and keeps the private-beta launch hub planning-only for now.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
 - Fog Harbor remains the canonical demo world; `museum-night` is the minimal transfer world used to prove the pipeline is not single-world-only.
 

--- a/backend/tests/test_phase50_product_boundary_note.py
+++ b/backend/tests/test_phase50_product_boundary_note.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+NOTE_PATH = Path("docs/plans/phase-50-product-boundary-2026-05-18.md")
+
+
+def test_phase50_product_boundary_note_exists_with_required_sections() -> None:
+    assert NOTE_PATH.exists()
+
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    required_sections = [
+        "# Phase 50 Product Boundary Decision",
+        "Issue: `#401`",
+        "## Decision",
+        "## Evidence",
+        "## Public Demo Boundary",
+        "## Plugin Boundary",
+        "## Private-Beta Boundary",
+        "## Follow-Up Gate",
+        "## Non-Goals",
+        "## Validation Commands",
+    ]
+    for section in required_sections:
+        assert section in note
+
+
+def test_phase50_product_boundary_note_records_public_private_plugin_boundary() -> None:
+    assert NOTE_PATH.exists()
+
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    required_phrases = [
+        "launch hub remains planning-only for now",
+        "`/` remains the guided public demo",
+        "`/worlds/<world_id>` remains the private-beta candidate product path",
+        "Mirror Codex plugin remains read-only",
+        "does not start sessions, generate branches, upload corpus data, create worlds, enable Hosted GPT, accept BYOK, or call the OpenAI API",
+        "Do not add Hosted GPT, BYOK, upload, auth, billing, database, object storage, or quota behavior to the public path or plugin path",
+        "TODO[verify]: open a reviewed route contract before replacing `/` or adding a private-beta launch hub route",
+    ]
+    for phrase in required_phrases:
+        assert phrase in note
+
+
+def test_active_phase50_docs_point_to_product_boundary_work() -> None:
+    required_docs = [
+        Path("README.md"),
+        Path("docs/plans/current-state-baseline.md"),
+        Path("docs/plans/phase-execution-queue.md"),
+        Path("docs/plans/phase-50-successor-gate-2026-05-18.md"),
+    ]
+
+    for path in required_docs:
+        text = path.read_text(encoding="utf-8")
+        assert "`#397`" in text
+        assert "`#398`" in text
+        assert "`#401`" in text
+        assert "launch hub remains planning-only for now" in text
+        assert "Phase 50 Product Boundary Decision" in text

--- a/backend/tests/test_phase50_successor_gate.py
+++ b/backend/tests/test_phase50_successor_gate.py
@@ -12,7 +12,8 @@ def test_phase50_successor_gate_exists_with_required_sections() -> None:
     gate = PHASE50_GATE_PATH.read_text(encoding="utf-8")
     required_sections = [
         "# Phase 50 Successor Gate",
-        "Issue: `#397` `Phase 50: sync repo truth after Phase 49 closeout`",
+        "Issue: `#401` `Phase 50: ratify private-beta launch hub and public-path boundary`",
+        "Current work item: `#401` `Phase 50: ratify private-beta launch hub and public-path boundary`",
         "## Phase 49 Closeout Evidence",
         "## Phase 50 Operational Queue",
         "## Protected-Core Lane Coverage",
@@ -45,6 +46,8 @@ def test_phase50_successor_gate_records_queue_and_boundaries() -> None:
         "Do not recreate local Codex automations without a new explicit operator request",
         "`docs/plans/phase-50-runtime-generation-duration-measurement-2026-05-18.md`",
         "Keep synchronous generation for v1",
+        "`#401` `Phase 50: ratify private-beta launch hub and public-path boundary`",
+        "`docs/plans/phase-50-product-boundary-2026-05-18.md`",
     ]
     for phrase in required_phrases:
         assert phrase in gate

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -241,8 +241,13 @@ This note records the completed Phase 49 contract-hardening closeout and the app
     - milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening` is `closed`
   - `gh issue list --milestone "Phase 50 - Runtime Orchestration Measurement and Product Boundary" --state all`
     - `#396` `Phase 50 exit gate` is `open`, `blocked`, and `lane:protected-core`
-    - `#397` `Phase 50: sync repo truth after Phase 49 closeout` is the current `status:ready` protected-core work item
-    - `#398` `Phase 50: measure runtime generation duration before task_id decision` is `blocked` until the Phase 50 baseline lands
+    - `#397` `Phase 50: sync repo truth after Phase 49 closeout` is `closed` by PR `#399`
+    - `#398` `Phase 50: measure runtime generation duration before task_id decision` is `closed` by PR `#400`
+    - `#401` `Phase 50: ratify private-beta launch hub and public-path boundary` is the current `status:ready` protected-core work item
+  - Phase 50 Product Boundary Decision:
+    - launch hub remains planning-only for now
+    - `/` remains the guided public demo
+    - `docs/plans/phase-50-product-boundary-2026-05-18.md` records the boundary note
 
 ## Trusted Source Of Truth
 
@@ -274,8 +279,10 @@ This note records the completed Phase 49 contract-hardening closeout and the app
 - The Phase 49 unlock order is resolved: `#384` closed through PR `#385`, `#386` closed through PR `#387`, `#388` closed through PR `#389`, `#390` closed through PR `#391`, `#392` closed through PR `#393`, `#394` closed through PR `#395`, and `#383` closed after the post-merge exit-gate reassessment.
 - The active successor milestone is `Phase 50 - Runtime Orchestration Measurement and Product Boundary`.
 - The Phase 50 exit gate is `#396` `Phase 50 exit gate`, which remains the open blocked closeout gate for this phase.
-- `#397` `Phase 50: sync repo truth after Phase 49 closeout` is the current ready work item.
-- `#398` `Phase 50: measure runtime generation duration before task_id decision` is blocked until the Phase 50 baseline lands.
+- `#397` `Phase 50: sync repo truth after Phase 49 closeout` is closed by PR `#399`.
+- `#398` `Phase 50: measure runtime generation duration before task_id decision` is closed by PR `#400`.
+- `#401` `Phase 50: ratify private-beta launch hub and public-path boundary` is the current ready work item.
+- Phase 50 Product Boundary Decision: launch hub remains planning-only for now; current tracked code keeps `/` as the guided public demo.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.

--- a/docs/plans/phase-50-product-boundary-2026-05-18.md
+++ b/docs/plans/phase-50-product-boundary-2026-05-18.md
@@ -1,0 +1,109 @@
+# Phase 50 Product Boundary Decision
+
+Date: 2026-05-18
+
+Issue: `#401` `Phase 50: ratify private-beta launch hub and public-path boundary`
+
+## Decision
+
+The private-beta launch hub remains planning-only for now.
+
+`/` remains the guided Phase 1 public Fog Harbor demo. `/review` remains the advanced
+read-only review surface. The current private-beta candidate product path remains
+world-scoped under `/worlds/<world_id>` and related runtime routes when public-demo flags are
+disabled in local or explicitly authorized private-beta environments. Do not replace `/`, add
+a private-beta launch hub route, or move private-beta capabilities into the public path
+without a separate reviewed route contract.
+
+This chooses the conservative Phase 50 option: keep the launch hub as a planning concept
+until a later PR explicitly ratifies route ownership, access mode, public-demo interaction,
+and deployment posture.
+
+## Evidence
+
+- `README.md` documents `/` as the guided public demo and lists private-beta candidate
+  entrypoints separately under `/worlds/<world_id>`.
+- `docs/deploy/render-public-demo.md` states that `/` loads the guided public demo and that
+  runtime mutation endpoints return `403` in public demo mode.
+- `docs/architecture/contracts.md` states that Phase 1 public demo mode does not start
+  sessions, generate branches, upload corpus data, create worlds, enable Hosted GPT, accept
+  BYOK, or call the OpenAI API.
+- `docs/deploy/mirror-codex-plugin.md` states that the Mirror Codex plugin is for read-only
+  inspection of the deterministic public demo and must not upload data, call model
+  providers, create worlds, mutate runtime state, or require private configuration.
+- The current frontend route layout already has world-scoped private-beta candidate routes
+  such as `/worlds/<world_id>`, `/worlds/new`, `/worlds/<world_id>/perturb`,
+  `/worlds/<world_id>/runtime/<session_id>`, `/worlds/<world_id>/runtime/<session_id>/explain`,
+  `/worlds/<world_id>/runtime/<session_id>/report`, and `/worlds/<world_id>/review`.
+
+## Public Demo Boundary
+
+`/` remains the guided public demo, and `/review` remains the advanced read-only review
+surface.
+
+The public demo remains read-only, anonymous, deterministic-only, and artifact-backed. It
+does not start sessions, generate branches, upload corpus data, create worlds, enable Hosted GPT, accept BYOK, or call the OpenAI API.
+
+Public demo mode must keep runtime mutation endpoints disabled. Public API responses must not
+expose absolute repository paths, runtime paths, provider secrets, or arbitrary path lookup
+results.
+
+## Plugin Boundary
+
+Mirror Codex plugin remains read-only.
+
+The plugin remains scoped to deterministic public-demo inspection. It must not gain mutating
+MCP tools, runtime mutation, Hosted GPT, BYOK, uploads, auth, billing, database, object
+storage, quota behavior, provider calls, or filesystem-path disclosure without a separate
+reviewed plugin contract.
+
+## Private-Beta Boundary
+
+`/worlds/<world_id>` remains the private-beta candidate product path.
+
+Private-beta runtime behavior may continue to use explicitly configured local or authorized
+deployment settings. Hosted private-beta model access remains server-side only, beta-gated,
+quota-limited, and disabled by default. Browser-submitted BYO credentials remain
+request-scoped and must not be persisted into session, node, report, claims, or decision-trace
+artifacts.
+
+The private-beta launch hub remains planning-only for now because the route ownership,
+deployment posture, and public-demo interaction are not yet ratified.
+
+## Follow-Up Gate
+
+- TODO[verify]: open a reviewed route contract before replacing `/` or adding a private-beta launch hub route.
+- TODO[verify]: if the launch hub becomes an implementation target, decide whether it lives
+  behind a separate route, an authenticated/private deployment flag, or another explicit
+  product boundary.
+- TODO[verify]: keep untracked April/private-beta planning notes as candidate inputs only
+  until a PR intentionally promotes them.
+
+## Non-Goals
+
+- Do not implement a new launch hub route or change `/` in `#401`.
+- Do not change public demo behavior.
+- Do not change Mirror Codex plugin MCP tools or resources.
+- Do not add mutating Mirror Codex MCP tools.
+- Do not implement async workers, queues, `task_id`, retry, status, cleanup, checkpoint
+  mutation/deletion, or restore semantics.
+- Do not add Hosted GPT, BYOK, upload, auth, billing, database, object storage, or quota behavior to the public path or plugin path.
+- Do not change session or node manifest shape.
+- Do not change compare artifact shape.
+- Do not change scenario DSL, claim labels, report claim `evidence_ids`, run trace shape, or
+  public demo artifact layout or plugin MCP contract.
+- Do not build real-person personas, digital doubles, political persuasion, law-enforcement,
+  hiring, credit, medical, or judicial decision systems.
+- Do not present Mirror as real-world prediction or package simulation output as certain
+  real-world conclusions.
+
+## Validation Commands
+
+```powershell
+python -m pytest backend/tests/test_phase50_product_boundary_note.py backend/tests/test_phase50_successor_gate.py backend/tests/test_automation.py -q
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md docs/plans/phase-50-successor-gate-2026-05-18.md docs/plans/phase-50-product-boundary-2026-05-18.md backend/tests/test_phase50_product_boundary_note.py backend/tests/test_phase50_successor_gate.py
+git diff --check
+./make.ps1 eval-demo
+```

--- a/docs/plans/phase-50-successor-gate-2026-05-18.md
+++ b/docs/plans/phase-50-successor-gate-2026-05-18.md
@@ -2,9 +2,9 @@
 
 Date: 2026-05-18
 
-Issue: `#397` `Phase 50: sync repo truth after Phase 49 closeout`
+Issue: `#401` `Phase 50: ratify private-beta launch hub and public-path boundary`
 
-Current work item: `#397` `Phase 50: sync repo truth after Phase 49 closeout`
+Current work item: `#401` `Phase 50: ratify private-beta launch hub and public-path boundary`
 
 This note records the post-Phase-49 baseline and opens the Phase 50 successor queue.
 Phase 50 is a protected-core measurement and boundary phase for runtime orchestration.
@@ -65,17 +65,22 @@ Active GitHub objects:
   - Status: blocked closeout gate for Phase 50.
 - `#397` `Phase 50: sync repo truth after Phase 49 closeout`
   - Lane: `protected-core`.
-  - Status: current ready work item.
+  - Status: closed by PR `#399`.
   - Scope: sync tracked docs to Phase 50 after closing Phase 49.
 - `#398` `Phase 50: measure runtime generation duration before task_id decision`
   - Lane: `protected-core`.
-  - Status: blocked until `#397` lands.
+  - Status: closed by PR `#400`.
   - Scope: measure the current runtime branch-generation path and decide whether to keep
     synchronous v1 generation or open a dedicated async-orchestration ADR.
+- `#401` `Phase 50: ratify private-beta launch hub and public-path boundary`
+  - Lane: `protected-core`.
+  - Status: current ready work item.
+  - Scope: record the Phase 50 Product Boundary Decision, keep launch hub remains planning-only for now,
+    and preserve public demo/plugin/hosted-model boundaries before any product-path widening.
 
 `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
 with Phase 50 as the only open milestone, `#396` as the protected blocked exit gate, and
-`#397` as the current ready work item.
+`#401` as the current ready work item.
 
 ## Protected-Core Lane Coverage
 
@@ -134,8 +139,11 @@ public demo artifact layout, or the Mirror Codex MCP contract.
   Current local deterministic measurements support: Keep synchronous generation for v1.
   TODO[verify]: rerun hosted/private-beta model measurements before introducing `task_id`,
   worker, retry, status, or cleanup semantics.
-- TODO[verify]: Decide whether a future private-beta launch hub should conditionally replace
-  `/`, live at a separate route, or remain a planning-only concept.
+- Phase 50 Product Boundary Decision is now recorded in
+  `docs/plans/phase-50-product-boundary-2026-05-18.md`.
+  The launch hub remains planning-only for now; `/` remains the guided public demo.
+  TODO[verify]: open a reviewed route contract before replacing `/` or adding a private-beta
+  launch hub route.
 
 ## Phase 50 Work Package Map
 
@@ -153,7 +161,9 @@ public demo artifact layout, or the Mirror Codex MCP contract.
      async orchestration.
 
 3. Product boundary follow-up
-   - Keep private-beta route and launch-hub language explicit.
+   - Recorded the Phase 50 Product Boundary Decision in
+     `docs/plans/phase-50-product-boundary-2026-05-18.md`.
+   - Decision: launch hub remains planning-only for now.
    - Do not move public demo, plugin, or hosted-model behavior without a separate reviewed
      contract decision.
 
@@ -174,9 +184,9 @@ Phase 50 must stay aligned with `mirror.md` and `AGENTS.md`:
 ## Non-Goals
 
 - Do not implement async workers, queues, `task_id`, retry, status, cleanup, checkpoint
-  mutation/deletion, or restore semantics inside `#397`.
+  mutation/deletion, or restore semantics inside `#401`.
 - Do not change scenario DSL, claim/evidence shape, run trace shape, compare artifact shape,
-  public demo artifact layout, or plugin MCP tool/resource contract in `#397`.
+  public demo artifact layout, or plugin MCP tool/resource contract in `#401`.
 - Do not add Hosted GPT, BYOK, upload, auth, billing, database, object storage, or quota
   behavior to the public path or plugin path.
 - Do not add mutating Mirror Codex MCP tools.
@@ -203,5 +213,16 @@ For `#398`, run:
 python scripts/check_no_secrets.py
 python -m backend.app.cli classify-lane --files docs/architecture/contracts.md docs/decisions/ADR-0006-interactive-simulator-runtime-v1.md backend/app/sessions/service.py frontend/src/app/api/runtime/generate-branch/route.ts
 python -m pytest backend/tests/test_cli.py -k "start_session or generate_branch" -q
+./make.ps1 eval-demo
+```
+
+For `#401`, run:
+
+```powershell
+python -m pytest backend/tests/test_phase50_product_boundary_note.py backend/tests/test_phase50_successor_gate.py backend/tests/test_automation.py -q
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md docs/plans/phase-50-successor-gate-2026-05-18.md docs/plans/phase-50-product-boundary-2026-05-18.md backend/tests/test_phase50_product_boundary_note.py backend/tests/test_phase50_successor_gate.py
+git diff --check
 ./make.ps1 eval-demo
 ```

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -71,11 +71,14 @@ Local phase audits currently report:
   - open and blocked
   - labeled `lane:protected-core` because it is the protected closeout gate
 - `#397` `Phase 50: sync repo truth after Phase 49 closeout`
-  - current protected-core repo-truth work item
-  - expected to close with the PR that syncs durable docs to Phase 50
+  - closed by PR `#399`
+  - synced durable docs to Phase 50
 - `#398` `Phase 50: measure runtime generation duration before task_id decision`
-  - blocked until the Phase 50 baseline lands
-  - will measure runtime generation duration before any async orchestration ADR or implementation
+  - closed by PR `#400`
+  - recorded that synchronous v1 generation remains the current contract
+- `#401` `Phase 50: ratify private-beta launch hub and public-path boundary`
+  - current protected-core product-boundary work item
+  - Phase 50 Product Boundary Decision: launch hub remains planning-only for now
 - phase gate baseline
   - active Phase 50 gate note: `docs/plans/phase-50-successor-gate-2026-05-18.md`
 


### PR DESCRIPTION
## Summary
- Ratify the Phase 50 Product Boundary Decision: the private-beta launch hub remains planning-only for now.
- Keep `/` as the guided public demo and `/worlds/<world_id>` as the private-beta candidate product path.
- Sync active docs so #397/#398 are closed and #401 is the current ready product-boundary item.

## Boundary
- No new launch hub route and no `/` replacement in this PR.
- No public demo behavior change.
- No Mirror Codex plugin MCP tool/resource change.
- No Hosted GPT, BYOK, upload, auth, billing, database, object storage, or quota behavior is added to public/plugin paths.

## Validation
- `python -m pytest backend/tests/test_phase50_product_boundary_note.py backend/tests/test_phase50_successor_gate.py backend/tests/test_automation.py -q`
- `python scripts/check_no_secrets.py`
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
- `python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md docs/plans/phase-50-successor-gate-2026-05-18.md docs/plans/phase-50-product-boundary-2026-05-18.md backend/tests/test_phase50_product_boundary_note.py backend/tests/test_phase50_successor_gate.py`
- `git diff --check`
- `./make.ps1 eval-demo`
- `./make.ps1 test`

Closes #401.