### PR TITLE
Phase 51 private-beta route ownership contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,13 @@ Current tracked code keeps `/` as the public demo, and any future private-beta l
 requires a separate reviewed route contract before replacing `/` or widening public/plugin
 behavior. See `docs/plans/phase-50-product-boundary-2026-05-18.md`.
 
+Phase 51 Private-Beta Route Ownership Contract (`#405`): the private-beta launch hub remains planning-only.
+`/` and `/review` stay public-demo surfaces, while `/worlds/<world_id>` and its child routes
+remain the private-beta candidate product path. See
+`docs/plans/phase-51-private-beta-route-contract-2026-05-18.md`; the durable route ownership
+contract is also recorded in `docs/architecture/contracts.md` and
+`docs/decisions/ADR-0011-private-beta-route-ownership.md`.
+
 ---
 
 ## What You Can Inspect Locally | 本地能看到什么
@@ -271,7 +278,7 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - Phase 48 is closed after PR `#382`, issue `#375`, and milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
 - Phase 49 is closed after PR `#395`, issue `#383`, and milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; completed work items were `#384`, `#386`, `#388`, `#390`, `#392`, and `#394`.
 - Phase 50 is closed after PR `#402`, issue `#396`, and milestone `Phase 50 - Runtime Orchestration Measurement and Product Boundary`; completed work items were `#397`, `#398`, and `#401`. Phase 50 measured before any `task_id` or worker contract is introduced and kept the private-beta launch hub planning-only for now.
-- Phase 51 is the active approved successor queue: `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`; `audit-github-queue` reports `ready` with `#403` as the blocked exit gate, `#404` as the current ready repo-truth item, `#405` as the blocked private-beta route ownership contract, and `#406` as the blocked runtime readiness and world-scoped session guards item.
+- Phase 51 is the active approved successor queue: `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`; `audit-github-queue` reports `ready` with `#403` as the blocked exit gate, `#404` closed by PR `#407`, `#405` as the current ready private-beta route ownership contract, and `#406` as the blocked runtime readiness and world-scoped session guards item.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
 - Fog Harbor remains the canonical demo world; `museum-night` is the minimal transfer world used to prove the pipeline is not single-world-only.
 

--- a/backend/tests/test_phase51_route_contract_note.py
+++ b/backend/tests/test_phase51_route_contract_note.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+NOTE_PATH = Path("docs/plans/phase-51-private-beta-route-contract-2026-05-18.md")
+
+
+def test_phase51_route_contract_note_exists_with_required_sections() -> None:
+    assert NOTE_PATH.exists()
+
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    required_sections = [
+        "# Phase 51 Private-Beta Route Ownership Contract",
+        "Issue: `#405`",
+        "## Decision",
+        "## Evidence",
+        "## Route Ownership Table",
+        "## Launch Hub Contract",
+        "## Public Demo Boundary",
+        "## Plugin Boundary",
+        "## Private-Beta Boundary",
+        "## Follow-Up Gate",
+        "## Non-Goals",
+        "## Validation Commands",
+    ]
+    for section in required_sections:
+        assert section in note
+
+
+def test_phase51_route_contract_records_public_private_and_plugin_boundaries() -> None:
+    assert NOTE_PATH.exists()
+
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    required_phrases = [
+        "`/` remains the guided Phase 1 public Fog Harbor demo",
+        "`/review` remains the advanced read-only public-demo review surface",
+        "`/worlds/<world_id>` remains the private-beta candidate world home",
+        "`/worlds/new` remains a private-beta candidate creation route",
+        "`/worlds/<world_id>/perturb` remains the main private-beta operator path",
+        "`/worlds/<world_id>/runtime/<session_id>` remains the world-scoped runtime workspace",
+        "`/worlds/<world_id>/runtime/<session_id>/explain` remains the world-scoped explain workspace",
+        "`/worlds/<world_id>/runtime/<session_id>/report` remains the world-scoped report workspace",
+        "`/worlds/<world_id>/review` remains the world-scoped private-beta review surface",
+        "The private-beta launch hub remains planning-only in Phase 51",
+        "A future launch hub must not replace `/`",
+        "must not start sessions, generate branches, create worlds, upload corpora, enable Hosted GPT, accept BYOK, or call model providers from the public path",
+        "`/changes/<branch_id>`",
+        "`/perturb`",
+        "`/runtime/<session_id>`",
+        "`docs/architecture/contracts.md`",
+        "`docs/decisions/ADR-0011-private-beta-route-ownership.md`",
+        "Mirror Codex plugin remains read-only",
+        "Do not add Hosted GPT, BYOK, upload, auth, billing, database, object storage, or quota behavior to the public path or plugin path",
+        "Do not implement async workers, queues, `task_id`, retry, status, or cleanup semantics",
+        "TODO[verify]: verify that private-beta composer requests pass route-derived `worldId`",
+        "TODO[verify]: if a launch hub becomes an implementation target, open a new reviewed work item",
+    ]
+    for phrase in required_phrases:
+        assert phrase in note
+
+
+def test_architecture_and_adr_record_route_ownership_contract() -> None:
+    contract = Path("docs/architecture/contracts.md").read_text(encoding="utf-8")
+    adr = Path("docs/decisions/ADR-0011-private-beta-route-ownership.md").read_text(encoding="utf-8")
+
+    required_contract_phrases = [
+        "## Route Ownership Contract",
+        "`/` remains the guided Phase 1 public Fog Harbor demo",
+        "`/review` remains the advanced read-only public-demo review surface",
+        "`/worlds/<world_id>` remains the private-beta candidate world home",
+        "`/api/runtime/generate-branch`",
+        "The private-beta launch hub remains planning-only in Phase 51",
+        "Top-level `/perturb`, `/runtime/<session_id>`, and child runtime routes are legacy",
+        "TODO[verify]: verify that private-beta composer requests pass route-derived `worldId`",
+    ]
+    for phrase in required_contract_phrases:
+        assert phrase in contract
+
+    required_adr_phrases = [
+        "# ADR-0011: Private-Beta Route Ownership",
+        "Accepted",
+        "Mirror keeps `/` owned by the guided Phase 1 public Fog Harbor demo",
+        "The private-beta launch hub remains planning-only in Phase 51",
+        "Top-level `/perturb`, `/runtime/<session_id>`, and child runtime routes remain legacy",
+        "This decision does not add or alter public demo endpoints",
+    ]
+    for phrase in required_adr_phrases:
+        assert phrase in adr
+
+
+def test_world_scoped_navigation_does_not_label_public_demo_as_launch_hub() -> None:
+    world_route_expectations = {
+        Path("frontend/src/app/worlds/new/page.tsx"): '{ href: "/", label: "Public Demo", active: false }',
+        Path("frontend/src/app/worlds/[worldId]/page.tsx"): '{ href: "/", label: locale === "zh-CN" ? "公开演示" : "Public Demo", active: false }',
+        Path("frontend/src/app/worlds/[worldId]/perturb/page.tsx"): '{ href: "/", label: locale === "zh-CN" ? "公开演示" : "Public Demo", active: false }',
+        Path("frontend/src/app/worlds/[worldId]/review/page.tsx"): '{ href: "/", label: locale === "zh-CN" ? "公开演示" : "Public Demo", active: false }',
+        Path("frontend/src/app/worlds/[worldId]/runtime/[sessionId]/page.tsx"): '{ href: "/", label: locale === "zh-CN" ? "公开演示" : "Public Demo", active: false }',
+        Path(
+            "frontend/src/app/worlds/[worldId]/runtime/[sessionId]/explain/page.tsx"
+        ): '{ href: "/", label: locale === "zh-CN" ? "公开演示" : "Public Demo", active: false }',
+        Path(
+            "frontend/src/app/worlds/[worldId]/runtime/[sessionId]/report/page.tsx"
+        ): '{ href: "/", label: locale === "zh-CN" ? "公开演示" : "Public Demo", active: false }',
+    }
+
+    for path, expected_public_demo_link in world_route_expectations.items():
+        text = path.read_text(encoding="utf-8")
+        assert expected_public_demo_link in text
+        assert '"Launch Hub"' not in text
+        assert '"世界入口"' not in text
+
+
+def test_active_phase51_docs_point_to_route_contract_work() -> None:
+    required_docs = [
+        Path("README.md"),
+        Path("docs/plans/current-state-baseline.md"),
+        Path("docs/plans/phase-execution-queue.md"),
+        Path("docs/plans/phase-51-successor-gate-2026-05-18.md"),
+        Path("docs/plans/automation-roadmap.md"),
+    ]
+
+    for path in required_docs:
+        text = path.read_text(encoding="utf-8")
+        assert "`#405`" in text
+        assert "`#406`" in text
+        assert "Phase 51 Private-Beta Route Ownership Contract" in text
+        assert "private-beta launch hub remains planning-only" in text
+        assert "`docs/plans/phase-51-private-beta-route-contract-2026-05-18.md`" in text
+        assert "`docs/architecture/contracts.md`" in text
+        assert "`docs/decisions/ADR-0011-private-beta-route-ownership.md`" in text

--- a/backend/tests/test_phase51_successor_gate.py
+++ b/backend/tests/test_phase51_successor_gate.py
@@ -12,8 +12,8 @@ def test_phase51_successor_gate_exists_with_required_sections() -> None:
     gate = PHASE51_GATE_PATH.read_text(encoding="utf-8")
     required_sections = [
         "# Phase 51 Successor Gate",
-        "Issue: `#404` `Phase 51: sync repo truth after Phase 50 closeout`",
-        "Current work item: `#404` `Phase 51: sync repo truth after Phase 50 closeout`",
+        "Issue: `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract`",
+        "Current work item: `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract`",
         "## Phase 50 Closeout Evidence",
         "## Phase 51 Operational Queue",
         "## Protected-Core Lane Coverage",
@@ -38,6 +38,7 @@ def test_phase51_successor_gate_records_queue_and_boundaries() -> None:
         "`#405` `Phase 51: ratify private-beta route ownership and launch-hub contract`",
         "`#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`",
         "Private-beta route contract",
+        "Phase 51 Private-Beta Route Ownership Contract",
         "Runtime readiness and world-scoped session guards",
         "TODO[verify]: Codex UI tool-card",
         "Runtime generation duration is now recorded",

--- a/docs/architecture/contracts.md
+++ b/docs/architecture/contracts.md
@@ -471,6 +471,42 @@ All IDs must be serializable, stable across files, and traceable in `artifacts/`
   profile.
 - Phase 1 public demo mode does not start sessions, generate branches, upload corpus data, create worlds, enable Hosted GPT, accept BYOK, or call the OpenAI API.
 
+## Route Ownership Contract
+
+- `/` remains the guided Phase 1 public Fog Harbor demo.
+- `/review` remains the advanced read-only public-demo review surface for the same
+  precomputed artifacts.
+- `/api/health`, `/api/ready`, `/api/public-demo/manifest`, and
+  `/api/public-demo/artifacts/<artifact_id>` remain public-demo/readiness API surfaces.
+- `/worlds/<world_id>` remains the private-beta candidate world home when public-demo flags
+  are disabled in local or explicitly authorized private-beta environments.
+- `/worlds/new` remains a private-beta candidate creation route and must stay disabled in
+  public demo mode.
+- `/worlds/<world_id>/perturb` remains the main private-beta operator path.
+- `/worlds/<world_id>/runtime/<session_id>` and its `/explain` and `/report` children
+  remain world-scoped private-beta runtime surfaces.
+- `/worlds/<world_id>/review` remains the world-scoped private-beta review surface.
+- `/api/runtime/start-session`, `/api/runtime/generate-branch`,
+  `/api/runtime/rollback-session`, and `/api/worlds/create` remain private-beta mutation
+  APIs and must return `403` in public demo mode unless a reviewed private-preview override
+  explicitly applies.
+- Top-level `/changes/<branch_id>` and `/explain/<branch_id>` remain deterministic
+  public-demo support routes.
+- Top-level `/perturb`, `/runtime/<session_id>`, and child runtime routes are legacy
+  compatibility surfaces, not the canonical private-beta route owners. TODO[verify]: decide
+  whether to deprecate, redirect, or formally re-contract them before presenting them as a
+  private-beta main path.
+- The private-beta launch hub remains planning-only in Phase 51. A future launch hub must
+  not replace `/`, start sessions, generate branches, create worlds, upload corpora, enable
+  Hosted GPT, accept BYOK, or call model providers from the public path.
+- World-scoped navigation may link back to `/`, but it must label that route as the public
+  demo rather than as a launch hub until a future reviewed contract creates a real
+  launch-hub route.
+- TODO[verify]: if a launch hub becomes an implementation target, open a new reviewed work
+  item that names its route, access mode, public-demo interaction, and deployment posture.
+- TODO[verify]: verify that private-beta composer requests pass route-derived `worldId`
+  through every world-scoped mutation before expanding private-beta runtime surfaces.
+
 ## Artifact Contract
 
 ```text

--- a/docs/decisions/ADR-0011-private-beta-route-ownership.md
+++ b/docs/decisions/ADR-0011-private-beta-route-ownership.md
@@ -1,0 +1,68 @@
+# ADR-0011: Private-Beta Route Ownership
+
+## Status
+
+Accepted
+
+## Context
+
+Phase 50 kept the private-beta launch hub planning-only and left route placement unresolved.
+At the same time, the tracked app already has two distinct route families:
+
+- public-demo routes such as `/`, `/review`, `/api/public-demo/manifest`, and
+  `/api/public-demo/artifacts/<artifact_id>`
+- private-beta candidate routes under `/worlds/<world_id>` plus runtime and review children
+
+Replacing `/` with a launch hub would blur the Phase 1 public demo release boundary and could
+accidentally move private-beta mutation, Hosted GPT, BYOK, upload, auth, billing, database,
+object storage, quota, or async-runtime expectations into the public path.
+
+## Decision
+
+Mirror keeps `/` owned by the guided Phase 1 public Fog Harbor demo.
+
+`/review` remains the advanced read-only public-demo review surface. The private-beta
+candidate product path remains world-scoped under `/worlds/<world_id>` and related
+`/worlds/...` runtime/review routes when public-demo flags are disabled in local or
+explicitly authorized private-beta environments.
+
+The private-beta launch hub remains planning-only in Phase 51. A future launch hub must not
+replace `/` or move private-beta capabilities into the public path without a separate
+reviewed work item that names its route, access mode, public-demo interaction, and deployment
+posture.
+
+World-scoped navigation may link back to `/`, but that link must be labeled as the public
+demo rather than as a launch hub until a future reviewed contract creates a real launch-hub
+route.
+
+This decision does not add or alter public demo endpoints, Mirror Codex MCP tools/resources,
+Hosted GPT, BYOK, upload/ingest, auth, billing, database, object storage, quota, async task
+queues, `task_id`, retry/status/cleanup semantics, scenario DSL, claim/evidence shape, run
+trace shape, compare artifacts, or public demo artifact layout.
+
+Top-level `/perturb`, `/runtime/<session_id>`, and child runtime routes remain legacy
+compatibility surfaces. They are not the canonical private-beta route owners unless a future
+reviewed contract changes that status.
+
+## Consequences
+
+- The public release path keeps a stable, read-only, deterministic landing route.
+- Private-beta work can continue under explicit world-scoped routes without implying a public
+  launch hub or account system.
+- Future launch-hub work must start with a route/access/deployment contract before
+  implementation.
+- TODO[verify]: verify route/session mismatch handling before expanding private-beta runtime
+  surfaces.
+- TODO[verify]: verify that private-beta composer requests pass route-derived `worldId`
+  through every world-scoped mutation before treating runtime generation as route-safe.
+
+## Validation
+
+The route ownership contract is checked by:
+
+```bash
+python -m pytest backend/tests/test_phase51_route_contract_note.py backend/tests/test_phase51_successor_gate.py -q
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+git diff --check
+```

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -169,9 +169,10 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 51 is the active approved successor queue.
 - milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate` is open.
 - `#403` `Phase 51 exit gate` is open, blocked, and protected-core.
-- `#404` `Phase 51: sync repo truth after Phase 50 closeout` is the current ready work item.
-- `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract` is blocked until the Phase 51 baseline lands.
+- `#404` `Phase 51: sync repo truth after Phase 50 closeout` is closed by PR `#407`.
+- `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract` is the current ready work item.
 - `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards` is blocked until the route ownership contract lands.
+- Phase 51 Private-Beta Route Ownership Contract: private-beta launch hub remains planning-only and `/worlds/<world_id>` remains the private-beta candidate product path; the route note lives in `docs/plans/phase-51-private-beta-route-contract-2026-05-18.md`, and durable route ownership lives in `docs/architecture/contracts.md` and `docs/decisions/ADR-0011-private-beta-route-ownership.md`.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -252,9 +252,15 @@ This note records the completed Phase 50 runtime-boundary closeout and the appro
     - `docs/plans/phase-50-product-boundary-2026-05-18.md` records the boundary note
   - `gh issue list --milestone "Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate" --state all`
     - `#403` `Phase 51 exit gate` is `open`, `blocked`, and `lane:protected-core`
-    - `#404` `Phase 51: sync repo truth after Phase 50 closeout` is the current `status:ready` protected-core work item
-    - `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract` is `open` and blocked until repo truth is synced
+    - `#404` `Phase 51: sync repo truth after Phase 50 closeout` is `closed` by PR `#407`
+    - `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract` is the current `status:ready` protected-core work item
     - `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards` is `open` and blocked until the route contract lands
+  - Phase 51 Private-Beta Route Ownership Contract:
+    - private-beta launch hub remains planning-only
+    - `/` and `/review` remain public-demo surfaces
+    - `/worlds/<world_id>` remains the private-beta candidate product path
+    - `docs/plans/phase-51-private-beta-route-contract-2026-05-18.md` records the route contract note
+    - `docs/architecture/contracts.md` and `docs/decisions/ADR-0011-private-beta-route-ownership.md` record the durable route ownership contract
 
 ## Trusted Source Of Truth
 
@@ -291,9 +297,12 @@ This note records the completed Phase 50 runtime-boundary closeout and the appro
 - `#398` `Phase 50: measure runtime generation duration before task_id decision` is closed by PR `#400`.
 - `#401` `Phase 50: ratify private-beta launch hub and public-path boundary` is closed by PR `#402`.
 - Phase 50 Product Boundary Decision: launch hub remains planning-only for now; current tracked code keeps `/` as the guided public demo.
-- `#404` `Phase 51: sync repo truth after Phase 50 closeout` is the current ready work item.
-- `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract` is blocked until repo truth is synced.
+- `#404` `Phase 51: sync repo truth after Phase 50 closeout` is closed by PR `#407`.
+- `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract` is the current ready work item.
 - `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards` is blocked until the route ownership contract lands.
+- Phase 51 Private-Beta Route Ownership Contract: private-beta launch hub remains planning-only; `/` and `/review` stay public-demo surfaces, while `/worlds/<world_id>` remains the private-beta candidate product path.
+- The Phase 51 route contract note lives in `docs/plans/phase-51-private-beta-route-contract-2026-05-18.md`.
+- The durable route ownership contract lives in `docs/architecture/contracts.md` and `docs/decisions/ADR-0011-private-beta-route-ownership.md`.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.

--- a/docs/plans/phase-51-private-beta-route-contract-2026-05-18.md
+++ b/docs/plans/phase-51-private-beta-route-contract-2026-05-18.md
@@ -1,0 +1,159 @@
+# Phase 51 Private-Beta Route Ownership Contract
+
+Date: 2026-05-18
+
+Issue: `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract`
+
+## Decision
+
+The private-beta launch hub remains planning-only in Phase 51.
+
+`/` remains the guided Phase 1 public Fog Harbor demo. `/review` remains the advanced
+read-only public-demo review surface. The private-beta candidate product path remains
+world-scoped under `/worlds/<world_id>` and its child routes when public-demo flags are
+disabled in local or explicitly authorized private-beta environments.
+
+No route implementation changes land in `#405`. World-scoped navigation may label `/` as
+the public demo to match the route owner, but this does not add a launch hub or move any
+private-beta capability. A future launch hub must not replace `/` or move private-beta
+capabilities into the public path without a new reviewed work item that explicitly updates
+the route contract, deployment posture, and public-demo interaction model.
+
+## Evidence
+
+- `README.md` documents `/` and `/review` as public read-only endpoints, then lists
+  private-beta candidate entrypoints separately under `/worlds/<world_id>`.
+- `docs/plans/phase-50-product-boundary-2026-05-18.md` records that the launch hub remains
+  planning-only for now and that `/worlds/<world_id>` remains the private-beta candidate
+  product path.
+- `docs/architecture/contracts.md` states that Phase 1 public demo mode does not start
+  sessions, generate branches, upload corpus data, create worlds, enable Hosted GPT, accept
+  BYOK, or call the OpenAI API.
+- `docs/deploy/render-public-demo.md` records that `/` loads the guided public demo,
+  `/review` loads the advanced read-only review surface, and runtime mutation endpoints
+  return `403` in public demo mode.
+- `docs/deploy/mirror-codex-plugin.md` records that the Mirror Codex plugin is read-only and
+  must not upload data, call model providers, create worlds, mutate runtime state, or read
+  arbitrary filesystem paths.
+- `docs/architecture/contracts.md` now records the durable public/private route ownership
+  contract, and `docs/decisions/ADR-0011-private-beta-route-ownership.md` records the
+  architectural decision not to move `/` into a launch hub in this phase.
+- Current frontend route files already separate public demo routes from world-scoped
+  private-beta candidate routes:
+  - `frontend/src/app/page.tsx`
+  - `frontend/src/app/review/page.tsx`
+  - `frontend/src/app/worlds/new/page.tsx`
+  - `frontend/src/app/worlds/[worldId]/page.tsx`
+  - `frontend/src/app/worlds/[worldId]/perturb/page.tsx`
+  - `frontend/src/app/worlds/[worldId]/runtime/[sessionId]/page.tsx`
+  - `frontend/src/app/worlds/[worldId]/runtime/[sessionId]/explain/page.tsx`
+  - `frontend/src/app/worlds/[worldId]/runtime/[sessionId]/report/page.tsx`
+  - `frontend/src/app/worlds/[worldId]/review/page.tsx`
+
+## Route Ownership Table
+
+| Route | Owner | Contract |
+| --- | --- | --- |
+| `/` | Phase 1 public demo | `/` remains the guided Phase 1 public Fog Harbor demo. It serves precomputed demo artifacts and must not expose private-beta runtime mutation. |
+| `/review` | Phase 1 public demo | `/review` remains the advanced read-only public-demo review surface for the same precomputed artifacts. |
+| `/api/health` | Public readiness surface | Health stays public and minimal. It must not expose local filesystem paths, provider configuration, or private-beta state. |
+| `/api/ready` | Public readiness surface | Readiness stays public-demo aware and must surface degraded readiness without leaking arbitrary paths. |
+| `/api/public-demo/manifest` | Public demo artifact API | Manifest stays allowlisted and logical-artifact based. |
+| `/api/public-demo/artifacts/<id>` | Public demo artifact API | Artifact reads stay allowlisted and logical-artifact based. |
+| `/worlds/<world_id>` | Private-beta candidate product path | `/worlds/<world_id>` remains the private-beta candidate world home. |
+| `/worlds/new` | Private-beta candidate product path | `/worlds/new` remains a private-beta candidate creation route and must stay disabled in public demo mode. |
+| `/worlds/<world_id>/perturb` | Private-beta candidate product path | `/worlds/<world_id>/perturb` remains the main private-beta operator path. |
+| `/worlds/<world_id>/runtime/<session_id>` | Private-beta candidate product path | `/worlds/<world_id>/runtime/<session_id>` remains the world-scoped runtime workspace. |
+| `/worlds/<world_id>/runtime/<session_id>/explain` | Private-beta candidate product path | `/worlds/<world_id>/runtime/<session_id>/explain` remains the world-scoped explain workspace. |
+| `/worlds/<world_id>/runtime/<session_id>/report` | Private-beta candidate product path | `/worlds/<world_id>/runtime/<session_id>/report` remains the world-scoped report workspace. |
+| `/worlds/<world_id>/review` | Private-beta candidate product path | `/worlds/<world_id>/review` remains the world-scoped private-beta review surface. |
+| `/api/runtime/start-session` | Private-beta mutation API | Runtime mutation must stay disabled in public demo mode and must remain world-scoped. |
+| `/api/runtime/generate-branch` | Private-beta mutation API | Runtime mutation must stay disabled in public demo mode and must remain world-scoped. |
+| `/api/runtime/rollback-session` | Private-beta mutation API | Runtime mutation must stay disabled in public demo mode and must remain session-scoped. |
+| `/api/worlds/create` | Private-beta mutation API | World creation must stay disabled in public demo mode. |
+| `/changes/<branch_id>` | Public demo support route | Legacy public-demo support route for deterministic artifact inspection; it must stay artifact-backed and read-only. |
+| `/explain/<branch_id>` | Public demo support route | Legacy public-demo support route for deterministic artifact explanation; it must stay artifact-backed and read-only. |
+| `/perturb` | Legacy compatibility route | Legacy route retained for compatibility/reference only; it is not the canonical private-beta route owner. |
+| `/runtime/<session_id>` and child routes | Legacy compatibility route | Legacy runtime routes remain Fog Harbor-defaulted compatibility surfaces until separately deprecated, redirected, or brought under a reviewed route contract. |
+
+## Launch Hub Contract
+
+The private-beta launch hub remains planning-only in Phase 51.
+
+A future launch hub may be considered only as a reviewed product-path entry point that helps
+authorized operators choose an existing bounded world or move into the existing
+`/worlds/<world_id>` path. It may not be implemented as an implicit replacement for `/`, and
+it may not blur the public demo, private-beta, or plugin boundaries.
+
+A future launch hub must not replace `/`. It must not start sessions, generate branches, create worlds, upload corpora, enable Hosted GPT, accept BYOK, or call model providers from the public path. If a later implementation needs any of those capabilities, that later work must first update the route contract and the relevant deployment/access-control contract.
+
+## Public Demo Boundary
+
+The public demo remains read-only, anonymous, deterministic-only, and artifact-backed.
+
+`/` and `/review` stay public-demo surfaces. Public demo mode must keep runtime mutation
+endpoints disabled. Public API responses must not expose absolute repository paths, runtime
+paths, provider secrets, arbitrary path lookup results, or private-beta state.
+
+## Plugin Boundary
+
+Mirror Codex plugin remains read-only.
+
+The plugin remains scoped to deterministic public-demo inspection. It must not gain mutating
+MCP tools, runtime mutation, Hosted GPT, BYOK, uploads, auth, billing, database, object
+storage, quota behavior, provider calls, or filesystem-path disclosure without a separate
+reviewed plugin contract.
+
+## Private-Beta Boundary
+
+`/worlds/<world_id>` remains the private-beta candidate product path.
+
+Private-beta runtime behavior may continue to use explicitly configured local or authorized
+deployment settings. Hosted private-beta model access remains server-side only, beta-gated,
+quota-limited, and disabled by default. Browser-submitted BYO credentials remain
+request-scoped and must not be persisted into session, node, report, claims, or
+decision-trace artifacts.
+
+## Follow-Up Gate
+
+- TODO[verify]: verify the tracked frontend route tree before treating any private-beta path
+  beyond the documented `/worlds/...` candidate routes as durable route ownership.
+- TODO[verify]: if a launch hub becomes an implementation target, open a new reviewed work item
+  that names its route, access mode, public-demo interaction, and deployment posture.
+- TODO[verify]: verify route/session mismatch handling in `#406` before expanding
+  private-beta runtime surfaces.
+- TODO[verify]: verify that private-beta composer requests pass route-derived `worldId`
+  through every world-scoped mutation before treating runtime generation as route-safe.
+- TODO[verify]: rerun hosted/private-beta model measurements before introducing `task_id`,
+  worker, retry, status, or cleanup semantics.
+- TODO[verify]: keep untracked April/private-beta planning notes as candidate inputs only
+  until a PR intentionally promotes them.
+
+## Non-Goals
+
+- Do not implement a launch hub route in `#405`.
+- Do not replace `/` or widen the public path.
+- Do not change public demo behavior.
+- Do not change Mirror Codex plugin MCP tools or resources.
+- Do not add mutating Mirror Codex MCP tools.
+- Do not add Hosted GPT, BYOK, upload, auth, billing, database, object storage, or quota behavior to the public path or plugin path.
+- Do not implement async workers, queues, `task_id`, retry, status, or cleanup semantics.
+- Do not change session or node manifest shape.
+- Do not change compare artifact shape.
+- Do not change scenario DSL, claim labels, report claim `evidence_ids`, run trace shape,
+  public demo artifact layout, or plugin MCP contract.
+- Do not build real-person personas, digital doubles, political persuasion, law-enforcement,
+  hiring, credit, medical, or judicial decision systems.
+- Do not present Mirror as real-world prediction or package simulation output as certain
+  real-world conclusions.
+
+## Validation Commands
+
+```powershell
+python -m pytest backend/tests/test_phase51_route_contract_note.py backend/tests/test_phase51_successor_gate.py backend/tests/test_phase50_product_boundary_note.py backend/tests/test_automation.py -q
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+python -m backend.app.cli classify-lane --files README.md docs/architecture/contracts.md docs/decisions/ADR-0011-private-beta-route-ownership.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-51-successor-gate-2026-05-18.md docs/plans/phase-51-private-beta-route-contract-2026-05-18.md backend/tests/test_phase51_route_contract_note.py backend/tests/test_phase51_successor_gate.py
+git diff --check
+./make.ps1 eval-demo
+```

--- a/docs/plans/phase-51-successor-gate-2026-05-18.md
+++ b/docs/plans/phase-51-successor-gate-2026-05-18.md
@@ -2,9 +2,9 @@
 
 Date: 2026-05-18
 
-Issue: `#404` `Phase 51: sync repo truth after Phase 50 closeout`
+Issue: `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract`
 
-Current work item: `#404` `Phase 51: sync repo truth after Phase 50 closeout`
+Current work item: `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract`
 
 This note records the post-Phase-50 baseline and opens the Phase 51 successor queue.
 Phase 51 is a protected-core route-contract and runtime-readiness phase for the
@@ -45,12 +45,12 @@ Active GitHub objects:
   - Status: blocked closeout gate for Phase 51.
 - `#404` `Phase 51: sync repo truth after Phase 50 closeout`
   - Lane: `protected-core`.
-  - Status: current ready work item.
+  - Status: closed by PR `#407`.
   - Scope: sync tracked docs to Phase 51 after closing Phase 50.
 - `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract`
   - Lane: `protected-core`.
-  - Status: blocked until the repo-truth sync lands.
-  - Scope: record the Private-beta route contract before any launch-hub implementation.
+  - Status: current ready work item.
+  - Scope: record the Phase 51 Private-Beta Route Ownership Contract before any launch-hub implementation.
 - `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`
   - Lane: `protected-core`.
   - Status: blocked until the route ownership contract lands.
@@ -59,7 +59,7 @@ Active GitHub objects:
 
 `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
 with Phase 51 as the only open milestone, `#403` as the protected blocked exit gate, and
-`#404` as the current ready work item.
+`#405` as the current ready work item.
 
 ## Protected-Core Lane Coverage
 
@@ -101,11 +101,19 @@ public demo artifact layout, or the Mirror Codex MCP contract.
 - Phase 50 Product Boundary Decision is recorded in
   `docs/plans/phase-50-product-boundary-2026-05-18.md`.
   The launch hub remains planning-only for now; `/` remains the guided public demo.
-  TODO[verify]: open a reviewed route contract before replacing `/` or adding a private-beta
-  launch hub route.
+- Phase 51 Private-Beta Route Ownership Contract is recorded in
+  `docs/plans/phase-51-private-beta-route-contract-2026-05-18.md`.
+  The private-beta launch hub remains planning-only; `/` and `/review` stay public-demo
+  surfaces, while `/worlds/<world_id>` remains the private-beta candidate product path.
+  TODO[verify]: if a launch hub becomes an implementation target, open a new reviewed work
+  item that names its route, access mode, public-demo interaction, and deployment posture.
+- TODO[verify]: verify the tracked frontend route tree before treating any private-beta path
+  beyond the documented `/worlds/...` candidate routes as durable route ownership.
 - TODO[verify]: verify route/session mismatch handling before expanding private-beta runtime
   surfaces. World-scoped session guards must reject or clearly fail any request whose route
   `world_id` conflicts with the session's durable world id.
+- TODO[verify]: verify that private-beta composer requests pass route-derived `worldId`
+  through every world-scoped mutation before treating runtime generation as route-safe.
 - Latest-session versus latest-activity semantics are ratified as `last_activity_at`
   ordering with `created_at` fallback; TODO[verify]: re-open contract review before adding
   other activity sources or changing failed-operation activity behavior.
@@ -136,10 +144,13 @@ public demo artifact layout, or the Mirror Codex MCP contract.
      recreate them.
 
 2. Private-beta route ownership contract
-   - Record the reviewed route contract before replacing `/` or adding a private-beta launch
-     hub route.
+   - Record the reviewed route contract in
+     `docs/plans/phase-51-private-beta-route-contract-2026-05-18.md`.
+   - Promote the durable route boundary into `docs/architecture/contracts.md` and
+     `docs/decisions/ADR-0011-private-beta-route-ownership.md`.
    - Keep `/` as the guided public demo and `/worlds/<world_id>` as the private-beta
      candidate product path unless the contract explicitly changes.
+   - Private-beta route contract: keep the private-beta launch hub planning-only in Phase 51.
    - Preserve public demo, plugin, hosted-model, and async-runtime boundaries.
 
 3. Runtime readiness and world-scoped session guards
@@ -165,11 +176,11 @@ Phase 51 must stay aligned with `mirror.md` and `AGENTS.md`:
 ## Non-Goals
 
 - Do not implement a private-beta launch hub, move `/`, or widen the public path inside
-  `#404`.
+  `#405`.
 - Do not implement async workers, queues, `task_id`, retry, status, cleanup, checkpoint
-  mutation/deletion, or restore semantics inside `#404`.
+  mutation/deletion, or restore semantics inside `#405`.
 - Do not change scenario DSL, claim/evidence shape, run trace shape, compare artifact shape,
-  public demo artifact layout, or plugin MCP tool/resource contract in `#404`.
+  public demo artifact layout, or plugin MCP tool/resource contract in `#405`.
 - Do not add Hosted GPT, BYOK, upload, auth, billing, database, object storage, or quota
   behavior to the public path or plugin path.
 - Do not add mutating Mirror Codex MCP tools.
@@ -194,11 +205,12 @@ git diff --check
 For `#405`, run:
 
 ```powershell
-python -m pytest backend/tests/test_phase51_successor_gate.py -q
+python -m pytest backend/tests/test_phase51_route_contract_note.py backend/tests/test_phase51_successor_gate.py backend/tests/test_phase50_product_boundary_note.py backend/tests/test_automation.py -q
 python scripts/check_no_secrets.py
 python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
-python -m backend.app.cli classify-lane --files <changed-files>
+python -m backend.app.cli classify-lane --files README.md docs/architecture/contracts.md docs/decisions/ADR-0011-private-beta-route-ownership.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-51-successor-gate-2026-05-18.md docs/plans/phase-51-private-beta-route-contract-2026-05-18.md backend/tests/test_phase51_route_contract_note.py backend/tests/test_phase51_successor_gate.py
 git diff --check
+./make.ps1 eval-demo
 ```
 
 For `#406`, run:

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -72,16 +72,19 @@ Local phase audits currently report:
   - open and blocked
   - labeled `lane:protected-core` because it is the protected closeout gate
 - `#404` `Phase 51: sync repo truth after Phase 50 closeout`
-  - current protected-core repo-truth work item
-  - syncs durable docs to Phase 51
+  - closed by PR `#407`
+  - synced durable docs to Phase 51
 - `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract`
-  - open and blocked until the repo-truth sync lands
-  - records the reviewed route contract before any launch-hub implementation
+  - current protected-core route-contract work item
+  - records the reviewed Phase 51 Private-Beta Route Ownership Contract before any launch-hub implementation
+  - Phase 51 Private-Beta Route Ownership Contract: private-beta launch hub remains planning-only
+  - durable route ownership contract: `docs/architecture/contracts.md` and `docs/decisions/ADR-0011-private-beta-route-ownership.md`
 - `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`
   - open and blocked until the route contract lands
   - verifies runtime readiness and world-scoped session guards before runtime surfaces widen
 - phase gate baseline
   - active Phase 51 gate note: `docs/plans/phase-51-successor-gate-2026-05-18.md`
+  - route contract note: `docs/plans/phase-51-private-beta-route-contract-2026-05-18.md`
 
 ## Phase 50 Closeout
 

--- a/frontend/src/app/worlds/[worldId]/page.tsx
+++ b/frontend/src/app/worlds/[worldId]/page.tsx
@@ -84,7 +84,7 @@ export default async function WorldHomePage({ params, searchParams }: PageProps)
           locale={locale}
           eyebrow={locale === "zh-CN" ? "Mirror 引擎 / 世界主页" : "Mirror Engine / World Home"}
           items={[
-            { href: "/", label: locale === "zh-CN" ? "世界入口" : "Launch Hub", active: false },
+            { href: "/", label: locale === "zh-CN" ? "公开演示" : "Public Demo", active: false },
             { href: worldHref, label: locale === "zh-CN" ? "世界" : "World", active: true },
             { href: perturbHref, label: locale === "zh-CN" ? "扰动" : "Perturb", active: false },
             { href: reviewHref, label: locale === "zh-CN" ? "审阅" : "Review", active: false },

--- a/frontend/src/app/worlds/[worldId]/perturb/page.tsx
+++ b/frontend/src/app/worlds/[worldId]/perturb/page.tsx
@@ -89,7 +89,7 @@ export default async function WorldPerturbPage({ params, searchParams }: PagePro
           locale={locale}
           eyebrow={locale === "zh-CN" ? "Mirror 引擎 / 私有 Beta" : "Mirror Engine / Private Beta"}
           items={[
-            { href: "/", label: locale === "zh-CN" ? "世界入口" : "Launch Hub", active: false },
+            { href: "/", label: locale === "zh-CN" ? "公开演示" : "Public Demo", active: false },
             { href: worldHref, label: locale === "zh-CN" ? "世界" : "World", active: false },
             { href: perturbHref, label: locale === "zh-CN" ? "扰动" : "Perturb", active: true },
             { href: reviewHref, label: locale === "zh-CN" ? "审阅" : "Review", active: false },

--- a/frontend/src/app/worlds/[worldId]/review/page.tsx
+++ b/frontend/src/app/worlds/[worldId]/review/page.tsx
@@ -154,7 +154,7 @@ export default async function WorldReviewPage({ params, searchParams }: PageProp
           locale={locale}
           eyebrow={locale === "zh-CN" ? "Mirror 引擎 / 私有 Beta" : "Mirror Engine / Private Beta"}
           items={[
-            { href: "/", label: locale === "zh-CN" ? "世界入口" : "Launch Hub", active: false },
+            { href: "/", label: locale === "zh-CN" ? "公开演示" : "Public Demo", active: false },
             { href: worldHref, label: locale === "zh-CN" ? "世界" : "World", active: false },
             { href: perturbHref, label: locale === "zh-CN" ? "扰动" : "Perturb", active: false },
             { href: reviewHref, label: locale === "zh-CN" ? "审阅" : "Review", active: true },

--- a/frontend/src/app/worlds/[worldId]/runtime/[sessionId]/explain/page.tsx
+++ b/frontend/src/app/worlds/[worldId]/runtime/[sessionId]/explain/page.tsx
@@ -92,7 +92,7 @@ export default async function WorldRuntimeExplainPage({ params, searchParams }: 
           locale={locale}
           eyebrow={locale === "zh-CN" ? "Mirror 引擎 / 私有 Beta" : "Mirror Engine / Private Beta"}
           items={[
-            { href: "/", label: locale === "zh-CN" ? "世界入口" : "Launch Hub", active: false },
+            { href: "/", label: locale === "zh-CN" ? "公开演示" : "Public Demo", active: false },
             { href: worldHref, label: locale === "zh-CN" ? "世界" : "World", active: false },
             { href: perturbHref, label: locale === "zh-CN" ? "扰动" : "Perturb", active: false },
             { href: explainHref, label: locale === "zh-CN" ? "解释" : "Explain", active: true },

--- a/frontend/src/app/worlds/[worldId]/runtime/[sessionId]/page.tsx
+++ b/frontend/src/app/worlds/[worldId]/runtime/[sessionId]/page.tsx
@@ -88,7 +88,7 @@ export default async function WorldRuntimePage({ params, searchParams }: PagePro
           locale={locale}
           eyebrow={locale === "zh-CN" ? "Mirror 引擎 / 私有 Beta" : "Mirror Engine / Private Beta"}
           items={[
-            { href: "/", label: locale === "zh-CN" ? "世界入口" : "Launch Hub", active: false },
+            { href: "/", label: locale === "zh-CN" ? "公开演示" : "Public Demo", active: false },
             { href: worldHref, label: locale === "zh-CN" ? "世界" : "World", active: false },
             { href: perturbHref, label: locale === "zh-CN" ? "扰动" : "Perturb", active: false },
             { href: runtimeHref, label: locale === "zh-CN" ? "结果" : "Runtime", active: true },

--- a/frontend/src/app/worlds/[worldId]/runtime/[sessionId]/report/page.tsx
+++ b/frontend/src/app/worlds/[worldId]/runtime/[sessionId]/report/page.tsx
@@ -91,7 +91,7 @@ export default async function WorldRuntimeReportPage({ params, searchParams }: P
           locale={locale}
           eyebrow={locale === "zh-CN" ? "Mirror 引擎 / 私有 Beta" : "Mirror Engine / Private Beta"}
           items={[
-            { href: "/", label: locale === "zh-CN" ? "世界入口" : "Launch Hub", active: false },
+            { href: "/", label: locale === "zh-CN" ? "公开演示" : "Public Demo", active: false },
             { href: worldHref, label: locale === "zh-CN" ? "世界" : "World", active: false },
             { href: perturbHref, label: locale === "zh-CN" ? "扰动" : "Perturb", active: false },
             { href: reportHref, label: locale === "zh-CN" ? "报告" : "Report", active: true },

--- a/frontend/src/app/worlds/new/page.tsx
+++ b/frontend/src/app/worlds/new/page.tsx
@@ -26,7 +26,7 @@ export default async function CreateWorldPage() {
         locale={locale}
         eyebrow={readOnlyPublicDemo ? "Mirror Public Demo" : "Mirror Engine / Private Beta"}
         items={[
-          { href: "/", label: readOnlyPublicDemo ? "Public Demo" : "Launch Hub", active: false },
+          { href: "/", label: "Public Demo", active: false },
           { href: "/review", label: "Advanced Review", active: false },
           { href: "/worlds/new", label: "Create World", active: true }
         ]}


### PR DESCRIPTION
## Summary
- ratify the Phase 51 private-beta route ownership contract in plans, core contracts, and ADR-0011
- keep `/` and `/review` public-demo owned while `/worlds/<world_id>` remains the private-beta candidate path
- correct world-scoped navigation labels so links to `/` say Public Demo rather than Launch Hub
- keep launch hub planning-only and carry runtime/worldId checks into #406

## Validation
- `python -m pytest backend/tests/test_phase51_route_contract_note.py backend/tests/test_phase51_successor_gate.py backend/tests/test_phase50_product_boundary_note.py backend/tests/test_automation.py -q` -> 21 passed
- `npm run build --prefix frontend` -> passed
- `python scripts/check_no_secrets.py` -> passed
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` -> ready, active Phase 51, ready #405
- `python -m backend.app.cli classify-lane --files README.md docs/architecture/contracts.md docs/decisions/ADR-0011-private-beta-route-ownership.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-51-successor-gate-2026-05-18.md docs/plans/phase-51-private-beta-route-contract-2026-05-18.md backend/tests/test_phase51_route_contract_note.py backend/tests/test_phase51_successor_gate.py frontend/src/app/worlds/new/page.tsx frontend/src/app/worlds/[worldId]/page.tsx frontend/src/app/worlds/[worldId]/perturb/page.tsx frontend/src/app/worlds/[worldId]/review/page.tsx frontend/src/app/worlds/[worldId]/runtime/[sessionId]/page.tsx frontend/src/app/worlds/[worldId]/runtime/[sessionId]/explain/page.tsx frontend/src/app/worlds/[worldId]/runtime/[sessionId]/report/page.tsx` -> lane:protected-core
- `git diff --check` -> passed
- `./make.ps1 test` -> 107 passed
- `./make.ps1 eval-demo` -> pass (23/23)

Closes #405