### PR TITLE
Phase 51 runtime world guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,13 @@ remain the private-beta candidate product path. See
 contract is also recorded in `docs/architecture/contracts.md` and
 `docs/decisions/ADR-0011-private-beta-route-ownership.md`.
 
+Phase 51 Runtime Readiness and World-Scoped Guard Verification (`#406`): synchronous v1
+generation remains the current runtime contract. The private-beta composer now passes
+route-derived `worldId` into branch generation, CLI-backed mutations pass `--world`, backend
+session services reject expected-world mismatches, and world-scoped workspace loading rejects
+session or node manifests that conflict with route `worldId` or `sessionId`. See
+`docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`.
+
 ---
 
 ## What You Can Inspect Locally | 本地能看到什么
@@ -278,7 +285,7 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - Phase 48 is closed after PR `#382`, issue `#375`, and milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
 - Phase 49 is closed after PR `#395`, issue `#383`, and milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; completed work items were `#384`, `#386`, `#388`, `#390`, `#392`, and `#394`.
 - Phase 50 is closed after PR `#402`, issue `#396`, and milestone `Phase 50 - Runtime Orchestration Measurement and Product Boundary`; completed work items were `#397`, `#398`, and `#401`. Phase 50 measured before any `task_id` or worker contract is introduced and kept the private-beta launch hub planning-only for now.
-- Phase 51 is the active approved successor queue: `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`; `audit-github-queue` reports `ready` with `#403` as the blocked exit gate, `#404` closed by PR `#407`, `#405` as the current ready private-beta route ownership contract, and `#406` as the blocked runtime readiness and world-scoped session guards item.
+- Phase 51 is the active approved successor queue: `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`; private-beta route ownership is ratified by `#405`/PR `#408`, and `audit-github-queue` reports `ready` with `#403` as the blocked exit gate, `#404` closed by PR `#407`, `#405` closed by PR `#408`, and `#406` as the current ready runtime readiness and world-scoped session guards item.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
 - Fog Harbor remains the canonical demo world; `museum-night` is the minimal transfer world used to prove the pipeline is not single-world-only.
 

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -72,6 +72,7 @@ def build_parser() -> argparse.ArgumentParser:
     create_world.add_argument("--spec", required=True)
 
     generate_runtime = subparsers.add_parser("generate-branch", help="Generate one child branch from a session node")
+    generate_runtime.add_argument("--world")
     generate_runtime.add_argument("--session", required=True)
     generate_runtime.add_argument("--from", dest="from_node", required=True)
     generate_runtime.add_argument("--perturbation", required=True)
@@ -79,6 +80,7 @@ def build_parser() -> argparse.ArgumentParser:
     generate_runtime.add_argument("--beta-user-id")
 
     rollback_runtime = subparsers.add_parser("rollback-session", help="Move a session's active pointer back to an existing node")
+    rollback_runtime.add_argument("--world")
     rollback_runtime.add_argument("--session", required=True)
     rollback_runtime.add_argument("--to", dest="to_node", required=True)
     rollback_runtime.add_argument("--artifacts-root", required=True)
@@ -199,6 +201,7 @@ def main(argv: list[str] | None = None) -> int:
             repo_root=settings.repo_root,
             artifacts_root=Path(args.artifacts_root),
             beta_user_id=args.beta_user_id,
+            expected_world_id=args.world,
         )
         print(json.dumps(payload.model_dump(), indent=2, ensure_ascii=False))
         return 0
@@ -209,6 +212,7 @@ def main(argv: list[str] | None = None) -> int:
             args.to_node,
             repo_root=settings.repo_root,
             artifacts_root=Path(args.artifacts_root),
+            expected_world_id=args.world,
         )
         print(json.dumps(payload.model_dump(), indent=2, ensure_ascii=False))
         return 0

--- a/backend/app/sessions/service.py
+++ b/backend/app/sessions/service.py
@@ -395,6 +395,7 @@ def generate_branch(
     repo_root: Path | None = None,
     artifacts_root: Path | None = None,
     beta_user_id: str | None = None,
+    expected_world_id: str | None = None,
 ) -> SimulationSessionManifest:
     resolved_artifacts_root = _resolve_session_artifacts_root(
         session_id,
@@ -403,6 +404,10 @@ def generate_branch(
     )
 
     session = _load_session_manifest(session_id, resolved_artifacts_root)
+    if expected_world_id and session.world_id != expected_world_id:
+        raise ValueError(
+            f"Session `{session_id}` belongs to world `{session.world_id}`, not `{expected_world_id}`."
+        )
     quota_note = None
     if session.decision_config.provider == HOSTED_PROVIDER:
         validate_hosted_model_access(model_id=session.decision_config.model_id)
@@ -532,6 +537,7 @@ def rollback_session(
     *,
     repo_root: Path | None = None,
     artifacts_root: Path | None = None,
+    expected_world_id: str | None = None,
 ) -> SimulationSessionManifest:
     resolved_artifacts_root = _resolve_session_artifacts_root(
         session_id,
@@ -540,6 +546,10 @@ def rollback_session(
     )
 
     session = _load_session_manifest(session_id, resolved_artifacts_root)
+    if expected_world_id and session.world_id != expected_world_id:
+        raise ValueError(
+            f"Session `{session_id}` belongs to world `{session.world_id}`, not `{expected_world_id}`."
+        )
     _ = repo_root
     if not any(node.node_id == node_id for node in session.nodes):
         raise ValueError(f"Unknown rollback target `{node_id}` in session `{session_id}`.")

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -455,6 +455,147 @@ def test_cli_generate_branch_writes_child_node_and_compare(tmp_path: Path, capsy
     assert (tmp_path / child_node["decision_trace_path"]).exists()
 
 
+def test_generate_branch_rejects_expected_world_mismatch(tmp_path: Path, capsys) -> None:
+    settings = get_settings()
+    assert main(["ingest", str(settings.manifest_path), "--out", str(tmp_path / "ingest")]) == 0
+    assert main(["build-graph", str(tmp_path / "ingest" / "chunks.jsonl"), "--out", str(tmp_path / "graph")]) == 0
+    assert main(["personas", str(tmp_path / "graph" / "graph.json"), "--out", str(tmp_path / "personas")]) == 0
+    capsys.readouterr()
+
+    assert (
+        main(
+            [
+                "start-session",
+                "--world",
+                "fog-harbor-east-gate",
+                "--scenario",
+                "scenario_baseline",
+                "--artifacts-root",
+                str(tmp_path),
+            ]
+        )
+        == 0
+    )
+    session_payload = json.loads(capsys.readouterr().out)
+    perturbation = json.dumps(
+        {
+            "kind": "delay_document",
+            "target_id": "doc_ledger_copy",
+            "timing": "before_publication",
+            "summary": "Delay the copied ledger before it reaches the public decision loop.",
+            "parameters": {
+                "actor_id": "entity_lin_lan",
+                "delay_turns": 2,
+                "cause": "courier_interruption",
+            },
+        }
+    )
+
+    with pytest.raises(ValueError, match="belongs to world"):
+        sessions_service.generate_branch(
+            session_payload["session_id"],
+            "node_root",
+            perturbation,
+            repo_root=settings.repo_root,
+            artifacts_root=tmp_path,
+            expected_world_id="museum-night",
+        )
+
+
+def test_rollback_session_rejects_expected_world_mismatch(tmp_path: Path, capsys) -> None:
+    settings = get_settings()
+    assert main(["ingest", str(settings.manifest_path), "--out", str(tmp_path / "ingest")]) == 0
+    assert main(["build-graph", str(tmp_path / "ingest" / "chunks.jsonl"), "--out", str(tmp_path / "graph")]) == 0
+    assert main(["personas", str(tmp_path / "graph" / "graph.json"), "--out", str(tmp_path / "personas")]) == 0
+    capsys.readouterr()
+
+    assert (
+        main(
+            [
+                "start-session",
+                "--world",
+                "fog-harbor-east-gate",
+                "--scenario",
+                "scenario_baseline",
+                "--artifacts-root",
+                str(tmp_path),
+            ]
+        )
+        == 0
+    )
+    session_payload = json.loads(capsys.readouterr().out)
+
+    with pytest.raises(ValueError, match="belongs to world"):
+        sessions_service.rollback_session(
+            session_payload["session_id"],
+            "node_root",
+            repo_root=settings.repo_root,
+            artifacts_root=tmp_path,
+            expected_world_id="museum-night",
+        )
+
+
+def test_cli_generate_branch_passes_expected_world_guard(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    captured: dict[str, str | Path | None] = {}
+
+    def fake_generate_branch(
+        session_id: str,
+        node_id: str,
+        perturbation: str,
+        *,
+        repo_root: Path | None = None,
+        artifacts_root: Path | None = None,
+        beta_user_id: str | None = None,
+        expected_world_id: str | None = None,
+    ):
+        captured.update(
+            {
+                "session_id": session_id,
+                "node_id": node_id,
+                "perturbation": perturbation,
+                "repo_root": repo_root,
+                "artifacts_root": artifacts_root,
+                "beta_user_id": beta_user_id,
+                "expected_world_id": expected_world_id,
+            }
+        )
+        return sessions_service.start_session(
+            "fog-harbor-east-gate",
+            "scenario_baseline",
+            repo_root=get_settings().repo_root,
+            artifacts_root=tmp_path,
+        )
+
+    monkeypatch.setattr(cli_module, "generate_branch", fake_generate_branch)
+
+    assert (
+        main(
+            [
+                "generate-branch",
+                "--world",
+                "fog-harbor-east-gate",
+                "--session",
+                "session_demo",
+                "--from",
+                "node_root",
+                "--perturbation",
+                "{}",
+                "--artifacts-root",
+                str(tmp_path),
+                "--beta-user-id",
+                "beta-user",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert captured["expected_world_id"] == "fog-harbor-east-gate"
+    assert captured["beta_user_id"] == "beta-user"
+
+
 def test_cli_generate_branch_uses_session_decision_model(tmp_path: Path, capsys) -> None:
     settings = get_settings()
     assert main(["ingest", str(settings.manifest_path), "--out", str(tmp_path / "ingest")]) == 0

--- a/backend/tests/test_frontend_runtime_error_redaction.py
+++ b/backend/tests/test_frontend_runtime_error_redaction.py
@@ -106,3 +106,51 @@ def test_runtime_cli_wrapper_does_not_rethrow_raw_exec_error_message() -> None:
     source = (REPO_ROOT / "frontend/src/app/lib/runtime-cli.ts").read_text(encoding="utf-8")
 
     assert "throw new Error(message)" not in source
+
+
+def test_runtime_composer_generate_request_includes_world_id() -> None:
+    source = (
+        REPO_ROOT / "frontend/src/app/components/preset-perturbation-composer.tsx"
+    ).read_text(encoding="utf-8")
+    generate_request = source.split('fetch("/api/runtime/generate-branch"', maxsplit=1)[1]
+    generate_body = generate_request.split("perturbation:", maxsplit=1)[0]
+
+    assert "worldId," in generate_body
+
+
+def test_minimal_home_runtime_mutations_include_world_id() -> None:
+    source = (REPO_ROOT / "frontend/src/app/components/minimal-home-shell.tsx").read_text(
+        encoding="utf-8"
+    )
+    generate_request = source.split('fetch("/api/runtime/generate-branch"', maxsplit=1)[1]
+    generate_body = generate_request.split("perturbation:", maxsplit=1)[0]
+    rollback_request = source.split('fetch("/api/runtime/rollback-session"', maxsplit=1)[1]
+    rollback_body = rollback_request.split("toNode:", maxsplit=1)[0]
+
+    assert "worldId," in generate_body
+    assert "worldId," in rollback_body
+
+
+def test_runtime_cli_passes_expected_world_to_mutating_session_commands() -> None:
+    source = (REPO_ROOT / "frontend/src/app/lib/runtime-cli.ts").read_text(encoding="utf-8")
+
+    generate_args = source.split('    "generate-branch",', maxsplit=1)[1].split("  ];", maxsplit=1)[0]
+    rollback_args = source.split('    "rollback-session",', maxsplit=1)[1].split("  ]);", maxsplit=1)[0]
+
+    for command_args in [generate_args, rollback_args]:
+        assert '"--world"' in command_args
+        assert "worldId" in command_args
+
+
+def test_runtime_workspace_loader_rejects_route_session_world_mismatch() -> None:
+    source = (REPO_ROOT / "frontend/src/app/lib/runtime-session-data.ts").read_text(
+        encoding="utf-8"
+    )
+
+    assert "session.world_id !== worldId" in source
+    assert "selectedNode.world_id !== worldId || rootNode.world_id !== worldId" in source
+    assert "selectedNode.session_id !== sessionId || rootNode.session_id !== sessionId" in source
+    assert (
+        "lineage.some((entry) => entry.node.world_id !== worldId || entry.node.session_id !== sessionId)"
+        in source
+    )

--- a/backend/tests/test_phase51_route_contract_note.py
+++ b/backend/tests/test_phase51_route_contract_note.py
@@ -72,7 +72,7 @@ def test_architecture_and_adr_record_route_ownership_contract() -> None:
         "`/api/runtime/generate-branch`",
         "The private-beta launch hub remains planning-only in Phase 51",
         "Top-level `/perturb`, `/runtime/<session_id>`, and child runtime routes are legacy",
-        "TODO[verify]: verify that private-beta composer requests pass route-derived `worldId`",
+        "Private-beta composer requests must pass route-derived `worldId`",
     ]
     for phrase in required_contract_phrases:
         assert phrase in contract

--- a/backend/tests/test_phase51_runtime_guard_note.py
+++ b/backend/tests/test_phase51_runtime_guard_note.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+NOTE_PATH = Path("docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md")
+
+
+def test_phase51_runtime_guard_note_exists_with_required_sections() -> None:
+    assert NOTE_PATH.exists()
+
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    required_sections = [
+        "# Phase 51 Runtime Readiness and World-Scoped Guard Verification",
+        "Issue: `#406`",
+        "## Decision",
+        "## Evidence",
+        "## Guard Fixes",
+        "## Runtime Readiness Threshold",
+        "## Follow-Up Gate",
+        "## Non-Goals",
+        "## Validation Commands",
+    ]
+    for section in required_sections:
+        assert section in note
+
+
+def test_phase51_runtime_guard_note_records_guard_contract_and_boundaries() -> None:
+    assert NOTE_PATH.exists()
+
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    required_phrases = [
+        "Keep synchronous generation for v1",
+        "`task_id`, worker, retry, status, and cleanup semantics remain out of scope",
+        "The private-beta composer now sends route-derived `worldId` to `/api/runtime/generate-branch`",
+        "Minimal home runtime generation and rollback requests now include route-derived `worldId`",
+        "runtime CLI wrappers now pass `--world` to mutating session commands",
+        "backend session services reject expected-world mismatches",
+        "world-scoped workspace loading now rejects session or node manifests whose `world_id` conflicts with the route `worldId`",
+        "world-scoped workspace loading now rejects node manifests whose `session_id` conflicts with the route `sessionId`",
+        "lineage node manifests must also match the route `worldId` and `sessionId`",
+        "Direct local CLI calls may omit `--world` for compatibility when the operator provides an explicit artifacts root",
+        "Product and web-wrapper mutation calls must pass `--world`",
+        "`docs/plans/phase-50-runtime-generation-duration-measurement-2026-05-18.md`",
+        "No public demo, plugin, Hosted GPT, BYOK, upload, auth, billing, database, object storage, quota, or async contract is widened",
+        "TODO[verify]: rerun hosted/private-beta model measurements before introducing async task semantics",
+    ]
+    for phrase in required_phrases:
+        assert phrase in note
+
+
+def test_active_phase51_docs_point_to_runtime_guard_work() -> None:
+    required_docs = [
+        Path("README.md"),
+        Path("docs/plans/current-state-baseline.md"),
+        Path("docs/plans/phase-execution-queue.md"),
+        Path("docs/plans/phase-51-successor-gate-2026-05-18.md"),
+        Path("docs/plans/automation-roadmap.md"),
+    ]
+
+    for path in required_docs:
+        text = path.read_text(encoding="utf-8")
+        assert "`#406`" in text
+        assert "Phase 51 Runtime Readiness and World-Scoped Guard Verification" in text
+        assert "`docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`" in text
+
+
+def test_runtime_guard_contract_records_route_derived_world_id_requirement() -> None:
+    contract = Path("docs/architecture/contracts.md").read_text(encoding="utf-8")
+
+    required_phrases = [
+        "Private-beta composer requests must pass route-derived `worldId`",
+        "World-scoped runtime workspace loading must reject session or node manifests whose `world_id` conflicts with the route `worldId`",
+        "World-scoped runtime workspace loading must reject node manifests whose `session_id` conflicts with the route `sessionId`",
+        "Lineage node manifests must also match the route `worldId` and `sessionId` before the workspace can render.",
+        "Direct local CLI calls may omit `--world` for compatibility when the operator provides an explicit artifacts root.",
+        "Product and web-wrapper mutation calls must pass `--world`; when `--world` is provided, backend services must reject mismatches before branch generation or rollback.",
+    ]
+    for phrase in required_phrases:
+        assert phrase in contract

--- a/backend/tests/test_phase51_successor_gate.py
+++ b/backend/tests/test_phase51_successor_gate.py
@@ -12,8 +12,8 @@ def test_phase51_successor_gate_exists_with_required_sections() -> None:
     gate = PHASE51_GATE_PATH.read_text(encoding="utf-8")
     required_sections = [
         "# Phase 51 Successor Gate",
-        "Issue: `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract`",
-        "Current work item: `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract`",
+        "Issue: `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`",
+        "Current work item: `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`",
         "## Phase 50 Closeout Evidence",
         "## Phase 51 Operational Queue",
         "## Protected-Core Lane Coverage",
@@ -39,6 +39,7 @@ def test_phase51_successor_gate_records_queue_and_boundaries() -> None:
         "`#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`",
         "Private-beta route contract",
         "Phase 51 Private-Beta Route Ownership Contract",
+        "Phase 51 Runtime Readiness and World-Scoped Guard Verification",
         "Runtime readiness and world-scoped session guards",
         "TODO[verify]: Codex UI tool-card",
         "Runtime generation duration is now recorded",
@@ -51,6 +52,7 @@ def test_phase51_successor_gate_records_queue_and_boundaries() -> None:
         "Do not recreate local Codex automations without a new explicit operator request",
         "`docs/plans/phase-50-runtime-generation-duration-measurement-2026-05-18.md`",
         "`docs/plans/phase-50-product-boundary-2026-05-18.md`",
+        "`docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`",
     ]
     for phrase in required_phrases:
         assert phrase in gate

--- a/docs/architecture/contracts.md
+++ b/docs/architecture/contracts.md
@@ -288,8 +288,8 @@ All IDs must be serializable, stable across files, and traceable in `artifacts/`
 - Canonical v1 entrypoints are:
   - `python -m backend.app.cli start-session --world <world_id> --scenario <scenario_id> [--decision-provider <provider>] [--decision-model <model_id>]`
   - `python -m backend.app.cli inspect-session --session <session_id>`
-  - `python -m backend.app.cli generate-branch --session <session_id> --from <node_id> --perturbation <json-or-file>`
-  - `python -m backend.app.cli rollback-session --session <session_id> --to <node_id>`
+  - `python -m backend.app.cli generate-branch [--world <world_id>] --session <session_id> --from <node_id> --perturbation <json-or-file>`
+  - `python -m backend.app.cli rollback-session [--world <world_id>] --session <session_id> --to <node_id>`
 - `start-session` creates one durable simulation session rooted in one bounded world plus one baseline scenario.
 - `start-session` may pin one session-local decision model.
   - when present, the pinned model overrides the default environment-driven model lookup for later branch generation inside that session
@@ -504,8 +504,15 @@ All IDs must be serializable, stable across files, and traceable in `artifacts/`
   launch-hub route.
 - TODO[verify]: if a launch hub becomes an implementation target, open a new reviewed work
   item that names its route, access mode, public-demo interaction, and deployment posture.
-- TODO[verify]: verify that private-beta composer requests pass route-derived `worldId`
-  through every world-scoped mutation before expanding private-beta runtime surfaces.
+- Private-beta composer requests must pass route-derived `worldId` through world-scoped
+  session mutations before runtime branch generation or rollback can mutate session state.
+- World-scoped runtime workspace loading must reject session or node manifests whose `world_id` conflicts with the route `worldId`.
+- World-scoped runtime workspace loading must reject node manifests whose `session_id` conflicts with the route `sessionId`.
+- Lineage node manifests must also match the route `worldId` and `sessionId` before the workspace can render.
+- Direct local CLI calls may omit `--world` for compatibility when the operator provides an explicit artifacts root.
+- Product and web-wrapper mutation calls must pass `--world`; when `--world` is provided, backend services must reject mismatches before branch generation or rollback.
+- TODO[verify]: require the same route-derived world guard review before adding any new
+  world-scoped runtime mutation surface.
 
 ## Artifact Contract
 

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -170,9 +170,10 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate` is open.
 - `#403` `Phase 51 exit gate` is open, blocked, and protected-core.
 - `#404` `Phase 51: sync repo truth after Phase 50 closeout` is closed by PR `#407`.
-- `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract` is the current ready work item.
-- `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards` is blocked until the route ownership contract lands.
+- `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract` is closed by PR `#408`.
+- `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards` is the current ready work item.
 - Phase 51 Private-Beta Route Ownership Contract: private-beta launch hub remains planning-only and `/worlds/<world_id>` remains the private-beta candidate product path; the route note lives in `docs/plans/phase-51-private-beta-route-contract-2026-05-18.md`, and durable route ownership lives in `docs/architecture/contracts.md` and `docs/decisions/ADR-0011-private-beta-route-ownership.md`.
+- Phase 51 Runtime Readiness and World-Scoped Guard Verification: synchronous v1 generation remains the runtime contract; route-derived `worldId` guards now protect private-beta branch generation, rollback, and world-scoped workspace loading. The guard note lives in `docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -253,14 +253,19 @@ This note records the completed Phase 50 runtime-boundary closeout and the appro
   - `gh issue list --milestone "Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate" --state all`
     - `#403` `Phase 51 exit gate` is `open`, `blocked`, and `lane:protected-core`
     - `#404` `Phase 51: sync repo truth after Phase 50 closeout` is `closed` by PR `#407`
-    - `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract` is the current `status:ready` protected-core work item
-    - `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards` is `open` and blocked until the route contract lands
+    - `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract` is `closed` by PR `#408`
+    - `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards` is the current `status:ready` protected-core work item
   - Phase 51 Private-Beta Route Ownership Contract:
     - private-beta launch hub remains planning-only
     - `/` and `/review` remain public-demo surfaces
     - `/worlds/<world_id>` remains the private-beta candidate product path
     - `docs/plans/phase-51-private-beta-route-contract-2026-05-18.md` records the route contract note
     - `docs/architecture/contracts.md` and `docs/decisions/ADR-0011-private-beta-route-ownership.md` record the durable route ownership contract
+  - Phase 51 Runtime Readiness and World-Scoped Guard Verification:
+    - synchronous v1 generation remains the current runtime contract
+    - private-beta runtime mutations pass route-derived world scope through composer, CLI, and backend service guards
+    - world-scoped workspace loading rejects session or node manifests whose durable world/session ids conflict with route params
+    - `docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md` records the guard verification note
 
 ## Trusted Source Of Truth
 
@@ -298,11 +303,12 @@ This note records the completed Phase 50 runtime-boundary closeout and the appro
 - `#401` `Phase 50: ratify private-beta launch hub and public-path boundary` is closed by PR `#402`.
 - Phase 50 Product Boundary Decision: launch hub remains planning-only for now; current tracked code keeps `/` as the guided public demo.
 - `#404` `Phase 51: sync repo truth after Phase 50 closeout` is closed by PR `#407`.
-- `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract` is the current ready work item.
-- `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards` is blocked until the route ownership contract lands.
+- `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract` is closed by PR `#408`.
+- `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards` is the current ready work item.
 - Phase 51 Private-Beta Route Ownership Contract: private-beta launch hub remains planning-only; `/` and `/review` stay public-demo surfaces, while `/worlds/<world_id>` remains the private-beta candidate product path.
 - The Phase 51 route contract note lives in `docs/plans/phase-51-private-beta-route-contract-2026-05-18.md`.
 - The durable route ownership contract lives in `docs/architecture/contracts.md` and `docs/decisions/ADR-0011-private-beta-route-ownership.md`.
+- Phase 51 Runtime Readiness and World-Scoped Guard Verification keeps synchronous v1 generation, records route-derived `worldId` mutation guards, and lives in `docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.

--- a/docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md
+++ b/docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md
@@ -1,0 +1,98 @@
+# Phase 51 Runtime Readiness and World-Scoped Guard Verification
+
+Date: 2026-05-18
+
+Issue: `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`
+
+## Decision
+
+Keep synchronous generation for v1.
+
+Phase 51 verifies the runtime readiness evidence and closes the world-scoped guard gaps
+identified after the route ownership contract. `task_id`, worker, retry, status, and cleanup semantics remain out of scope until a future reviewed ADR ratifies the product
+threshold, queue lifecycle, status payload, retry rules, cleanup behavior, and artifact
+contract changes.
+
+The private-beta runtime path remains world-scoped under `/worlds/<world_id>`. This work
+does not create a launch hub, move `/`, widen public demo routes, widen plugin behavior, or
+change session/node/report/claim/trace/compare artifact schemas.
+
+## Evidence
+
+- `docs/plans/phase-50-runtime-generation-duration-measurement-2026-05-18.md` recorded five
+  local deterministic samples: `generate-branch` average `1218.1 ms`, minimum `1169.0 ms`,
+  maximum `1309.1 ms`; start-session plus generate average `2211.6 ms`.
+- Phase 50 explicitly did not ratify a product timeout threshold or async work contract.
+- `docs/plans/phase-51-private-beta-route-contract-2026-05-18.md` records `/worlds/<world_id>`
+  as the private-beta candidate product path and leaves the private-beta launch hub
+  planning-only.
+- `docs/architecture/contracts.md` records that v1 runtime generation does not introduce task
+  queues or a separate `task_id` contract.
+- Read-only review found three concrete guard gaps: composer branch generation omitted
+  route-derived `worldId`; CLI-backed session mutations lacked an expected-world guard; and
+  world-scoped workspace loading did not compare durable manifests with route params.
+
+## Guard Fixes
+
+- The private-beta composer now sends route-derived `worldId` to `/api/runtime/generate-branch`.
+- Minimal home runtime generation and rollback requests now include route-derived `worldId`.
+- The runtime CLI wrappers now pass `--world` to mutating session commands.
+- The backend session services reject expected-world mismatches before generating a child branch
+  or moving a rollback pointer.
+- The world-scoped workspace loading now rejects session or node manifests whose `world_id` conflicts with the route `worldId`.
+- The world-scoped workspace loading now rejects node manifests whose `session_id` conflicts with the route `sessionId`.
+- The lineage node manifests must also match the route `worldId` and `sessionId`.
+- Direct local CLI calls may omit `--world` for compatibility when the operator provides an explicit artifacts root.
+- Product and web-wrapper mutation calls must pass `--world`; when `--world` is provided, backend services must reject mismatches before branch generation or rollback.
+
+These guards fail closed before widening runtime surfaces. They preserve existing public-demo,
+plugin, hosted-model, BYOK, artifact, and session-shape contracts.
+
+## Runtime Readiness Threshold
+
+The current measurement evidence supports synchronous v1 generation for local deterministic
+private-beta use. It does not justify a background worker, retry queue, `task_id`, status API,
+cleanup process, or new artifact lifecycle.
+
+TODO[verify]: rerun hosted/private-beta model measurements before introducing async task semantics. That future review must name the threshold, hosted/BYOK deployment posture,
+operator-visible status model, failure model, retry limits, cleanup behavior, and any schema
+or artifact changes before implementation.
+
+## Follow-Up Gate
+
+- TODO[verify]: decide whether legacy top-level `/runtime/<session_id>` routes should be
+  deprecated, redirected, or formally re-contracted before presenting them as a private-beta
+  main path.
+- TODO[verify]: if new mutating runtime APIs are added, require route-derived `worldId` or an
+  equivalent reviewed scope guard before the API can mutate session state.
+- TODO[verify]: rerun hosted/private-beta model measurements before introducing async task semantics.
+
+## Non-Goals
+
+- Do not implement a launch hub route in `#406`.
+- Do not replace `/` or widen the public path.
+- Do not change public demo behavior.
+- Do not change Mirror Codex plugin MCP tools or resources.
+- Do not add mutating Mirror Codex MCP tools.
+- No public demo, plugin, Hosted GPT, BYOK, upload, auth, billing, database, object storage, quota, or async contract is widened.
+- Do not implement async workers, queues, `task_id`, retry, status, cleanup, checkpoint
+  mutation/deletion, or restore semantics.
+- Do not change scenario DSL, claim labels, report claim `evidence_ids`, run trace shape,
+  compare artifact shape, public demo artifact layout, or plugin MCP contract.
+- Do not build real-person personas, digital doubles, political persuasion, law-enforcement,
+  hiring, credit, medical, or judicial decision systems.
+- Do not present Mirror as real-world prediction or package simulation output as certain
+  real-world conclusions.
+
+## Validation Commands
+
+```powershell
+python -m pytest backend/tests/test_phase51_runtime_guard_note.py backend/tests/test_frontend_runtime_error_redaction.py::test_runtime_composer_generate_request_includes_world_id backend/tests/test_frontend_runtime_error_redaction.py::test_minimal_home_runtime_mutations_include_world_id backend/tests/test_frontend_runtime_error_redaction.py::test_runtime_cli_passes_expected_world_to_mutating_session_commands backend/tests/test_frontend_runtime_error_redaction.py::test_runtime_workspace_loader_rejects_route_session_world_mismatch backend/tests/test_cli.py::test_generate_branch_rejects_expected_world_mismatch backend/tests/test_cli.py::test_rollback_session_rejects_expected_world_mismatch backend/tests/test_cli.py::test_cli_generate_branch_passes_expected_world_guard -q
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+python -m backend.app.cli classify-lane --files README.md docs/architecture/contracts.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-51-successor-gate-2026-05-18.md docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md backend/app/cli.py backend/app/sessions/service.py backend/tests/test_cli.py backend/tests/test_frontend_runtime_error_redaction.py backend/tests/test_phase51_runtime_guard_note.py frontend/src/app/components/minimal-home-shell.tsx frontend/src/app/components/preset-perturbation-composer.tsx frontend/src/app/lib/runtime-cli.ts frontend/src/app/lib/runtime-session-data.ts
+git diff --check
+npm run build --prefix frontend
+./make.ps1 test
+./make.ps1 eval-demo
+```

--- a/docs/plans/phase-51-successor-gate-2026-05-18.md
+++ b/docs/plans/phase-51-successor-gate-2026-05-18.md
@@ -2,9 +2,9 @@
 
 Date: 2026-05-18
 
-Issue: `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract`
+Issue: `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`
 
-Current work item: `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract`
+Current work item: `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`
 
 This note records the post-Phase-50 baseline and opens the Phase 51 successor queue.
 Phase 51 is a protected-core route-contract and runtime-readiness phase for the
@@ -49,17 +49,17 @@ Active GitHub objects:
   - Scope: sync tracked docs to Phase 51 after closing Phase 50.
 - `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract`
   - Lane: `protected-core`.
-  - Status: current ready work item.
+  - Status: closed by PR `#408`.
   - Scope: record the Phase 51 Private-Beta Route Ownership Contract before any launch-hub implementation.
 - `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`
   - Lane: `protected-core`.
-  - Status: blocked until the route ownership contract lands.
+  - Status: current ready work item.
   - Scope: verify runtime readiness and world-scoped session guards before product-path
     runtime surfaces widen.
 
 `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
 with Phase 51 as the only open milestone, `#403` as the protected blocked exit gate, and
-`#405` as the current ready work item.
+`#406` as the current ready work item.
 
 ## Protected-Core Lane Coverage
 
@@ -109,11 +109,13 @@ public demo artifact layout, or the Mirror Codex MCP contract.
   item that names its route, access mode, public-demo interaction, and deployment posture.
 - TODO[verify]: verify the tracked frontend route tree before treating any private-beta path
   beyond the documented `/worlds/...` candidate routes as durable route ownership.
-- TODO[verify]: verify route/session mismatch handling before expanding private-beta runtime
-  surfaces. World-scoped session guards must reject or clearly fail any request whose route
-  `world_id` conflicts with the session's durable world id.
-- TODO[verify]: verify that private-beta composer requests pass route-derived `worldId`
-  through every world-scoped mutation before treating runtime generation as route-safe.
+- Phase 51 Runtime Readiness and World-Scoped Guard Verification is recorded in
+  `docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`.
+  Composer and minimal-home runtime mutations now pass route-derived `worldId`, CLI mutations pass `--world`,
+  backend session services reject expected-world mismatches, and world-scoped workspace
+  loading rejects mismatched session/node `world_id` or node `session_id` values.
+  TODO[verify]: require the same route-derived world guard review before adding any new
+  world-scoped runtime mutation surface.
 - Latest-session versus latest-activity semantics are ratified as `last_activity_at`
   ordering with `created_at` fallback; TODO[verify]: re-open contract review before adding
   other activity sources or changing failed-operation activity behavior.
@@ -154,9 +156,14 @@ public demo artifact layout, or the Mirror Codex MCP contract.
    - Preserve public demo, plugin, hosted-model, and async-runtime boundaries.
 
 3. Runtime readiness and world-scoped session guards
+   - Record the guard verification note in
+     `docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`.
    - Verify hosted/private-beta runtime thresholds against Phase 50 measurement evidence.
    - Verify route/session mismatch handling and world-scoped session guards before runtime
      product surfaces widen.
+   - Require route-derived `worldId` in private-beta composer generation and CLI-backed
+     session mutations.
+   - Reject world/session manifest mismatches while loading world-scoped runtime workspaces.
    - Preserve synchronous v1 unless an ADR approves async task semantics.
 
 ## Blueprint Boundary
@@ -176,11 +183,11 @@ Phase 51 must stay aligned with `mirror.md` and `AGENTS.md`:
 ## Non-Goals
 
 - Do not implement a private-beta launch hub, move `/`, or widen the public path inside
-  `#405`.
+  `#406`.
 - Do not implement async workers, queues, `task_id`, retry, status, cleanup, checkpoint
-  mutation/deletion, or restore semantics inside `#405`.
+  mutation/deletion, or restore semantics inside `#406`.
 - Do not change scenario DSL, claim/evidence shape, run trace shape, compare artifact shape,
-  public demo artifact layout, or plugin MCP tool/resource contract in `#405`.
+  public demo artifact layout, or plugin MCP tool/resource contract in `#406`.
 - Do not add Hosted GPT, BYOK, upload, auth, billing, database, object storage, or quota
   behavior to the public path or plugin path.
 - Do not add mutating Mirror Codex MCP tools.
@@ -216,9 +223,12 @@ git diff --check
 For `#406`, run:
 
 ```powershell
-python -m pytest backend/tests/test_phase51_successor_gate.py -q
+python -m pytest backend/tests/test_phase51_runtime_guard_note.py backend/tests/test_frontend_runtime_error_redaction.py::test_runtime_composer_generate_request_includes_world_id backend/tests/test_frontend_runtime_error_redaction.py::test_minimal_home_runtime_mutations_include_world_id backend/tests/test_frontend_runtime_error_redaction.py::test_runtime_cli_passes_expected_world_to_mutating_session_commands backend/tests/test_frontend_runtime_error_redaction.py::test_runtime_workspace_loader_rejects_route_session_world_mismatch backend/tests/test_cli.py::test_generate_branch_rejects_expected_world_mismatch backend/tests/test_cli.py::test_rollback_session_rejects_expected_world_mismatch backend/tests/test_cli.py::test_cli_generate_branch_passes_expected_world_guard backend/tests/test_phase51_successor_gate.py backend/tests/test_phase51_route_contract_note.py -q
 python scripts/check_no_secrets.py
 python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
-python -m backend.app.cli classify-lane --files <changed-files>
+python -m backend.app.cli classify-lane --files README.md docs/architecture/contracts.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-51-successor-gate-2026-05-18.md docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md backend/app/cli.py backend/app/sessions/service.py backend/tests/test_cli.py backend/tests/test_frontend_runtime_error_redaction.py backend/tests/test_phase51_runtime_guard_note.py backend/tests/test_phase51_route_contract_note.py backend/tests/test_phase51_successor_gate.py frontend/src/app/components/minimal-home-shell.tsx frontend/src/app/components/preset-perturbation-composer.tsx frontend/src/app/lib/runtime-cli.ts frontend/src/app/lib/runtime-session-data.ts
 git diff --check
+npm run build --prefix frontend
+./make.ps1 test
+./make.ps1 eval-demo
 ```

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -75,16 +75,18 @@ Local phase audits currently report:
   - closed by PR `#407`
   - synced durable docs to Phase 51
 - `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract`
-  - current protected-core route-contract work item
+  - closed by PR `#408`
   - records the reviewed Phase 51 Private-Beta Route Ownership Contract before any launch-hub implementation
   - Phase 51 Private-Beta Route Ownership Contract: private-beta launch hub remains planning-only
   - durable route ownership contract: `docs/architecture/contracts.md` and `docs/decisions/ADR-0011-private-beta-route-ownership.md`
 - `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`
-  - open and blocked until the route contract lands
+  - current protected-core runtime-readiness work item
   - verifies runtime readiness and world-scoped session guards before runtime surfaces widen
+  - Phase 51 Runtime Readiness and World-Scoped Guard Verification: synchronous v1 generation remains the current runtime contract and route-derived `worldId` guards now protect branch generation, rollback, and world-scoped workspace loading
 - phase gate baseline
   - active Phase 51 gate note: `docs/plans/phase-51-successor-gate-2026-05-18.md`
   - route contract note: `docs/plans/phase-51-private-beta-route-contract-2026-05-18.md`
+  - runtime guard note: `docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`
 
 ## Phase 50 Closeout
 

--- a/frontend/src/app/components/minimal-home-shell.tsx
+++ b/frontend/src/app/components/minimal-home-shell.tsx
@@ -242,6 +242,7 @@ export function MinimalHomeShell({
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
+            worldId,
             sessionId: resolvedSessionId,
             fromNode: fromNodeId,
             perturbation: {
@@ -306,6 +307,7 @@ export function MinimalHomeShell({
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
+            worldId,
             sessionId,
             toNode: targetNodeId,
           }),

--- a/frontend/src/app/components/preset-perturbation-composer.tsx
+++ b/frontend/src/app/components/preset-perturbation-composer.tsx
@@ -372,6 +372,7 @@ export function PresetPerturbationComposer({
         },
         body: JSON.stringify({
           locale,
+          worldId,
           sessionId: resolvedSessionId,
           fromNode: fromNodeId,
           decisionProvider: draft.provider,

--- a/frontend/src/app/lib/runtime-cli.ts
+++ b/frontend/src/app/lib/runtime-cli.ts
@@ -76,6 +76,8 @@ export async function generateRuntimeBranch(
 ) {
   const args = [
     "generate-branch",
+    "--world",
+    worldId,
     "--session",
     sessionId,
     "--from",
@@ -98,6 +100,8 @@ export async function generateRuntimeBranch(
 export async function rollbackRuntimeSession(worldId: string, sessionId: string, toNode: string) {
   return runMirrorCli([
     "rollback-session",
+    "--world",
+    worldId,
     "--session",
     sessionId,
     "--to",

--- a/frontend/src/app/lib/runtime-session-data.ts
+++ b/frontend/src/app/lib/runtime-session-data.ts
@@ -390,6 +390,9 @@ export async function loadRuntimeSessionWorkspaceForWorld(
       readJson<RuntimeSessionManifest>(sessionPath),
       readJson<GraphPayload>(path.join(artifactsRoot, "graph", "graph.json")),
     ]);
+    if (session.world_id !== worldId) {
+      return null;
+    }
     const selectedNodeId = session.nodes.some((node) => node.node_id === requestedNodeId)
       ? requestedNodeId ?? session.active_node_id
       : session.active_node_id;
@@ -409,6 +412,17 @@ export async function loadRuntimeSessionWorkspaceForWorld(
       readJson<RuntimeSessionNodeManifest>(path.join(artifactsRoot, rootNodePath)),
       loadRuntimeNodeLineage(session, selectedNodeId, artifactsRoot),
     ]);
+    if (selectedNode.world_id !== worldId || rootNode.world_id !== worldId) {
+      return null;
+    }
+    if (selectedNode.session_id !== sessionId || rootNode.session_id !== sessionId) {
+      return null;
+    }
+    if (
+      lineage.some((entry) => entry.node.world_id !== worldId || entry.node.session_id !== sessionId)
+    ) {
+      return null;
+    }
     const decisionSummary = await loadRuntimeDecisionSummary(
       sessionRoot,
       selectedNode.decision_trace_path


### PR DESCRIPTION
Closes #406.

## Summary
- pass route-derived `worldId` through private-beta runtime generation and rollback surfaces
- reject expected-world mismatches in backend session mutation services
- reject mismatched world/session manifests in world-scoped runtime workspace loading
- record the Phase 51 runtime-readiness guard note and active queue docs

## Validation
- python -m pytest backend/tests/test_phase51_runtime_guard_note.py backend/tests/test_frontend_runtime_error_redaction.py::test_runtime_composer_generate_request_includes_world_id backend/tests/test_frontend_runtime_error_redaction.py::test_minimal_home_runtime_mutations_include_world_id backend/tests/test_frontend_runtime_error_redaction.py::test_runtime_cli_passes_expected_world_to_mutating_session_commands backend/tests/test_frontend_runtime_error_redaction.py::test_runtime_workspace_loader_rejects_route_session_world_mismatch backend/tests/test_cli.py::test_generate_branch_rejects_expected_world_mismatch backend/tests/test_cli.py::test_rollback_session_rejects_expected_world_mismatch backend/tests/test_cli.py::test_cli_generate_branch_passes_expected_world_guard backend/tests/test_phase51_successor_gate.py backend/tests/test_phase51_route_contract_note.py -q
- python scripts/check_no_secrets.py
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files README.md docs/architecture/contracts.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-51-successor-gate-2026-05-18.md docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md backend/app/cli.py backend/app/sessions/service.py backend/tests/test_cli.py backend/tests/test_frontend_runtime_error_redaction.py backend/tests/test_phase51_runtime_guard_note.py backend/tests/test_phase51_route_contract_note.py backend/tests/test_phase51_successor_gate.py frontend/src/app/components/minimal-home-shell.tsx frontend/src/app/components/preset-perturbation-composer.tsx frontend/src/app/lib/runtime-cli.ts frontend/src/app/lib/runtime-session-data.ts
- git diff --check
- npm run build --prefix frontend
- ./make.ps1 test
- ./make.ps1 eval-demo