### PR TITLE
Phase 52 repo truth sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,13 @@ session services reject expected-world mismatches, and world-scoped workspace lo
 session or node manifests that conflict with route `worldId` or `sessionId`. See
 `docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`.
 
+Phase 52 Legacy Route Containment and Runtime Scope Audit: Phase 51 is closed after PR
+`#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime
+Readiness Gate`; private-beta route ownership and world-scoped session guards remain ratified by Phase 51. Phase 52 is the active approved successor queue. It starts with repo-truth
+sync, then audits legacy top-level runtime routes and strengthens runtime mutation guard
+regression coverage without widening public demo, plugin, Hosted GPT/BYOK, or async
+contracts. See `docs/plans/phase-52-successor-gate-2026-05-18.md`.
+
 ---
 
 ## What You Can Inspect Locally | 本地能看到什么
@@ -281,11 +288,13 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - The completed Phase 48 successor gate lives in [docs/plans/phase-48-successor-gate-2026-05-17.md](docs/plans/phase-48-successor-gate-2026-05-17.md).
 - The completed Phase 49 successor gate lives in [docs/plans/phase-49-successor-gate-2026-05-18.md](docs/plans/phase-49-successor-gate-2026-05-18.md).
 - The completed Phase 50 successor gate lives in [docs/plans/phase-50-successor-gate-2026-05-18.md](docs/plans/phase-50-successor-gate-2026-05-18.md).
-- The active successor gate lives in [docs/plans/phase-51-successor-gate-2026-05-18.md](docs/plans/phase-51-successor-gate-2026-05-18.md).
+- The completed Phase 51 successor gate lives in [docs/plans/phase-51-successor-gate-2026-05-18.md](docs/plans/phase-51-successor-gate-2026-05-18.md).
+- The active Phase 52 successor gate lives in [docs/plans/phase-52-successor-gate-2026-05-18.md](docs/plans/phase-52-successor-gate-2026-05-18.md).
 - Phase 48 is closed after PR `#382`, issue `#375`, and milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
 - Phase 49 is closed after PR `#395`, issue `#383`, and milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; completed work items were `#384`, `#386`, `#388`, `#390`, `#392`, and `#394`.
 - Phase 50 is closed after PR `#402`, issue `#396`, and milestone `Phase 50 - Runtime Orchestration Measurement and Product Boundary`; completed work items were `#397`, `#398`, and `#401`. Phase 50 measured before any `task_id` or worker contract is introduced and kept the private-beta launch hub planning-only for now.
-- Phase 51 is the active approved successor queue: `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`; private-beta route ownership is ratified by `#405`/PR `#408`, and `audit-github-queue` reports `ready` with `#403` as the blocked exit gate, `#404` closed by PR `#407`, `#405` closed by PR `#408`, and `#406` as the current ready runtime readiness and world-scoped session guards item.
+- Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`; completed work items were `#404`, `#405`, and `#406`.
+- Phase 52 is the active approved successor queue: `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; `audit-github-queue` reports `ready` with `#410` as the blocked exit gate, `#411` as the current ready repo-truth sync item, and `#412`/`#413` as blocked follow-up items for legacy top-level runtime routes and runtime mutation guard regression coverage.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
 - Fog Harbor remains the canonical demo world; `museum-night` is the minimal transfer world used to prove the pipeline is not single-world-only.
 

--- a/backend/tests/test_automation.py
+++ b/backend/tests/test_automation.py
@@ -45,6 +45,7 @@ def test_classify_paths_marks_phase_queue_docs_protected() -> None:
         "docs/plans/phase-execution-queue.md",
         "docs/plans/phase-50-successor-gate-2026-05-18.md",
         "docs/plans/phase-51-successor-gate-2026-05-18.md",
+        "docs/plans/phase-52-successor-gate-2026-05-18.md",
     ]
 
     decision = classify_paths(phase_queue_paths)

--- a/backend/tests/test_phase51_successor_gate.py
+++ b/backend/tests/test_phase51_successor_gate.py
@@ -12,8 +12,7 @@ def test_phase51_successor_gate_exists_with_required_sections() -> None:
     gate = PHASE51_GATE_PATH.read_text(encoding="utf-8")
     required_sections = [
         "# Phase 51 Successor Gate",
-        "Issue: `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`",
-        "Current work item: `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`",
+        "Final work item: `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`",
         "## Phase 50 Closeout Evidence",
         "## Phase 51 Operational Queue",
         "## Protected-Core Lane Coverage",
@@ -37,6 +36,8 @@ def test_phase51_successor_gate_records_queue_and_boundaries() -> None:
         "`#404` `Phase 51: sync repo truth after Phase 50 closeout`",
         "`#405` `Phase 51: ratify private-beta route ownership and launch-hub contract`",
         "`#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`",
+        "Closed GitHub objects:",
+        "Status: closed by PR `#409`.",
         "Private-beta route contract",
         "Phase 51 Private-Beta Route Ownership Contract",
         "Phase 51 Runtime Readiness and World-Scoped Guard Verification",
@@ -58,13 +59,12 @@ def test_phase51_successor_gate_records_queue_and_boundaries() -> None:
         assert phrase in gate
 
 
-def test_active_state_docs_point_to_phase51_queue() -> None:
+def test_active_state_docs_record_phase51_closeout_and_phase52_queue() -> None:
     required_docs = [
         Path("README.md"),
         Path("docs/plans/current-state-baseline.md"),
         Path("docs/plans/phase-execution-queue.md"),
         Path("docs/plans/automation-roadmap.md"),
-        Path("docs/plans/phase-50-successor-gate-2026-05-18.md"),
     ]
 
     for path in required_docs:
@@ -75,5 +75,7 @@ def test_active_state_docs_point_to_phase51_queue() -> None:
         assert "`#404`" in text
         assert "`#405`" in text
         assert "`#406`" in text
+        assert "Phase 51 is closed" in text
+        assert "Phase 52 - Legacy Route Containment and Runtime Scope Audit" in text
         assert "private-beta route ownership" in text
         assert "world-scoped session guards" in text

--- a/backend/tests/test_phase52_successor_gate.py
+++ b/backend/tests/test_phase52_successor_gate.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+PHASE52_GATE_PATH = Path("docs/plans/phase-52-successor-gate-2026-05-18.md")
+
+
+def test_phase52_successor_gate_exists_with_required_sections() -> None:
+    assert PHASE52_GATE_PATH.exists()
+
+    gate = PHASE52_GATE_PATH.read_text(encoding="utf-8")
+    required_sections = [
+        "# Phase 52 Successor Gate",
+        "Issue: `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate`",
+        "Current work item: `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate`",
+        "## Phase 51 Closeout Evidence",
+        "## Phase 52 Operational Queue",
+        "## Protected-Core Lane Coverage",
+        "## Carried Forward TODO[verify] Items",
+        "## Phase 52 Work Package Map",
+        "## Blueprint Boundary",
+        "## Non-Goals",
+        "## Validation Commands",
+    ]
+    for section in required_sections:
+        assert section in gate
+
+
+def test_phase52_successor_gate_records_queue_and_boundaries() -> None:
+    assert PHASE52_GATE_PATH.exists()
+
+    gate = PHASE52_GATE_PATH.read_text(encoding="utf-8")
+    required_phrases = [
+        "Phase 52 - Legacy Route Containment and Runtime Scope Audit",
+        "`#410` `Phase 52 exit gate`",
+        "`#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate`",
+        "`#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`",
+        "`#413` `Phase 52: strengthen runtime mutation guard regression baseline`",
+        "Status: blocked closeout gate for Phase 52.",
+        "Status: current ready work item.",
+        "Status: blocked until the repo-truth sync lands.",
+        "Status: blocked until the legacy route audit lands.",
+        "Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`",
+        "legacy top-level runtime routes",
+        "route-derived `worldId`",
+        "Keep synchronous generation for v1",
+        "TODO[verify]: rerun hosted/private-beta model measurements before introducing async task semantics",
+        "Every report claim must keep both `label` and `evidence_ids`",
+        "Do not present Mirror as a real-world prediction machine",
+        "Do not implement a launch hub",
+        "Do not implement async workers, queues, `task_id`, retry, status, cleanup",
+        "Do not change scenario DSL, claim labels, report claim `evidence_ids`, run trace shape",
+        "compare artifact shape, session/node manifest shape, public demo artifact layout",
+        "Do not recreate local Codex automations without a new explicit operator request",
+        "`docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`",
+        "`docs/plans/phase-52-successor-gate-2026-05-18.md`",
+    ]
+    for phrase in required_phrases:
+        assert phrase in gate
+
+
+def test_active_state_docs_point_to_phase52_queue() -> None:
+    required_docs = [
+        Path("README.md"),
+        Path("docs/plans/current-state-baseline.md"),
+        Path("docs/plans/phase-execution-queue.md"),
+        Path("docs/plans/automation-roadmap.md"),
+        Path("docs/plans/phase-51-successor-gate-2026-05-18.md"),
+    ]
+
+    for path in required_docs:
+        text = path.read_text(encoding="utf-8")
+        assert "Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate" in text
+        assert "Phase 52 - Legacy Route Containment and Runtime Scope Audit" in text
+        assert "`#410`" in text
+        assert "`#411`" in text
+        assert "`#412`" in text
+        assert "`#413`" in text
+        assert "legacy top-level runtime routes" in text
+        assert "runtime mutation guard regression" in text
+        assert (
+            "public/plugin/async" in text
+            or "public demo, plugin, Hosted GPT/BYOK, or async" in text
+        )

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, Phase 47 closeout is complete, Phase 48 closeout is complete, Phase 49 closeout is complete, Phase 50 closeout is complete, Phase 51 is the active approved successor queue, and the first formal release remains published as `v0.1.0`.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, Phase 47 closeout is complete, Phase 48 closeout is complete, Phase 49 closeout is complete, Phase 50 closeout is complete, Phase 51 closeout is complete, Phase 52 is the active approved successor queue, and the first formal release remains published as `v0.1.0`.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -166,21 +166,26 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - `#397` `Phase 50: sync repo truth after Phase 49 closeout` is closed by PR `#399`.
 - `#398` `Phase 50: measure runtime generation duration before task_id decision` is closed by PR `#400`.
 - `#401` `Phase 50: ratify private-beta launch hub and public-path boundary` is closed by PR `#402`.
-- Phase 51 is the active approved successor queue.
-- milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate` is open.
-- `#403` `Phase 51 exit gate` is open, blocked, and protected-core.
+- Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`.
 - `#404` `Phase 51: sync repo truth after Phase 50 closeout` is closed by PR `#407`.
 - `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract` is closed by PR `#408`.
-- `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards` is the current ready work item.
+- `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards` is closed by PR `#409`.
 - Phase 51 Private-Beta Route Ownership Contract: private-beta launch hub remains planning-only and `/worlds/<world_id>` remains the private-beta candidate product path; the route note lives in `docs/plans/phase-51-private-beta-route-contract-2026-05-18.md`, and durable route ownership lives in `docs/architecture/contracts.md` and `docs/decisions/ADR-0011-private-beta-route-ownership.md`.
 - Phase 51 Runtime Readiness and World-Scoped Guard Verification: synchronous v1 generation remains the runtime contract; route-derived `worldId` guards now protect private-beta branch generation, rollback, and world-scoped workspace loading. The guard note lives in `docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`.
+- Phase 52 is the active approved successor queue.
+- milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit` is open.
+- `#410` `Phase 52 exit gate` is open, blocked, and protected-core.
+- `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate` is the current ready work item.
+- `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract` is blocked until the repo-truth sync lands.
+- `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is blocked until the legacy route audit lands.
+- Phase 52 focuses on legacy top-level runtime routes and runtime mutation guard regression coverage without widening public/plugin/async contracts. The gate note lives in `docs/plans/phase-52-successor-gate-2026-05-18.md`.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.
 - `#390` `Phase 49: ratify runtime parent-child compare emission policy` is closed by PR `#391`.
 - `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope` is closed by PR `#393`.
 - `#394` `Phase 49: strengthen transfer eval outcome coverage` is closed by PR `#395`.
-- `audit-github-queue` reports `ready` with Phase 51 as the active milestone.
+- `audit-github-queue` reports `ready` with Phase 52 as the active milestone.
 - The first formal repository release is published as `v0.1.0`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
@@ -237,5 +242,5 @@ Before builder automation is allowed to write code or auto-merge:
 - Long-running execution must run from isolated worktrees rather than the current `main` checkout.
 - Queue pickup order, one-writer ownership, and branch hygiene should follow `docs/plans/long-running-loop-runbook.md`.
 - When the active milestone exists and the queue reports `ready`, the builder may resume against that milestone only.
-- Phase 51 is the active approved successor queue; do not open a parallel execution queue.
+- Phase 52 is the active approved successor queue; do not open a parallel execution queue.
 - When no open milestone exists and `audit-github-queue` reports `paused`, treat that state as an intentional released stop-state rather than a broken queue.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note records the completed Phase 50 runtime-boundary closeout and the approved Phase 51 successor queue after the formal `v0.1.0` release baseline.
+This note records the completed Phase 51 route/runtime-readiness closeout and the approved Phase 52 successor queue after the formal `v0.1.0` release baseline.
 
 ## Snapshot
 
@@ -214,7 +214,7 @@ This note records the completed Phase 50 runtime-boundary closeout and the appro
   - `gh api repos/YSCJRH/mirror-sim/releases`
     - release `v0.1.0` exists and matches the committed release notes baseline
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - queue reports `ready` with `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate` as the active milestone
+    - queue reports `ready` with `Phase 52 - Legacy Route Containment and Runtime Scope Audit` as the active milestone
   - `gh issue list --milestone "Phase 47 - Boundary Readiness and Successor Hygiene" --state all`
     - `#365` `Phase 47 exit gate` is `closed` after merging PR `#374`
     - `#366` `Phase 47: sync repo truth to successor queue` is `closed` after merging PR `#370`
@@ -251,10 +251,12 @@ This note records the completed Phase 50 runtime-boundary closeout and the appro
     - `/` remains the guided public demo
     - `docs/plans/phase-50-product-boundary-2026-05-18.md` records the boundary note
   - `gh issue list --milestone "Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate" --state all`
-    - `#403` `Phase 51 exit gate` is `open`, `blocked`, and `lane:protected-core`
+    - `#403` `Phase 51 exit gate` is `closed` after the Phase 51 closeout reassessment
     - `#404` `Phase 51: sync repo truth after Phase 50 closeout` is `closed` by PR `#407`
     - `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract` is `closed` by PR `#408`
-    - `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards` is the current `status:ready` protected-core work item
+    - `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards` is `closed` by PR `#409`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/51`
+    - milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate` is `closed`
   - Phase 51 Private-Beta Route Ownership Contract:
     - private-beta launch hub remains planning-only
     - `/` and `/review` remain public-demo surfaces
@@ -266,6 +268,15 @@ This note records the completed Phase 50 runtime-boundary closeout and the appro
     - private-beta runtime mutations pass route-derived world scope through composer, CLI, and backend service guards
     - world-scoped workspace loading rejects session or node manifests whose durable world/session ids conflict with route params
     - `docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md` records the guard verification note
+  - `gh issue list --milestone "Phase 52 - Legacy Route Containment and Runtime Scope Audit" --state all`
+    - `#410` `Phase 52 exit gate` is `open`, `blocked`, and `lane:protected-core`
+    - `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate` is the current `status:ready` protected-core work item
+    - `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract` is `open` and blocked until the repo-truth sync lands
+    - `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is `open` and blocked until the legacy route audit lands
+  - Phase 52 successor gate:
+    - legacy top-level runtime routes remain the next protected route-containment audit surface
+    - runtime mutation guard regression coverage remains the follow-up after route audit
+    - `docs/plans/phase-52-successor-gate-2026-05-18.md` records the active gate note
 
 ## Trusted Source Of Truth
 
@@ -287,28 +298,33 @@ This note records the completed Phase 50 runtime-boundary closeout and the appro
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
 - The default workbench path now consumes the canonical compare artifact directly and keeps focused divergent trace surfaces ahead of heavier packet-driven review flows.
 - The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, execution recovery release boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, escalation acknowledgment packets, and escalation closure packets without introducing backend API expansion.
-- The current repository state has completed the Phase 50 runtime-boundary queue, preserved `v0.1.0` as the latest published release baseline, and opened the approved Phase 51 successor queue.
+- The current repository state has completed the Phase 51 route/runtime-readiness queue, preserved `v0.1.0` as the latest published release baseline, and opened the approved Phase 52 successor queue.
 
 ## Next Entry Point
 
-- Phase 51 is the active approved successor queue; `audit-github-queue` reports `ready`.
+- Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`.
+- Phase 52 is the active approved successor queue; `audit-github-queue` reports `ready`.
 - The Phase 47 unlock order is resolved: the queue-sync issue is closed after PR `#370`, the boundary-regression report is closed after PR `#371`, the runtime-world safety preflight is closed after PR `#372`, the main-path containment report is closed after PR `#373`, and the exit gate is closed after PR `#374`.
 - The Phase 48 unlock order is resolved: `#376` and `#377` closed through earlier Phase 48 PRs, `#378` and `#379` closed through PR `#382`, and `#375` closed after the post-merge exit-gate reassessment.
 - The Phase 49 unlock order is resolved: `#384` closed through PR `#385`, `#386` closed through PR `#387`, `#388` closed through PR `#389`, `#390` closed through PR `#391`, `#392` closed through PR `#393`, `#394` closed through PR `#395`, and `#383` closed after the post-merge exit-gate reassessment.
 - The Phase 50 unlock order is resolved: `#397` closed through PR `#399`, `#398` closed through PR `#400`, `#401` closed through PR `#402`, and `#396` closed after the post-merge exit-gate reassessment.
-- The active successor milestone is `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`.
-- The Phase 51 exit gate is `#403` `Phase 51 exit gate`, which remains the open blocked closeout gate for this phase.
+- The active successor milestone is `Phase 52 - Legacy Route Containment and Runtime Scope Audit`.
+- The Phase 52 exit gate is `#410` `Phase 52 exit gate`, which remains the open blocked closeout gate for this phase.
 - `#397` `Phase 50: sync repo truth after Phase 49 closeout` is closed by PR `#399`.
 - `#398` `Phase 50: measure runtime generation duration before task_id decision` is closed by PR `#400`.
 - `#401` `Phase 50: ratify private-beta launch hub and public-path boundary` is closed by PR `#402`.
 - Phase 50 Product Boundary Decision: launch hub remains planning-only for now; current tracked code keeps `/` as the guided public demo.
 - `#404` `Phase 51: sync repo truth after Phase 50 closeout` is closed by PR `#407`.
 - `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract` is closed by PR `#408`.
-- `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards` is the current ready work item.
+- `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards` is closed by PR `#409`.
 - Phase 51 Private-Beta Route Ownership Contract: private-beta launch hub remains planning-only; `/` and `/review` stay public-demo surfaces, while `/worlds/<world_id>` remains the private-beta candidate product path.
 - The Phase 51 route contract note lives in `docs/plans/phase-51-private-beta-route-contract-2026-05-18.md`.
 - The durable route ownership contract lives in `docs/architecture/contracts.md` and `docs/decisions/ADR-0011-private-beta-route-ownership.md`.
 - Phase 51 Runtime Readiness and World-Scoped Guard Verification keeps synchronous v1 generation, records route-derived `worldId` mutation guards, and lives in `docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`.
+- `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate` is the current ready work item.
+- `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract` is blocked until `#411` lands.
+- `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is blocked until `#412` lands.
+- Phase 52 focuses on legacy top-level runtime routes and runtime mutation guard regression coverage without widening public/plugin/async contracts.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.
@@ -319,7 +335,8 @@ This note records the completed Phase 50 runtime-boundary closeout and the appro
 - The completed Phase 48 successor-gate baseline lives in `docs/plans/phase-48-successor-gate-2026-05-17.md`.
 - The completed Phase 49 successor-gate baseline lives in `docs/plans/phase-49-successor-gate-2026-05-18.md`.
 - The completed Phase 50 successor-gate baseline lives in `docs/plans/phase-50-successor-gate-2026-05-18.md`.
-- The active Phase 51 successor-gate baseline lives in `docs/plans/phase-51-successor-gate-2026-05-18.md`.
+- The completed Phase 51 successor-gate baseline lives in `docs/plans/phase-51-successor-gate-2026-05-18.md`.
+- The active Phase 52 successor-gate baseline lives in `docs/plans/phase-52-successor-gate-2026-05-18.md`.
 - Local untracked private-beta, kernel, and design-system planning files under `docs/plans/...` are candidate inputs only until a PR intentionally promotes them.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.

--- a/docs/plans/phase-51-successor-gate-2026-05-18.md
+++ b/docs/plans/phase-51-successor-gate-2026-05-18.md
@@ -2,9 +2,7 @@
 
 Date: 2026-05-18
 
-Issue: `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`
-
-Current work item: `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`
+Final work item: `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`
 
 This note records the post-Phase-50 baseline and opens the Phase 51 successor queue.
 Phase 51 is a protected-core route-contract and runtime-readiness phase for the
@@ -38,11 +36,11 @@ Phase 51 title:
 Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate
 ```
 
-Active GitHub objects:
+Closed GitHub objects:
 
 - `#403` `Phase 51 exit gate`
   - Lane: `protected-core`.
-  - Status: blocked closeout gate for Phase 51.
+  - Status: closed after the Phase 51 closeout reassessment.
 - `#404` `Phase 51: sync repo truth after Phase 50 closeout`
   - Lane: `protected-core`.
   - Status: closed by PR `#407`.
@@ -53,13 +51,12 @@ Active GitHub objects:
   - Scope: record the Phase 51 Private-Beta Route Ownership Contract before any launch-hub implementation.
 - `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`
   - Lane: `protected-core`.
-  - Status: current ready work item.
+  - Status: closed by PR `#409`.
   - Scope: verify runtime readiness and world-scoped session guards before product-path
     runtime surfaces widen.
 
-`python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
-with Phase 51 as the only open milestone, `#403` as the protected blocked exit gate, and
-`#406` as the current ready work item.
+Phase 51 is closed after PR `#409`, issue `#403`, and milestone
+`Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`.
 
 ## Protected-Core Lane Coverage
 
@@ -208,6 +205,29 @@ git diff --check
 ./make.ps1 test
 ./make.ps1 eval-demo
 ```
+
+## Post-Phase 51 Closeout
+
+Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`.
+
+Phase 52 is the active approved successor queue:
+
+- Milestone: `Phase 52 - Legacy Route Containment and Runtime Scope Audit`.
+- `#410` `Phase 52 exit gate` is open and blocked.
+- `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate`
+  is the current ready work item.
+- `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`
+  is blocked until the repo-truth sync lands.
+- `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is blocked until
+  the legacy route audit lands.
+
+Phase 52 keeps legacy top-level runtime routes and runtime mutation guard regression as
+protected-core follow-up surfaces. It does not widen public/plugin/async contracts, implement
+a launch hub, replace `/`, or change session/node/report/claim/trace/compare artifact
+contracts.
+
+The active Phase 52 successor-gate baseline lives in
+`docs/plans/phase-52-successor-gate-2026-05-18.md`.
 
 For `#405`, run:
 

--- a/docs/plans/phase-52-successor-gate-2026-05-18.md
+++ b/docs/plans/phase-52-successor-gate-2026-05-18.md
@@ -1,0 +1,164 @@
+# Phase 52 Successor Gate
+
+Date: 2026-05-18
+
+Issue: `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate`
+
+Current work item: `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate`
+
+This note records the post-Phase-51 baseline and opens the Phase 52 successor queue.
+Phase 52 is a protected-core route-containment and runtime-scope audit phase. It syncs
+repo truth after the Phase 51 closeout, audits legacy top-level runtime routes, and
+strengthens runtime mutation guard regression coverage. It is not a launch-hub,
+public-path, plugin, async-runtime, or schema-expansion phase.
+
+This gate is recorded at `docs/plans/phase-52-successor-gate-2026-05-18.md`.
+
+## Phase 51 Closeout Evidence
+
+Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`.
+
+- PR `#407` closed `#404` `Phase 51: sync repo truth after Phase 50 closeout`.
+- PR `#408` closed `#405` `Phase 51: ratify private-beta route ownership and launch-hub contract`.
+- PR `#409` closed `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`.
+- Issue `#403` `Phase 51 exit gate` is closed after post-merge validation on `main`.
+- Milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate` is closed.
+- Phase 51 Private-Beta Route Ownership Contract is recorded in
+  `docs/plans/phase-51-private-beta-route-contract-2026-05-18.md`.
+- Phase 51 Runtime Readiness and World-Scoped Guard Verification is recorded in
+  `docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`.
+- Queue audit reached the formal paused stop-state after Phase 51 closed, then returned
+  `ready` once Phase 52 was opened with one blocked exit gate and one ready work item.
+
+## Phase 52 Operational Queue
+
+Phase 52 title:
+
+```text
+Phase 52 - Legacy Route Containment and Runtime Scope Audit
+```
+
+Active GitHub objects:
+
+- `#410` `Phase 52 exit gate`
+  - Lane: `protected-core`.
+  - Status: blocked closeout gate for Phase 52.
+- `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate`
+  - Lane: `protected-core`.
+  - Status: current ready work item.
+  - Scope: sync tracked docs to Phase 52 after closing Phase 51.
+- `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`
+  - Lane: `protected-core`.
+  - Status: blocked until the repo-truth sync lands.
+  - Scope: audit legacy top-level runtime routes before presenting any route as the
+    private-beta main path.
+- `#413` `Phase 52: strengthen runtime mutation guard regression baseline`
+  - Lane: `protected-core`.
+  - Status: blocked until the legacy route audit lands.
+  - Scope: strengthen regression coverage for runtime mutation guard boundaries.
+
+`python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
+with Phase 52 as the only open milestone, `#410` as the protected blocked exit gate, and
+`#411` as the current ready work item.
+
+## Protected-Core Lane Coverage
+
+Phase 52 work is protected-core by default when it touches route ownership, runtime guard
+boundaries, session contracts, safety behavior, eval contracts, or queue governance. The
+lane policy already protects:
+
+- `docs/architecture/contracts.md`
+- `docs/decisions/`
+- `docs/plans/automation-roadmap.md`
+- `docs/plans/current-state-baseline.md`
+- `docs/plans/phase-`
+- `backend/app/sessions/`
+- `frontend/src/app/api/runtime/`
+- `frontend/src/app/lib/runtime-cli.ts`
+
+This protection is operational governance. It does not itself change scenario DSL,
+perturbation payloads, session/node manifests, `decision_trace.jsonl`, compare artifacts,
+public demo artifact layout, or the Mirror Codex MCP contract.
+
+## Carried Forward TODO[verify] Items
+
+- TODO[verify]: Codex UI tool-card evidence remains open until a clean Codex app session
+  shows observable MCP tool or resource cards/traces for the Mirror Codex plugin.
+- Runtime generation duration is recorded in
+  `docs/plans/phase-50-runtime-generation-duration-measurement-2026-05-18.md`.
+  Keep synchronous generation for v1.
+  TODO[verify]: rerun hosted/private-beta model measurements before introducing async task semantics.
+- Phase 51 Route Ownership keeps `/` and `/review` as public-demo surfaces and
+  `/worlds/<world_id>` as the private-beta candidate product path.
+- Phase 51 Runtime Readiness and World-Scoped Guard Verification keeps route-derived
+  `worldId` guards for private-beta mutation paths.
+- TODO[verify]: decide whether legacy top-level runtime routes should remain
+  compatibility surfaces, redirect, deprecate, or receive a separate durable contract.
+- TODO[verify]: require route-derived `worldId` or an equivalent reviewed scope guard
+  before adding any new mutating runtime API.
+- Do not recreate local Codex automations without a new explicit operator request.
+
+## Phase 52 Work Package Map
+
+1. Repo-truth sync after Phase 51 closeout
+   - Record Phase 51 closure, Phase 52 queue objects, validation, and carried-forward
+     boundaries across README and active planning docs.
+   - Keep local Mirror-specific automations revoked unless the operator explicitly asks to
+     recreate them.
+
+2. Legacy top-level runtime route audit
+   - Inventory legacy top-level runtime routes.
+   - Decide whether `/perturb`, `/runtime/<session_id>`, and child routes remain
+     compatibility surfaces, should redirect, or need a later deprecation contract.
+   - Preserve public demo, plugin, private-beta, and async-runtime boundaries.
+
+3. Runtime mutation guard regression baseline
+   - Strengthen coverage that product/web-wrapper mutation calls pass route-derived
+     `worldId` or an equivalent reviewed scope guard.
+   - Preserve public-demo blocking and backend expected-world mismatch rejection.
+
+## Blueprint Boundary
+
+Phase 52 must stay aligned with `mirror.md` and `AGENTS.md`:
+
+- Mirror is a constrained, evidence-backed, replayable what-if sandbox for fictional or
+  explicitly authorized worlds.
+- Do not present Mirror as a real-world prediction machine.
+- Do not build real-person personas or digital doubles.
+- Do not build political persuasion, law-enforcement scoring, hiring, credit, medical, or
+  judicial decision systems.
+- Every report claim must keep both `label` and `evidence_ids`.
+- Durable contract changes require `docs/architecture/contracts.md` updates and an ADR when
+  the contract is long-lived.
+
+## Non-Goals
+
+- Do not implement a launch hub in Phase 52.
+- Do not replace `/` or widen the public path.
+- Do not change public demo behavior.
+- Do not change Mirror Codex plugin MCP tools or resources.
+- Do not add mutating Mirror Codex MCP tools.
+- Do not add Hosted GPT, BYOK, upload, auth, billing, database, object storage, or quota
+  behavior to the public path or plugin path.
+- Do not implement async workers, queues, `task_id`, retry, status, cleanup, checkpoint
+  mutation/deletion, or restore semantics.
+- Do not change scenario DSL, claim labels, report claim `evidence_ids`, run trace shape,
+  compare artifact shape, session/node manifest shape, public demo artifact layout, or
+  plugin MCP contract.
+- Do not promote local untracked April/private-beta planning files as durable truth without
+  a reviewed PR.
+- Do not recreate local Codex automations without a new explicit operator request.
+
+## Validation Commands
+
+For `#411`, run:
+
+```powershell
+python -m pytest backend/tests/test_phase52_successor_gate.py backend/tests/test_phase51_successor_gate.py backend/tests/test_phase51_runtime_guard_note.py backend/tests/test_automation.py::test_classify_paths_marks_phase_queue_docs_protected -q
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-51-successor-gate-2026-05-18.md docs/plans/phase-52-successor-gate-2026-05-18.md backend/tests/test_phase51_successor_gate.py backend/tests/test_phase52_successor_gate.py backend/tests/test_automation.py
+git diff --check
+./make.ps1 test
+./make.ps1 eval-demo
+```

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 50 runtime-boundary closeout, and the approved Phase 51 successor queue.
+This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 51 route/runtime-readiness closeout, and the approved Phase 52 successor queue.
 
 ## Current Gate State
 
@@ -54,7 +54,8 @@ This note records the current post-Day-0 execution status for Mirror after the f
 - Phase 48 exit gate: closed
 - Phase 49 exit gate: closed
 - Phase 50 exit gate: closed
-- Phase 51 exit gate: open and blocked
+- Phase 51 exit gate: closed
+- Phase 52 exit gate: open and blocked
 
 Local phase audits currently report:
 
@@ -62,15 +63,38 @@ Local phase audits currently report:
 - `phase2`: pass
 - `phase3`: pass
 
-## Phase 51 Successor Queue
+## Phase 52 Successor Queue
 
 - `audit-github-queue`
-  - reports `ready` with `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate` as the active milestone
-- milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`
+  - reports `ready` with `Phase 52 - Legacy Route Containment and Runtime Scope Audit` as the active milestone
+- milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`
   - open
-- `#403` `Phase 51 exit gate`
+- `#410` `Phase 52 exit gate`
   - open and blocked
   - labeled `lane:protected-core` because it is the protected closeout gate
+- `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate`
+  - current protected-core repo-truth work item
+  - syncs durable docs to Phase 52 after Phase 51 closeout
+- `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`
+  - open and blocked until the repo-truth sync lands
+  - audits legacy top-level runtime routes before any route is presented as the private-beta main path
+- `#413` `Phase 52: strengthen runtime mutation guard regression baseline`
+  - open and blocked until the legacy route audit lands
+  - strengthens runtime mutation guard regression coverage
+- boundary posture
+  - Phase 52 does not widen public/plugin/async contracts.
+- phase gate baseline
+  - active Phase 52 gate note: `docs/plans/phase-52-successor-gate-2026-05-18.md`
+
+## Phase 51 Closeout
+
+Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`.
+
+- milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`
+  - closed after PR `#409` and the post-merge exit-gate reassessment
+- `#403` `Phase 51 exit gate`
+  - closed after the post-merge reassessment on `main`
+  - labeled `lane:protected-core` because it was the protected closeout gate
 - `#404` `Phase 51: sync repo truth after Phase 50 closeout`
   - closed by PR `#407`
   - synced durable docs to Phase 51
@@ -80,11 +104,11 @@ Local phase audits currently report:
   - Phase 51 Private-Beta Route Ownership Contract: private-beta launch hub remains planning-only
   - durable route ownership contract: `docs/architecture/contracts.md` and `docs/decisions/ADR-0011-private-beta-route-ownership.md`
 - `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards`
-  - current protected-core runtime-readiness work item
+  - closed by PR `#409`
   - verifies runtime readiness and world-scoped session guards before runtime surfaces widen
   - Phase 51 Runtime Readiness and World-Scoped Guard Verification: synchronous v1 generation remains the current runtime contract and route-derived `worldId` guards now protect branch generation, rollback, and world-scoped workspace loading
 - phase gate baseline
-  - active Phase 51 gate note: `docs/plans/phase-51-successor-gate-2026-05-18.md`
+  - completed Phase 51 gate note: `docs/plans/phase-51-successor-gate-2026-05-18.md`
   - route contract note: `docs/plans/phase-51-private-beta-route-contract-2026-05-18.md`
   - runtime guard note: `docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`
 
@@ -208,8 +232,9 @@ Local phase audits currently report:
   - Phase 48 completed as a successor-intake and boundary contract triage round
   - Phase 49 completed as a contract-hardening round
   - Phase 50 completed as a runtime-orchestration measurement and product-boundary round
-  - Phase 51 is the active approved successor queue
-  - any work beyond the Phase 51 queue requires a fresh decision against the trigger conditions in `mirror.md`
+  - Phase 51 completed as a private-beta route contract and runtime-readiness round
+  - Phase 52 is the active approved successor queue
+  - any work beyond the Phase 52 queue requires a fresh decision against the trigger conditions in `mirror.md`
 
 ## Closeout Snapshot
 
@@ -667,7 +692,7 @@ Local phase audits currently report:
 - Protected-core changes still require explicit review and must not auto-merge.
 - Long-running execution should assign exactly one writer worktree per issue.
 - When `audit-github-queue` reports `ready`, consume only the currently active milestone and do not parallel-open another execution queue.
-- Phase 51 is the active approved successor queue; do not open a parallel execution queue.
+- Phase 52 is the active approved successor queue; do not open a parallel execution queue.
 - The previous local queue follow-up automation has been revoked or left paused per operator request; do not recreate an automation without a new explicit request.
 
 ## Historical Branch Status


### PR DESCRIPTION
Closes #411.

## Summary
- record Phase 51 closeout and Phase 52 queue objects in tracked docs
- add the Phase 52 successor gate note and regression coverage
- update active docs so Phase 52 is the active queue and Phase 51 is historical
- preserve public/plugin/async/schema non-goals and local automation revocation guidance

## Validation
- python -m pytest backend/tests/test_phase52_successor_gate.py backend/tests/test_phase51_successor_gate.py backend/tests/test_phase51_runtime_guard_note.py backend/tests/test_automation.py::test_classify_paths_marks_phase_queue_docs_protected -q
- python scripts/check_no_secrets.py
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-51-successor-gate-2026-05-18.md docs/plans/phase-52-successor-gate-2026-05-18.md backend/tests/test_phase51_successor_gate.py backend/tests/test_phase52_successor_gate.py backend/tests/test_automation.py
- git diff --check
- ./make.ps1 test
- ./make.ps1 eval-demo