### PR TITLE
Phase 51 repo truth sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,10 +266,12 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - The completed Phase 47 successor gate lives in [docs/plans/phase-47-successor-gate-2026-05-16.md](docs/plans/phase-47-successor-gate-2026-05-16.md).
 - The completed Phase 48 successor gate lives in [docs/plans/phase-48-successor-gate-2026-05-17.md](docs/plans/phase-48-successor-gate-2026-05-17.md).
 - The completed Phase 49 successor gate lives in [docs/plans/phase-49-successor-gate-2026-05-18.md](docs/plans/phase-49-successor-gate-2026-05-18.md).
-- The active successor gate lives in [docs/plans/phase-50-successor-gate-2026-05-18.md](docs/plans/phase-50-successor-gate-2026-05-18.md).
+- The completed Phase 50 successor gate lives in [docs/plans/phase-50-successor-gate-2026-05-18.md](docs/plans/phase-50-successor-gate-2026-05-18.md).
+- The active successor gate lives in [docs/plans/phase-51-successor-gate-2026-05-18.md](docs/plans/phase-51-successor-gate-2026-05-18.md).
 - Phase 48 is closed after PR `#382`, issue `#375`, and milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
 - Phase 49 is closed after PR `#395`, issue `#383`, and milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; completed work items were `#384`, `#386`, `#388`, `#390`, `#392`, and `#394`.
-- Phase 50 is the active approved successor queue: `Phase 50 - Runtime Orchestration Measurement and Product Boundary`; `audit-github-queue` reports `ready` with `#396` as the blocked exit gate, `#397` closed by PR `#399`, `#398` closed by PR `#400`, and `#401` as the current ready product-boundary item. Phase 50 measures before any `task_id` or worker contract is introduced and keeps the private-beta launch hub planning-only for now.
+- Phase 50 is closed after PR `#402`, issue `#396`, and milestone `Phase 50 - Runtime Orchestration Measurement and Product Boundary`; completed work items were `#397`, `#398`, and `#401`. Phase 50 measured before any `task_id` or worker contract is introduced and kept the private-beta launch hub planning-only for now.
+- Phase 51 is the active approved successor queue: `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`; `audit-github-queue` reports `ready` with `#403` as the blocked exit gate, `#404` as the current ready repo-truth item, `#405` as the blocked private-beta route ownership contract, and `#406` as the blocked runtime readiness and world-scoped session guards item.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
 - Fog Harbor remains the canonical demo world; `museum-night` is the minimal transfer world used to prove the pipeline is not single-world-only.
 

--- a/backend/tests/test_automation.py
+++ b/backend/tests/test_automation.py
@@ -44,6 +44,7 @@ def test_classify_paths_marks_phase_queue_docs_protected() -> None:
         "docs/plans/current-state-baseline.md",
         "docs/plans/phase-execution-queue.md",
         "docs/plans/phase-50-successor-gate-2026-05-18.md",
+        "docs/plans/phase-51-successor-gate-2026-05-18.md",
     ]
 
     decision = classify_paths(phase_queue_paths)

--- a/backend/tests/test_phase50_successor_gate.py
+++ b/backend/tests/test_phase50_successor_gate.py
@@ -13,7 +13,7 @@ def test_phase50_successor_gate_exists_with_required_sections() -> None:
     required_sections = [
         "# Phase 50 Successor Gate",
         "Issue: `#401` `Phase 50: ratify private-beta launch hub and public-path boundary`",
-        "Current work item: `#401` `Phase 50: ratify private-beta launch hub and public-path boundary`",
+        "Final work item: `#401` `Phase 50: ratify private-beta launch hub and public-path boundary`",
         "## Phase 49 Closeout Evidence",
         "## Phase 50 Operational Queue",
         "## Protected-Core Lane Coverage",
@@ -33,6 +33,7 @@ def test_phase50_successor_gate_records_queue_and_boundaries() -> None:
     gate = PHASE50_GATE_PATH.read_text(encoding="utf-8")
     required_phrases = [
         "Phase 50 - Runtime Orchestration Measurement and Product Boundary",
+        "Closed GitHub objects:",
         "`#396` `Phase 50 exit gate`",
         "`#397` `Phase 50: sync repo truth after Phase 49 closeout`",
         "`#398` `Phase 50: measure runtime generation duration before task_id decision`",
@@ -48,9 +49,18 @@ def test_phase50_successor_gate_records_queue_and_boundaries() -> None:
         "Keep synchronous generation for v1",
         "`#401` `Phase 50: ratify private-beta launch hub and public-path boundary`",
         "`docs/plans/phase-50-product-boundary-2026-05-18.md`",
+        "`docs/plans/phase-51-successor-gate-2026-05-18.md`",
     ]
     for phrase in required_phrases:
         assert phrase in gate
+
+    stale_active_phrases = [
+        "Active GitHub objects:",
+        "Status: current ready work item.",
+        "with Phase 50 as the only open milestone",
+    ]
+    for phrase in stale_active_phrases:
+        assert phrase not in gate
 
 
 def test_active_state_docs_point_to_phase50_queue() -> None:

--- a/backend/tests/test_phase51_successor_gate.py
+++ b/backend/tests/test_phase51_successor_gate.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+PHASE51_GATE_PATH = Path("docs/plans/phase-51-successor-gate-2026-05-18.md")
+
+
+def test_phase51_successor_gate_exists_with_required_sections() -> None:
+    assert PHASE51_GATE_PATH.exists()
+
+    gate = PHASE51_GATE_PATH.read_text(encoding="utf-8")
+    required_sections = [
+        "# Phase 51 Successor Gate",
+        "Issue: `#404` `Phase 51: sync repo truth after Phase 50 closeout`",
+        "Current work item: `#404` `Phase 51: sync repo truth after Phase 50 closeout`",
+        "## Phase 50 Closeout Evidence",
+        "## Phase 51 Operational Queue",
+        "## Protected-Core Lane Coverage",
+        "## Carried Forward TODO[verify] Items",
+        "## Phase 51 Work Package Map",
+        "## Blueprint Boundary",
+        "## Non-Goals",
+        "## Validation Commands",
+    ]
+    for section in required_sections:
+        assert section in gate
+
+
+def test_phase51_successor_gate_records_queue_and_boundaries() -> None:
+    assert PHASE51_GATE_PATH.exists()
+
+    gate = PHASE51_GATE_PATH.read_text(encoding="utf-8")
+    required_phrases = [
+        "Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate",
+        "`#403` `Phase 51 exit gate`",
+        "`#404` `Phase 51: sync repo truth after Phase 50 closeout`",
+        "`#405` `Phase 51: ratify private-beta route ownership and launch-hub contract`",
+        "`#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`",
+        "Private-beta route contract",
+        "Runtime readiness and world-scoped session guards",
+        "TODO[verify]: Codex UI tool-card",
+        "Runtime generation duration is now recorded",
+        "Keep synchronous generation for v1",
+        "Phase 50 Product Boundary Decision",
+        "launch hub remains planning-only for now",
+        "Every report claim must keep both `label` and `evidence_ids`",
+        "Do not present Mirror as a real-world prediction machine",
+        "Do not implement async workers, queues, `task_id`, retry, status, cleanup",
+        "Do not recreate local Codex automations without a new explicit operator request",
+        "`docs/plans/phase-50-runtime-generation-duration-measurement-2026-05-18.md`",
+        "`docs/plans/phase-50-product-boundary-2026-05-18.md`",
+    ]
+    for phrase in required_phrases:
+        assert phrase in gate
+
+
+def test_active_state_docs_point_to_phase51_queue() -> None:
+    required_docs = [
+        Path("README.md"),
+        Path("docs/plans/current-state-baseline.md"),
+        Path("docs/plans/phase-execution-queue.md"),
+        Path("docs/plans/automation-roadmap.md"),
+        Path("docs/plans/phase-50-successor-gate-2026-05-18.md"),
+    ]
+
+    for path in required_docs:
+        text = path.read_text(encoding="utf-8")
+        assert "Phase 50 - Runtime Orchestration Measurement and Product Boundary" in text
+        assert "Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate" in text
+        assert "`#403`" in text
+        assert "`#404`" in text
+        assert "`#405`" in text
+        assert "`#406`" in text
+        assert "private-beta route ownership" in text
+        assert "world-scoped session guards" in text

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, Phase 47 closeout is complete, Phase 48 closeout is complete, Phase 49 closeout is complete, Phase 50 is the active approved successor queue, and the first formal release remains published as `v0.1.0`.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, Phase 47 closeout is complete, Phase 48 closeout is complete, Phase 49 closeout is complete, Phase 50 closeout is complete, Phase 51 is the active approved successor queue, and the first formal release remains published as `v0.1.0`.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -162,18 +162,23 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - `#369` `Phase 47: main-path product containment` is merged and closed via PR `#373`.
 - Phase 48 is closed after PR `#382`, exit gate `#375`, and milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
 - Phase 49 is closed after PR `#395`, exit gate `#383`, and milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`.
-- Phase 50 is the active approved successor queue.
-- milestone `Phase 50 - Runtime Orchestration Measurement and Product Boundary` is open.
-- `#396` `Phase 50 exit gate` is open, blocked, and protected-core.
-- `#397` `Phase 50: sync repo truth after Phase 49 closeout` is the current ready work item.
-- `#398` `Phase 50: measure runtime generation duration before task_id decision` is blocked until the Phase 50 baseline lands.
+- Phase 50 is closed after PR `#402`, exit gate `#396`, and milestone `Phase 50 - Runtime Orchestration Measurement and Product Boundary`.
+- `#397` `Phase 50: sync repo truth after Phase 49 closeout` is closed by PR `#399`.
+- `#398` `Phase 50: measure runtime generation duration before task_id decision` is closed by PR `#400`.
+- `#401` `Phase 50: ratify private-beta launch hub and public-path boundary` is closed by PR `#402`.
+- Phase 51 is the active approved successor queue.
+- milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate` is open.
+- `#403` `Phase 51 exit gate` is open, blocked, and protected-core.
+- `#404` `Phase 51: sync repo truth after Phase 50 closeout` is the current ready work item.
+- `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract` is blocked until the Phase 51 baseline lands.
+- `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards` is blocked until the route ownership contract lands.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.
 - `#390` `Phase 49: ratify runtime parent-child compare emission policy` is closed by PR `#391`.
 - `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope` is closed by PR `#393`.
 - `#394` `Phase 49: strengthen transfer eval outcome coverage` is closed by PR `#395`.
-- `audit-github-queue` reports `ready` with Phase 50 as the active milestone.
+- `audit-github-queue` reports `ready` with Phase 51 as the active milestone.
 - The first formal repository release is published as `v0.1.0`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
@@ -230,5 +235,5 @@ Before builder automation is allowed to write code or auto-merge:
 - Long-running execution must run from isolated worktrees rather than the current `main` checkout.
 - Queue pickup order, one-writer ownership, and branch hygiene should follow `docs/plans/long-running-loop-runbook.md`.
 - When the active milestone exists and the queue reports `ready`, the builder may resume against that milestone only.
-- Phase 50 is the active approved successor queue; do not open a parallel execution queue.
+- Phase 51 is the active approved successor queue; do not open a parallel execution queue.
 - When no open milestone exists and `audit-github-queue` reports `paused`, treat that state as an intentional released stop-state rather than a broken queue.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note records the completed Phase 49 contract-hardening closeout and the approved Phase 50 successor queue after the formal `v0.1.0` release baseline.
+This note records the completed Phase 50 runtime-boundary closeout and the approved Phase 51 successor queue after the formal `v0.1.0` release baseline.
 
 ## Snapshot
 
@@ -214,7 +214,7 @@ This note records the completed Phase 49 contract-hardening closeout and the app
   - `gh api repos/YSCJRH/mirror-sim/releases`
     - release `v0.1.0` exists and matches the committed release notes baseline
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - queue reports `ready` with `Phase 50 - Runtime Orchestration Measurement and Product Boundary` as the active milestone
+    - queue reports `ready` with `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate` as the active milestone
   - `gh issue list --milestone "Phase 47 - Boundary Readiness and Successor Hygiene" --state all`
     - `#365` `Phase 47 exit gate` is `closed` after merging PR `#374`
     - `#366` `Phase 47: sync repo truth to successor queue` is `closed` after merging PR `#370`
@@ -240,14 +240,21 @@ This note records the completed Phase 49 contract-hardening closeout and the app
   - `gh api repos/YSCJRH/mirror-sim/milestones/49`
     - milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening` is `closed`
   - `gh issue list --milestone "Phase 50 - Runtime Orchestration Measurement and Product Boundary" --state all`
-    - `#396` `Phase 50 exit gate` is `open`, `blocked`, and `lane:protected-core`
+    - `#396` `Phase 50 exit gate` is `closed` after the Phase 50 closeout reassessment
     - `#397` `Phase 50: sync repo truth after Phase 49 closeout` is `closed` by PR `#399`
     - `#398` `Phase 50: measure runtime generation duration before task_id decision` is `closed` by PR `#400`
-    - `#401` `Phase 50: ratify private-beta launch hub and public-path boundary` is the current `status:ready` protected-core work item
+    - `#401` `Phase 50: ratify private-beta launch hub and public-path boundary` is `closed` by PR `#402`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/50`
+    - milestone `Phase 50 - Runtime Orchestration Measurement and Product Boundary` is `closed`
   - Phase 50 Product Boundary Decision:
     - launch hub remains planning-only for now
     - `/` remains the guided public demo
     - `docs/plans/phase-50-product-boundary-2026-05-18.md` records the boundary note
+  - `gh issue list --milestone "Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate" --state all`
+    - `#403` `Phase 51 exit gate` is `open`, `blocked`, and `lane:protected-core`
+    - `#404` `Phase 51: sync repo truth after Phase 50 closeout` is the current `status:ready` protected-core work item
+    - `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract` is `open` and blocked until repo truth is synced
+    - `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards` is `open` and blocked until the route contract lands
 
 ## Trusted Source Of Truth
 
@@ -269,20 +276,24 @@ This note records the completed Phase 49 contract-hardening closeout and the app
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
 - The default workbench path now consumes the canonical compare artifact directly and keeps focused divergent trace surfaces ahead of heavier packet-driven review flows.
 - The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, execution recovery release boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, escalation acknowledgment packets, and escalation closure packets without introducing backend API expansion.
-- The current repository state has completed the Phase 49 contract-hardening queue, preserved `v0.1.0` as the latest published release baseline, and opened the approved Phase 50 successor queue.
+- The current repository state has completed the Phase 50 runtime-boundary queue, preserved `v0.1.0` as the latest published release baseline, and opened the approved Phase 51 successor queue.
 
 ## Next Entry Point
 
-- Phase 50 is the active approved successor queue; `audit-github-queue` reports `ready`.
+- Phase 51 is the active approved successor queue; `audit-github-queue` reports `ready`.
 - The Phase 47 unlock order is resolved: the queue-sync issue is closed after PR `#370`, the boundary-regression report is closed after PR `#371`, the runtime-world safety preflight is closed after PR `#372`, the main-path containment report is closed after PR `#373`, and the exit gate is closed after PR `#374`.
 - The Phase 48 unlock order is resolved: `#376` and `#377` closed through earlier Phase 48 PRs, `#378` and `#379` closed through PR `#382`, and `#375` closed after the post-merge exit-gate reassessment.
 - The Phase 49 unlock order is resolved: `#384` closed through PR `#385`, `#386` closed through PR `#387`, `#388` closed through PR `#389`, `#390` closed through PR `#391`, `#392` closed through PR `#393`, `#394` closed through PR `#395`, and `#383` closed after the post-merge exit-gate reassessment.
-- The active successor milestone is `Phase 50 - Runtime Orchestration Measurement and Product Boundary`.
-- The Phase 50 exit gate is `#396` `Phase 50 exit gate`, which remains the open blocked closeout gate for this phase.
+- The Phase 50 unlock order is resolved: `#397` closed through PR `#399`, `#398` closed through PR `#400`, `#401` closed through PR `#402`, and `#396` closed after the post-merge exit-gate reassessment.
+- The active successor milestone is `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`.
+- The Phase 51 exit gate is `#403` `Phase 51 exit gate`, which remains the open blocked closeout gate for this phase.
 - `#397` `Phase 50: sync repo truth after Phase 49 closeout` is closed by PR `#399`.
 - `#398` `Phase 50: measure runtime generation duration before task_id decision` is closed by PR `#400`.
-- `#401` `Phase 50: ratify private-beta launch hub and public-path boundary` is the current ready work item.
+- `#401` `Phase 50: ratify private-beta launch hub and public-path boundary` is closed by PR `#402`.
 - Phase 50 Product Boundary Decision: launch hub remains planning-only for now; current tracked code keeps `/` as the guided public demo.
+- `#404` `Phase 51: sync repo truth after Phase 50 closeout` is the current ready work item.
+- `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract` is blocked until repo truth is synced.
+- `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards` is blocked until the route ownership contract lands.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.
@@ -292,7 +303,8 @@ This note records the completed Phase 49 contract-hardening closeout and the app
 - The completed Phase 47 successor-gate baseline lives in `docs/plans/phase-47-successor-gate-2026-05-16.md`.
 - The completed Phase 48 successor-gate baseline lives in `docs/plans/phase-48-successor-gate-2026-05-17.md`.
 - The completed Phase 49 successor-gate baseline lives in `docs/plans/phase-49-successor-gate-2026-05-18.md`.
-- The active Phase 50 successor-gate baseline lives in `docs/plans/phase-50-successor-gate-2026-05-18.md`.
+- The completed Phase 50 successor-gate baseline lives in `docs/plans/phase-50-successor-gate-2026-05-18.md`.
+- The active Phase 51 successor-gate baseline lives in `docs/plans/phase-51-successor-gate-2026-05-18.md`.
 - Local untracked private-beta, kernel, and design-system planning files under `docs/plans/...` are candidate inputs only until a PR intentionally promotes them.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.

--- a/docs/plans/phase-50-successor-gate-2026-05-18.md
+++ b/docs/plans/phase-50-successor-gate-2026-05-18.md
@@ -4,7 +4,7 @@ Date: 2026-05-18
 
 Issue: `#401` `Phase 50: ratify private-beta launch hub and public-path boundary`
 
-Current work item: `#401` `Phase 50: ratify private-beta launch hub and public-path boundary`
+Final work item: `#401` `Phase 50: ratify private-beta launch hub and public-path boundary`
 
 This note records the post-Phase-49 baseline and opens the Phase 50 successor queue.
 Phase 50 is a protected-core measurement and boundary phase for runtime orchestration.
@@ -58,11 +58,11 @@ Phase 50 title:
 Phase 50 - Runtime Orchestration Measurement and Product Boundary
 ```
 
-Active GitHub objects:
+Closed GitHub objects:
 
 - `#396` `Phase 50 exit gate`
   - Lane: `protected-core`.
-  - Status: blocked closeout gate for Phase 50.
+  - Status: closed after the Phase 50 post-merge reassessment.
 - `#397` `Phase 50: sync repo truth after Phase 49 closeout`
   - Lane: `protected-core`.
   - Status: closed by PR `#399`.
@@ -74,13 +74,13 @@ Active GitHub objects:
     synchronous v1 generation or open a dedicated async-orchestration ADR.
 - `#401` `Phase 50: ratify private-beta launch hub and public-path boundary`
   - Lane: `protected-core`.
-  - Status: current ready work item.
+  - Status: closed by PR `#402`.
   - Scope: record the Phase 50 Product Boundary Decision, keep launch hub remains planning-only for now,
     and preserve public demo/plugin/hosted-model boundaries before any product-path widening.
 
-`python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
-with Phase 50 as the only open milestone, `#396` as the protected blocked exit gate, and
-`#401` as the current ready work item.
+After the Phase 50 closeout, `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
+reports `ready` with Phase 51 as the only open milestone. The active successor queue is recorded in
+`docs/plans/phase-51-successor-gate-2026-05-18.md`.
 
 ## Protected-Core Lane Coverage
 
@@ -166,6 +166,30 @@ public demo artifact layout, or the Mirror Codex MCP contract.
    - Decision: launch hub remains planning-only for now.
    - Do not move public demo, plugin, or hosted-model behavior without a separate reviewed
      contract decision.
+
+## Phase 51 Successor Handoff
+
+Phase 50 is closed after PR `#402`, issue `#396`, and milestone
+`Phase 50 - Runtime Orchestration Measurement and Product Boundary`.
+
+The active approved successor queue is now:
+
+```text
+Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate
+```
+
+- `#403` `Phase 51 exit gate`
+  - Status: open and blocked.
+- `#404` `Phase 51: sync repo truth after Phase 50 closeout`
+  - Status: current ready repo-truth work item.
+- `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract`
+  - Status: blocked until the Phase 51 baseline lands.
+- `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`
+  - Status: blocked until the route ownership contract lands.
+
+Phase 51 carries forward the Phase 50 Product Boundary Decision and requires a reviewed
+private-beta route ownership contract before any launch-hub implementation. It also verifies
+runtime readiness and world-scoped session guards before product-path runtime surfaces widen.
 
 ## Blueprint Boundary
 

--- a/docs/plans/phase-51-successor-gate-2026-05-18.md
+++ b/docs/plans/phase-51-successor-gate-2026-05-18.md
@@ -1,0 +1,212 @@
+# Phase 51 Successor Gate
+
+Date: 2026-05-18
+
+Issue: `#404` `Phase 51: sync repo truth after Phase 50 closeout`
+
+Current work item: `#404` `Phase 51: sync repo truth after Phase 50 closeout`
+
+This note records the post-Phase-50 baseline and opens the Phase 51 successor queue.
+Phase 51 is a protected-core route-contract and runtime-readiness phase for the
+private-beta product path. It records private-beta route ownership before any launch-hub
+implementation and verifies runtime readiness and world-scoped session guards before
+expanding runtime surfaces. It is not a launch-hub implementation phase.
+
+## Phase 50 Closeout Evidence
+
+- PR `#399` closed `#397` `Phase 50: sync repo truth after Phase 49 closeout`.
+- PR `#400` closed `#398` `Phase 50: measure runtime generation duration before task_id decision`.
+- PR `#402` closed `#401` `Phase 50: ratify private-beta launch hub and public-path boundary`
+  and merged into `main` at merge commit `54b7053`.
+- Issue `#396` `Phase 50 exit gate` is closed after the post-merge reassessment comment.
+- Milestone `Phase 50 - Runtime Orchestration Measurement and Product Boundary` is closed.
+- Runtime generation duration is now recorded in
+  `docs/plans/phase-50-runtime-generation-duration-measurement-2026-05-18.md`.
+  Current local deterministic measurements support: Keep synchronous generation for v1.
+- Phase 50 Product Boundary Decision is recorded in
+  `docs/plans/phase-50-product-boundary-2026-05-18.md`.
+  The launch hub remains planning-only for now; `/` remains the guided public demo.
+- The public demo and Mirror Codex plugin remain deterministic/read-only. They do not gain
+  Hosted GPT, BYOK, upload, auth, billing, database, object storage, quota, or mutating MCP
+  behavior.
+
+## Phase 51 Operational Queue
+
+Phase 51 title:
+
+```text
+Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate
+```
+
+Active GitHub objects:
+
+- `#403` `Phase 51 exit gate`
+  - Lane: `protected-core`.
+  - Status: blocked closeout gate for Phase 51.
+- `#404` `Phase 51: sync repo truth after Phase 50 closeout`
+  - Lane: `protected-core`.
+  - Status: current ready work item.
+  - Scope: sync tracked docs to Phase 51 after closing Phase 50.
+- `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract`
+  - Lane: `protected-core`.
+  - Status: blocked until the repo-truth sync lands.
+  - Scope: record the Private-beta route contract before any launch-hub implementation.
+- `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`
+  - Lane: `protected-core`.
+  - Status: blocked until the route ownership contract lands.
+  - Scope: verify runtime readiness and world-scoped session guards before product-path
+    runtime surfaces widen.
+
+`python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
+with Phase 51 as the only open milestone, `#403` as the protected blocked exit gate, and
+`#404` as the current ready work item.
+
+## Protected-Core Lane Coverage
+
+Phase 51 work is protected-core by default when it touches private-beta route ownership,
+runtime readiness, session contracts, model access, safety behavior, eval contracts, or
+queue governance. The lane policy already protects:
+
+- `.github/automation/`
+- `docs/architecture/contracts.md`
+- `docs/decisions/`
+- `docs/plans/automation-roadmap.md`
+- `docs/plans/current-state-baseline.md`
+- `docs/plans/phase-`
+- `backend/app/decision_kernel/`
+- `backend/app/evals/`
+- `backend/app/model_access/`
+- `backend/app/perturbations/`
+- `backend/app/safety/`
+- `backend/app/sessions/`
+- `backend/app/simulation/`
+- `backend/app/reports/`
+- `frontend/src/app/api/runtime/`
+- `frontend/src/app/api/worlds/create/`
+- `frontend/src/app/lib/runtime-cli.ts`
+
+This protection is operational governance. It does not itself change scenario DSL,
+perturbation payloads, session/node manifests, `decision_trace.jsonl`, compare artifacts,
+public demo artifact layout, or the Mirror Codex MCP contract.
+
+## Carried Forward TODO[verify] Items
+
+- TODO[verify]: Codex UI tool-card evidence remains open until a clean Codex app session
+  shows observable MCP tool or resource cards/traces for the Mirror Codex plugin.
+- Runtime generation duration is now recorded in
+  `docs/plans/phase-50-runtime-generation-duration-measurement-2026-05-18.md`.
+  Current local deterministic measurements support: Keep synchronous generation for v1.
+  TODO[verify]: rerun hosted/private-beta model measurements before introducing `task_id`,
+  worker, retry, status, or cleanup semantics.
+- Phase 50 Product Boundary Decision is recorded in
+  `docs/plans/phase-50-product-boundary-2026-05-18.md`.
+  The launch hub remains planning-only for now; `/` remains the guided public demo.
+  TODO[verify]: open a reviewed route contract before replacing `/` or adding a private-beta
+  launch hub route.
+- TODO[verify]: verify route/session mismatch handling before expanding private-beta runtime
+  surfaces. World-scoped session guards must reject or clearly fail any request whose route
+  `world_id` conflicts with the session's durable world id.
+- Latest-session versus latest-activity semantics are ratified as `last_activity_at`
+  ordering with `created_at` fallback; TODO[verify]: re-open contract review before adding
+  other activity sources or changing failed-operation activity behavior.
+- The first `decision_trace.jsonl` v1 field set is ratified in
+  `docs/architecture/contracts.md`; TODO[verify]: re-open contract review before adding new
+  trace fields, changing validation status values, or widening provider output persistence.
+- Kernel boundary action-type validation is ratified in
+  `docs/decisions/ADR-0007-rule-bounded-llm-kernel.md` and
+  `docs/architecture/contracts.md`; TODO[verify]: re-open contract review before accepting
+  any caller-supplied action outside a world-local `allowed_action_types` list.
+- Every successful generated non-root runtime node emits a session-scoped parent-vs-child
+  compare output; TODO[verify]: re-open contract review before making runtime compare
+  emission optional or changing reference-branch selection away from the immediate parent.
+- Checkpoint rollback remains deferred; v1 rollback only moves `active_node_id`.
+  TODO[verify]: re-open contract review before adding deletion, mutation, retry, or restore
+  semantics beyond pointer movement.
+- Fog Harbor-shaped report and eval assumptions are inventoried in
+  `docs/plans/phase-49-transfer-assumption-inventory-2026-05-18.md`; TODO[verify]:
+  re-open contract review before removing legacy `RunTrace` fields or claiming transfer
+  beyond the two-world proof.
+
+## Phase 51 Work Package Map
+
+1. Repo-truth sync after Phase 50 closeout
+   - Record Phase 50 closure, Phase 51 queue objects, validation, and carried-forward
+     boundaries across README and active planning docs.
+   - Keep local Mirror-specific automations revoked unless the operator explicitly asks to
+     recreate them.
+
+2. Private-beta route ownership contract
+   - Record the reviewed route contract before replacing `/` or adding a private-beta launch
+     hub route.
+   - Keep `/` as the guided public demo and `/worlds/<world_id>` as the private-beta
+     candidate product path unless the contract explicitly changes.
+   - Preserve public demo, plugin, hosted-model, and async-runtime boundaries.
+
+3. Runtime readiness and world-scoped session guards
+   - Verify hosted/private-beta runtime thresholds against Phase 50 measurement evidence.
+   - Verify route/session mismatch handling and world-scoped session guards before runtime
+     product surfaces widen.
+   - Preserve synchronous v1 unless an ADR approves async task semantics.
+
+## Blueprint Boundary
+
+Phase 51 must stay aligned with `mirror.md` and `AGENTS.md`:
+
+- Mirror is a constrained, evidence-backed, replayable what-if sandbox for fictional or
+  explicitly authorized worlds.
+- Do not present Mirror as a real-world prediction machine.
+- Do not build real-person personas or digital doubles.
+- Do not build political persuasion, law-enforcement scoring, hiring, credit, medical, or
+  judicial decision systems.
+- Every report claim must keep both `label` and `evidence_ids`.
+- Durable contract changes require `docs/architecture/contracts.md` updates and an ADR when
+  the contract is long-lived.
+
+## Non-Goals
+
+- Do not implement a private-beta launch hub, move `/`, or widen the public path inside
+  `#404`.
+- Do not implement async workers, queues, `task_id`, retry, status, cleanup, checkpoint
+  mutation/deletion, or restore semantics inside `#404`.
+- Do not change scenario DSL, claim/evidence shape, run trace shape, compare artifact shape,
+  public demo artifact layout, or plugin MCP tool/resource contract in `#404`.
+- Do not add Hosted GPT, BYOK, upload, auth, billing, database, object storage, or quota
+  behavior to the public path or plugin path.
+- Do not add mutating Mirror Codex MCP tools.
+- Do not promote local untracked April/private-beta planning files as durable truth without a
+  reviewed PR.
+- Do not recreate local Codex automations without a new explicit operator request.
+
+## Validation Commands
+
+For `#404`, run:
+
+```powershell
+python -m pytest backend/tests/test_phase51_successor_gate.py backend/tests/test_phase50_successor_gate.py backend/tests/test_phase50_product_boundary_note.py backend/tests/test_automation.py -q
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-50-successor-gate-2026-05-18.md docs/plans/phase-51-successor-gate-2026-05-18.md backend/tests/test_phase50_successor_gate.py backend/tests/test_phase51_successor_gate.py backend/tests/test_automation.py
+git diff --check
+./make.ps1 test
+./make.ps1 eval-demo
+```
+
+For `#405`, run:
+
+```powershell
+python -m pytest backend/tests/test_phase51_successor_gate.py -q
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+python -m backend.app.cli classify-lane --files <changed-files>
+git diff --check
+```
+
+For `#406`, run:
+
+```powershell
+python -m pytest backend/tests/test_phase51_successor_gate.py -q
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+python -m backend.app.cli classify-lane --files <changed-files>
+git diff --check
+```

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 49 contract-hardening closeout, and the approved Phase 50 successor queue.
+This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 50 runtime-boundary closeout, and the approved Phase 51 successor queue.
 
 ## Current Gate State
 
@@ -53,7 +53,8 @@ This note records the current post-Day-0 execution status for Mirror after the f
 - Phase 47 exit gate: closed
 - Phase 48 exit gate: closed
 - Phase 49 exit gate: closed
-- Phase 50 exit gate: open and blocked
+- Phase 50 exit gate: closed
+- Phase 51 exit gate: open and blocked
 
 Local phase audits currently report:
 
@@ -61,15 +62,34 @@ Local phase audits currently report:
 - `phase2`: pass
 - `phase3`: pass
 
-## Phase 50 Successor Queue
+## Phase 51 Successor Queue
 
 - `audit-github-queue`
-  - reports `ready` with `Phase 50 - Runtime Orchestration Measurement and Product Boundary` as the active milestone
-- milestone `Phase 50 - Runtime Orchestration Measurement and Product Boundary`
+  - reports `ready` with `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate` as the active milestone
+- milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`
   - open
-- `#396` `Phase 50 exit gate`
+- `#403` `Phase 51 exit gate`
   - open and blocked
   - labeled `lane:protected-core` because it is the protected closeout gate
+- `#404` `Phase 51: sync repo truth after Phase 50 closeout`
+  - current protected-core repo-truth work item
+  - syncs durable docs to Phase 51
+- `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract`
+  - open and blocked until the repo-truth sync lands
+  - records the reviewed route contract before any launch-hub implementation
+- `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`
+  - open and blocked until the route contract lands
+  - verifies runtime readiness and world-scoped session guards before runtime surfaces widen
+- phase gate baseline
+  - active Phase 51 gate note: `docs/plans/phase-51-successor-gate-2026-05-18.md`
+
+## Phase 50 Closeout
+
+- milestone `Phase 50 - Runtime Orchestration Measurement and Product Boundary`
+  - closed after PR `#402` and the post-merge exit-gate reassessment
+- `#396` `Phase 50 exit gate`
+  - closed after the post-merge reassessment on `main`
+  - labeled `lane:protected-core` because it was the protected closeout gate
 - `#397` `Phase 50: sync repo truth after Phase 49 closeout`
   - closed by PR `#399`
   - synced durable docs to Phase 50
@@ -77,10 +97,10 @@ Local phase audits currently report:
   - closed by PR `#400`
   - recorded that synchronous v1 generation remains the current contract
 - `#401` `Phase 50: ratify private-beta launch hub and public-path boundary`
-  - current protected-core product-boundary work item
+  - closed by PR `#402`
   - Phase 50 Product Boundary Decision: launch hub remains planning-only for now
 - phase gate baseline
-  - active Phase 50 gate note: `docs/plans/phase-50-successor-gate-2026-05-18.md`
+  - completed Phase 50 gate note: `docs/plans/phase-50-successor-gate-2026-05-18.md`
 
 ## Phase 49 Closeout
 
@@ -182,8 +202,9 @@ Local phase audits currently report:
 - successor posture
   - Phase 48 completed as a successor-intake and boundary contract triage round
   - Phase 49 completed as a contract-hardening round
-  - Phase 50 is the active approved successor queue
-  - any work beyond the Phase 50 queue requires a fresh decision against the trigger conditions in `mirror.md`
+  - Phase 50 completed as a runtime-orchestration measurement and product-boundary round
+  - Phase 51 is the active approved successor queue
+  - any work beyond the Phase 51 queue requires a fresh decision against the trigger conditions in `mirror.md`
 
 ## Closeout Snapshot
 
@@ -641,7 +662,7 @@ Local phase audits currently report:
 - Protected-core changes still require explicit review and must not auto-merge.
 - Long-running execution should assign exactly one writer worktree per issue.
 - When `audit-github-queue` reports `ready`, consume only the currently active milestone and do not parallel-open another execution queue.
-- Phase 50 is the active approved successor queue; do not open a parallel execution queue.
+- Phase 51 is the active approved successor queue; do not open a parallel execution queue.
 - The previous local queue follow-up automation has been revoked or left paused per operator request; do not recreate an automation without a new explicit request.
 
 ## Historical Branch Status


### PR DESCRIPTION
## Summary
- sync repo truth from the closed Phase 50 queue to the active Phase 51 queue
- add the Phase 51 successor gate note and regression coverage
- update the completed Phase 50 gate so it no longer presents closed work as active/current

## Validation
- `python -m pytest backend/tests/test_phase51_successor_gate.py backend/tests/test_phase50_successor_gate.py backend/tests/test_phase50_product_boundary_note.py backend/tests/test_automation.py -q` -> 19 passed
- `python scripts/check_no_secrets.py` -> passed
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` -> ready, active Phase 51, ready #404
- `python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-50-successor-gate-2026-05-18.md docs/plans/phase-51-successor-gate-2026-05-18.md backend/tests/test_phase50_successor_gate.py backend/tests/test_phase51_successor_gate.py backend/tests/test_automation.py` -> lane:protected-core
- `git diff --check` -> passed
- `./make.ps1 test` -> 102 passed
- `./make.ps1 eval-demo` -> pass (23/23)

Closes #404