### PR TITLE
Phase 52 legacy route audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,10 +254,13 @@ session or node manifests that conflict with route `worldId` or `sessionId`. See
 
 Phase 52 Legacy Route Containment and Runtime Scope Audit: Phase 51 is closed after PR
 `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime
-Readiness Gate`; private-beta route ownership and world-scoped session guards remain ratified by Phase 51. Phase 52 is the active approved successor queue. It starts with repo-truth
-sync, then audits legacy top-level runtime routes and strengthens runtime mutation guard
-regression coverage without widening public demo, plugin, Hosted GPT/BYOK, or async
-contracts. See `docs/plans/phase-52-successor-gate-2026-05-18.md`.
+Readiness Gate`; private-beta route ownership and world-scoped session guards remain ratified by Phase 51. Phase 52 is the active approved successor queue. Repo-truth sync closed
+through PR `#414`; the current work item is the Phase 52 Legacy Top-Level Runtime Route
+Audit for `#412`, recorded in
+`docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`. It audits
+legacy top-level runtime routes before runtime mutation guard regression coverage without
+widening public demo, plugin, Hosted GPT/BYOK, or async contracts. See
+`docs/plans/phase-52-successor-gate-2026-05-18.md`.
 
 ---
 
@@ -294,7 +297,7 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - Phase 49 is closed after PR `#395`, issue `#383`, and milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; completed work items were `#384`, `#386`, `#388`, `#390`, `#392`, and `#394`.
 - Phase 50 is closed after PR `#402`, issue `#396`, and milestone `Phase 50 - Runtime Orchestration Measurement and Product Boundary`; completed work items were `#397`, `#398`, and `#401`. Phase 50 measured before any `task_id` or worker contract is introduced and kept the private-beta launch hub planning-only for now.
 - Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`; completed work items were `#404`, `#405`, and `#406`.
-- Phase 52 is the active approved successor queue: `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; `audit-github-queue` reports `ready` with `#410` as the blocked exit gate, `#411` as the current ready repo-truth sync item, and `#412`/`#413` as blocked follow-up items for legacy top-level runtime routes and runtime mutation guard regression coverage.
+- Phase 52 is the active approved successor queue: `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; `audit-github-queue` reports `ready` with `#410` as the blocked exit gate, `#411` closed by PR `#414`, `#412` as the current ready Phase 52 Legacy Top-Level Runtime Route Audit, and `#413` blocked for runtime mutation guard regression coverage until the legacy route audit lands. The route audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`; Phase 52 does not widen public demo, plugin, Hosted GPT/BYOK, or async contracts.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
 - Fog Harbor remains the canonical demo world; `museum-night` is the minimal transfer world used to prove the pipeline is not single-world-only.
 

--- a/backend/tests/test_phase52_legacy_route_audit_note.py
+++ b/backend/tests/test_phase52_legacy_route_audit_note.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+NOTE_PATH = Path("docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md")
+
+
+def test_phase52_legacy_route_audit_note_exists_with_required_sections() -> None:
+    assert NOTE_PATH.exists()
+
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    required_sections = [
+        "# Phase 52 Legacy Top-Level Runtime Route Audit",
+        "Issue: `#412`",
+        "## Decision",
+        "## Evidence",
+        "## Route Inventory",
+        "## Legacy Route Posture",
+        "## Follow-Up Gate",
+        "## Non-Goals",
+        "## Validation Commands",
+    ]
+    for section in required_sections:
+        assert section in note
+
+
+def test_phase52_legacy_route_audit_records_route_posture() -> None:
+    assert NOTE_PATH.exists()
+
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    required_phrases = [
+        "`/perturb` remains a Fog Harbor-defaulted legacy compatibility surface",
+        "`/runtime/<session_id>` remains a Fog Harbor-defaulted legacy compatibility surface",
+        "`/runtime/<session_id>/explain` remains a Fog Harbor-defaulted legacy compatibility surface",
+        "`/runtime/<session_id>/report` remains a Fog Harbor-defaulted legacy compatibility surface",
+        "`/worlds/<world_id>/perturb` remains the canonical private-beta operator route",
+        "`/worlds/<world_id>/runtime/<session_id>` remains the canonical world-scoped runtime workspace",
+        "Do not redirect, delete, or promote legacy top-level runtime routes in `#412`",
+        "Do not present legacy top-level runtime routes as the private-beta main path",
+        "No public demo, plugin, Hosted GPT, BYOK, upload, auth, billing, database, object storage, quota, or async contract is widened",
+        "Do not change scenario DSL, claim labels, report claim `evidence_ids`, run trace shape",
+        "TODO[verify]: open a separate migration work item before redirecting or deleting any legacy top-level runtime route",
+    ]
+    for phrase in required_phrases:
+        assert phrase in note
+
+
+def test_architecture_contract_records_phase52_legacy_route_posture() -> None:
+    contract = Path("docs/architecture/contracts.md").read_text(encoding="utf-8")
+
+    required_phrases = [
+        "Top-level `/perturb`, `/runtime/<session_id>`, and child runtime routes remain Fog Harbor-defaulted legacy compatibility surfaces.",
+        "They must not be promoted or linked as canonical private-beta route owners.",
+        "`/worlds/<world_id>/perturb` remains the canonical private-beta operator route.",
+        "`/worlds/<world_id>/runtime/<session_id>` remains the canonical world-scoped runtime workspace.",
+        "TODO[verify]: open a separate migration work item before redirecting or deleting any legacy top-level runtime route.",
+    ]
+    for phrase in required_phrases:
+        assert phrase in contract
+
+
+def test_tracked_frontend_route_tree_contains_legacy_and_world_scoped_runtime_routes() -> None:
+    route_files = [
+        Path("frontend/src/app/perturb/page.tsx"),
+        Path("frontend/src/app/runtime/[sessionId]/page.tsx"),
+        Path("frontend/src/app/runtime/[sessionId]/explain/page.tsx"),
+        Path("frontend/src/app/runtime/[sessionId]/report/page.tsx"),
+        Path("frontend/src/app/worlds/[worldId]/perturb/page.tsx"),
+        Path("frontend/src/app/worlds/[worldId]/runtime/[sessionId]/page.tsx"),
+        Path("frontend/src/app/worlds/[worldId]/runtime/[sessionId]/explain/page.tsx"),
+        Path("frontend/src/app/worlds/[worldId]/runtime/[sessionId]/report/page.tsx"),
+    ]
+
+    for path in route_files:
+        assert path.exists(), path.as_posix()
+
+    legacy_perturb = Path("frontend/src/app/perturb/page.tsx").read_text(encoding="utf-8")
+    legacy_runtime = Path("frontend/src/app/runtime/[sessionId]/page.tsx").read_text(
+        encoding="utf-8"
+    )
+    legacy_explain = Path("frontend/src/app/runtime/[sessionId]/explain/page.tsx").read_text(
+        encoding="utf-8"
+    )
+    legacy_report = Path("frontend/src/app/runtime/[sessionId]/report/page.tsx").read_text(
+        encoding="utf-8"
+    )
+    world_runtime = Path("frontend/src/app/worlds/[worldId]/runtime/[sessionId]/page.tsx").read_text(
+        encoding="utf-8"
+    )
+    world_explain = Path(
+        "frontend/src/app/worlds/[worldId]/runtime/[sessionId]/explain/page.tsx"
+    ).read_text(encoding="utf-8")
+    world_report = Path(
+        "frontend/src/app/worlds/[worldId]/runtime/[sessionId]/report/page.tsx"
+    ).read_text(encoding="utf-8")
+
+    assert "loadRuntimeSessionWorkspace(" in legacy_perturb
+    assert "loadRuntimeSessionWorkspace(" in legacy_runtime
+    assert "loadRuntimeSessionWorkspace(" in legacy_explain
+    assert "loadRuntimeSessionWorkspace(" in legacy_report
+    assert "loadRuntimeSessionWorkspaceForWorld(worldId" in world_runtime
+    assert "loadRuntimeSessionWorkspaceForWorld(worldId" in world_explain
+    assert "loadRuntimeSessionWorkspaceForWorld(worldId" in world_report

--- a/backend/tests/test_phase52_successor_gate.py
+++ b/backend/tests/test_phase52_successor_gate.py
@@ -12,8 +12,8 @@ def test_phase52_successor_gate_exists_with_required_sections() -> None:
     gate = PHASE52_GATE_PATH.read_text(encoding="utf-8")
     required_sections = [
         "# Phase 52 Successor Gate",
-        "Issue: `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate`",
-        "Current work item: `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate`",
+        "Issue: `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`",
+        "Current work item: `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`",
         "## Phase 51 Closeout Evidence",
         "## Phase 52 Operational Queue",
         "## Protected-Core Lane Coverage",
@@ -38,9 +38,10 @@ def test_phase52_successor_gate_records_queue_and_boundaries() -> None:
         "`#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`",
         "`#413` `Phase 52: strengthen runtime mutation guard regression baseline`",
         "Status: blocked closeout gate for Phase 52.",
+        "Status: closed by PR",
         "Status: current ready work item.",
-        "Status: blocked until the repo-truth sync lands.",
         "Status: blocked until the legacy route audit lands.",
+        "Phase 52 Legacy Top-Level Runtime Route Audit",
         "Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`",
         "legacy top-level runtime routes",
         "route-derived `worldId`",
@@ -54,6 +55,7 @@ def test_phase52_successor_gate_records_queue_and_boundaries() -> None:
         "compare artifact shape, session/node manifest shape, public demo artifact layout",
         "Do not recreate local Codex automations without a new explicit operator request",
         "`docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`",
+        "`docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`",
         "`docs/plans/phase-52-successor-gate-2026-05-18.md`",
     ]
     for phrase in required_phrases:
@@ -77,6 +79,8 @@ def test_active_state_docs_point_to_phase52_queue() -> None:
         assert "`#411`" in text
         assert "`#412`" in text
         assert "`#413`" in text
+        assert "Phase 52 Legacy Top-Level Runtime Route Audit" in text
+        assert "`docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`" in text
         assert "legacy top-level runtime routes" in text
         assert "runtime mutation guard regression" in text
         assert (

--- a/docs/architecture/contracts.md
+++ b/docs/architecture/contracts.md
@@ -482,9 +482,10 @@ All IDs must be serializable, stable across files, and traceable in `artifacts/`
   are disabled in local or explicitly authorized private-beta environments.
 - `/worlds/new` remains a private-beta candidate creation route and must stay disabled in
   public demo mode.
-- `/worlds/<world_id>/perturb` remains the main private-beta operator path.
+- `/worlds/<world_id>/perturb` remains the canonical private-beta operator route.
 - `/worlds/<world_id>/runtime/<session_id>` and its `/explain` and `/report` children
   remain world-scoped private-beta runtime surfaces.
+- `/worlds/<world_id>/runtime/<session_id>` remains the canonical world-scoped runtime workspace.
 - `/worlds/<world_id>/review` remains the world-scoped private-beta review surface.
 - `/api/runtime/start-session`, `/api/runtime/generate-branch`,
   `/api/runtime/rollback-session`, and `/api/worlds/create` remain private-beta mutation
@@ -492,10 +493,11 @@ All IDs must be serializable, stable across files, and traceable in `artifacts/`
   explicitly applies.
 - Top-level `/changes/<branch_id>` and `/explain/<branch_id>` remain deterministic
   public-demo support routes.
+- Top-level `/perturb`, `/runtime/<session_id>`, and child runtime routes remain Fog Harbor-defaulted legacy compatibility surfaces.
 - Top-level `/perturb`, `/runtime/<session_id>`, and child runtime routes are legacy
-  compatibility surfaces, not the canonical private-beta route owners. TODO[verify]: decide
-  whether to deprecate, redirect, or formally re-contract them before presenting them as a
-  private-beta main path.
+  compatibility surfaces, not the canonical private-beta route owners.
+- They must not be promoted or linked as canonical private-beta route owners.
+- TODO[verify]: open a separate migration work item before redirecting or deleting any legacy top-level runtime route.
 - The private-beta launch hub remains planning-only in Phase 51. A future launch hub must
   not replace `/`, start sessions, generate branches, create worlds, upload corpora, enable
   Hosted GPT, accept BYOK, or call model providers from the public path.

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -175,10 +175,10 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 52 is the active approved successor queue.
 - milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit` is open.
 - `#410` `Phase 52 exit gate` is open, blocked, and protected-core.
-- `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate` is the current ready work item.
-- `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract` is blocked until the repo-truth sync lands.
+- `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate` is closed by PR `#414`.
+- `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract` is the current ready Phase 52 Legacy Top-Level Runtime Route Audit.
 - `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is blocked until the legacy route audit lands.
-- Phase 52 focuses on legacy top-level runtime routes and runtime mutation guard regression coverage without widening public/plugin/async contracts. The gate note lives in `docs/plans/phase-52-successor-gate-2026-05-18.md`.
+- Phase 52 focuses on legacy top-level runtime routes and runtime mutation guard regression coverage without widening public/plugin/async contracts. The route audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`, and the gate note lives in `docs/plans/phase-52-successor-gate-2026-05-18.md`.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -270,11 +270,13 @@ This note records the completed Phase 51 route/runtime-readiness closeout and th
     - `docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md` records the guard verification note
   - `gh issue list --milestone "Phase 52 - Legacy Route Containment and Runtime Scope Audit" --state all`
     - `#410` `Phase 52 exit gate` is `open`, `blocked`, and `lane:protected-core`
-    - `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate` is the current `status:ready` protected-core work item
-    - `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract` is `open` and blocked until the repo-truth sync lands
+    - `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate` is `closed` by PR `#414`
+    - `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract` is the current `status:ready` protected-core work item
     - `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is `open` and blocked until the legacy route audit lands
   - Phase 52 successor gate:
-    - legacy top-level runtime routes remain the next protected route-containment audit surface
+    - Phase 52 Legacy Top-Level Runtime Route Audit is the current protected route-containment audit surface
+    - `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md` records the route audit note
+    - legacy top-level runtime routes remain the current protected route-containment audit surface
     - runtime mutation guard regression coverage remains the follow-up after route audit
     - `docs/plans/phase-52-successor-gate-2026-05-18.md` records the active gate note
 
@@ -321,10 +323,11 @@ This note records the completed Phase 51 route/runtime-readiness closeout and th
 - The Phase 51 route contract note lives in `docs/plans/phase-51-private-beta-route-contract-2026-05-18.md`.
 - The durable route ownership contract lives in `docs/architecture/contracts.md` and `docs/decisions/ADR-0011-private-beta-route-ownership.md`.
 - Phase 51 Runtime Readiness and World-Scoped Guard Verification keeps synchronous v1 generation, records route-derived `worldId` mutation guards, and lives in `docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`.
-- `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate` is the current ready work item.
-- `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract` is blocked until `#411` lands.
+- `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate` is closed by PR `#414`.
+- `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract` is the current ready Phase 52 Legacy Top-Level Runtime Route Audit.
 - `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is blocked until `#412` lands.
 - Phase 52 focuses on legacy top-level runtime routes and runtime mutation guard regression coverage without widening public/plugin/async contracts.
+- The Phase 52 Legacy Top-Level Runtime Route Audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.

--- a/docs/plans/phase-51-successor-gate-2026-05-18.md
+++ b/docs/plans/phase-51-successor-gate-2026-05-18.md
@@ -215,9 +215,9 @@ Phase 52 is the active approved successor queue:
 - Milestone: `Phase 52 - Legacy Route Containment and Runtime Scope Audit`.
 - `#410` `Phase 52 exit gate` is open and blocked.
 - `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate`
-  is the current ready work item.
+  is closed by PR `#414`.
 - `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`
-  is blocked until the repo-truth sync lands.
+  is the current ready Phase 52 Legacy Top-Level Runtime Route Audit.
 - `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is blocked until
   the legacy route audit lands.
 
@@ -227,7 +227,9 @@ a launch hub, replace `/`, or change session/node/report/claim/trace/compare art
 contracts.
 
 The active Phase 52 successor-gate baseline lives in
-`docs/plans/phase-52-successor-gate-2026-05-18.md`.
+`docs/plans/phase-52-successor-gate-2026-05-18.md`, and the Phase 52 Legacy Top-Level
+Runtime Route Audit note lives in
+`docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`.
 
 For `#405`, run:
 

--- a/docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md
+++ b/docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md
@@ -1,0 +1,80 @@
+# Phase 52 Legacy Top-Level Runtime Route Audit
+
+Date: 2026-05-18
+
+Issue: `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`
+
+## Decision
+
+Legacy top-level runtime routes stay contained as compatibility surfaces in `#412`.
+
+`/perturb` remains a Fog Harbor-defaulted legacy compatibility surface. `/runtime/<session_id>` remains a Fog Harbor-defaulted legacy compatibility surface. `/runtime/<session_id>/explain` remains a Fog Harbor-defaulted legacy compatibility surface. `/runtime/<session_id>/report` remains a Fog Harbor-defaulted legacy compatibility surface.
+
+`/worlds/<world_id>/perturb` remains the canonical private-beta operator route. `/worlds/<world_id>/runtime/<session_id>` remains the canonical world-scoped runtime workspace, with its `/explain` and `/report` children kept under the same world-scoped route owner.
+
+Do not redirect, delete, or promote legacy top-level runtime routes in `#412`. Do not present legacy top-level runtime routes as the private-beta main path.
+
+## Evidence
+
+- `frontend/src/app/README.md` records world-scoped routes as private-beta product routes and lists top-level runtime routes under legacy/demo routes kept for reference.
+- `frontend/src/app/lib/runtime-session-data.ts` keeps `loadRuntimeSessionWorkspace()` defaulted to `fog-harbor-east-gate`, while `loadRuntimeSessionWorkspaceForWorld(worldId, ...)` is the world-scoped loader.
+- `frontend/src/app/perturb/page.tsx` and `frontend/src/app/runtime/[sessionId]/page.tsx` still render tracked top-level compatibility pages instead of redirecting.
+- `frontend/src/app/worlds/[worldId]/perturb/page.tsx` and `frontend/src/app/worlds/[worldId]/runtime/[sessionId]/page.tsx` remain the tracked world-scoped private-beta candidate routes.
+- `docs/plans/phase-51-private-beta-route-contract-2026-05-18.md` and `docs/decisions/ADR-0011-private-beta-route-ownership.md` already keep `/` and `/review` public-demo-owned while placing private-beta ownership under `/worlds/<world_id>`.
+- `docs/architecture/contracts.md` records public-demo mode as read-only and blocks public demo session start, branch generation, world creation, Hosted GPT, BYOK, uploads, and provider calls.
+
+## Route Inventory
+
+| Route | Current posture | Owner |
+| --- | --- | --- |
+| `/perturb` | Fog Harbor-defaulted legacy compatibility route | Legacy compatibility, not private-beta owner |
+| `/runtime/<session_id>` | Fog Harbor-defaulted legacy compatibility route | Legacy compatibility, not private-beta owner |
+| `/runtime/<session_id>/explain` | Fog Harbor-defaulted legacy compatibility route | Legacy compatibility, not private-beta owner |
+| `/runtime/<session_id>/report` | Fog Harbor-defaulted legacy compatibility route | Legacy compatibility, not private-beta owner |
+| `/worlds/<world_id>/perturb` | Canonical private-beta operator route | World-scoped private-beta candidate product path |
+| `/worlds/<world_id>/runtime/<session_id>` | Canonical world-scoped runtime workspace | World-scoped private-beta candidate product path |
+| `/worlds/<world_id>/runtime/<session_id>/explain` | World-scoped explain workspace | World-scoped private-beta candidate product path |
+| `/worlds/<world_id>/runtime/<session_id>/report` | World-scoped report workspace | World-scoped private-beta candidate product path |
+
+## Legacy Route Posture
+
+The legacy top-level runtime route posture is containment, not migration.
+
+- Keep the legacy top-level runtime routes tracked and explicit.
+- Keep them out of private-beta main-path documentation and navigation claims.
+- Treat their Fog Harbor defaulting as compatibility behavior, not as a multi-world contract.
+- Preserve the Phase 51 route ownership decision that private-beta product ownership is world-scoped.
+- Keep public-demo mutation blocking and private-beta route-derived `worldId` guards as separate contracts.
+
+No public demo, plugin, Hosted GPT, BYOK, upload, auth, billing, database, object storage, quota, or async contract is widened.
+
+## Follow-Up Gate
+
+- TODO[verify]: open a separate migration work item before redirecting or deleting any legacy top-level runtime route.
+- TODO[verify]: decide separately whether public-demo support links should keep, hide, or relabel `/perturb` before a private-beta launch surface is implemented.
+- TODO[verify]: keep route-derived `worldId` or an equivalent reviewed guard before adding any new mutating runtime API.
+
+## Non-Goals
+
+- Do not implement a launch hub in `#412`.
+- Do not replace `/` or widen the public path.
+- Do not change public demo behavior.
+- Do not change Mirror Codex plugin MCP tools or resources.
+- Do not add mutating Mirror Codex MCP tools.
+- Do not add Hosted GPT, BYOK, upload, auth, billing, database, object storage, or quota behavior to the public path or plugin path.
+- Do not implement async workers, queues, `task_id`, retry, status, cleanup, checkpoint mutation/deletion, or restore semantics.
+- Do not change scenario DSL, claim labels, report claim `evidence_ids`, run trace shape, compare artifact shape, session/node manifest shape, public demo artifact layout, or plugin MCP contract.
+- Do not build real-person personas, digital doubles, political persuasion, law-enforcement, hiring, credit, medical, or judicial decision systems.
+- Do not present Mirror as real-world prediction or package simulation output as certain real-world conclusions.
+
+## Validation Commands
+
+```powershell
+python -m pytest backend/tests/test_phase52_legacy_route_audit_note.py backend/tests/test_phase52_successor_gate.py backend/tests/test_phase51_route_contract_note.py backend/tests/test_phase51_runtime_guard_note.py -q
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+python -m backend.app.cli classify-lane --files README.md docs/architecture/contracts.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-51-successor-gate-2026-05-18.md docs/plans/phase-52-successor-gate-2026-05-18.md docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md backend/tests/test_phase52_legacy_route_audit_note.py backend/tests/test_phase52_successor_gate.py
+git diff --check
+./make.ps1 test
+./make.ps1 eval-demo
+```

--- a/docs/plans/phase-52-successor-gate-2026-05-18.md
+++ b/docs/plans/phase-52-successor-gate-2026-05-18.md
@@ -2,15 +2,16 @@
 
 Date: 2026-05-18
 
-Issue: `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate`
+Issue: `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`
 
-Current work item: `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate`
+Current work item: `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`
 
-This note records the post-Phase-51 baseline and opens the Phase 52 successor queue.
-Phase 52 is a protected-core route-containment and runtime-scope audit phase. It syncs
-repo truth after the Phase 51 closeout, audits legacy top-level runtime routes, and
-strengthens runtime mutation guard regression coverage. It is not a launch-hub,
-public-path, plugin, async-runtime, or schema-expansion phase.
+This note records the post-Phase-51 baseline and the Phase 52 successor queue. Phase 52
+is a protected-core route-containment and runtime-scope audit phase. It has synced repo
+truth after the Phase 51 closeout, now audits legacy top-level runtime routes through the
+Phase 52 Legacy Top-Level Runtime Route Audit, and then strengthens runtime mutation
+guard regression coverage. It is not a launch-hub, public-path, plugin, async-runtime, or
+schema-expansion phase.
 
 This gate is recorded at `docs/plans/phase-52-successor-gate-2026-05-18.md`.
 
@@ -45,11 +46,11 @@ Active GitHub objects:
   - Status: blocked closeout gate for Phase 52.
 - `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate`
   - Lane: `protected-core`.
-  - Status: current ready work item.
-  - Scope: sync tracked docs to Phase 52 after closing Phase 51.
+  - Status: closed by PR `#414`.
+  - Scope: synced tracked docs to Phase 52 after closing Phase 51.
 - `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`
   - Lane: `protected-core`.
-  - Status: blocked until the repo-truth sync lands.
+  - Status: current ready work item.
   - Scope: audit legacy top-level runtime routes before presenting any route as the
     private-beta main path.
 - `#413` `Phase 52: strengthen runtime mutation guard regression baseline`
@@ -59,7 +60,7 @@ Active GitHub objects:
 
 `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
 with Phase 52 as the only open milestone, `#410` as the protected blocked exit gate, and
-`#411` as the current ready work item.
+`#412` as the current ready work item.
 
 ## Protected-Core Lane Coverage
 
@@ -92,8 +93,10 @@ public demo artifact layout, or the Mirror Codex MCP contract.
   `/worlds/<world_id>` as the private-beta candidate product path.
 - Phase 51 Runtime Readiness and World-Scoped Guard Verification keeps route-derived
   `worldId` guards for private-beta mutation paths.
-- TODO[verify]: decide whether legacy top-level runtime routes should remain
-  compatibility surfaces, redirect, deprecate, or receive a separate durable contract.
+- Phase 52 Legacy Top-Level Runtime Route Audit is recorded in
+  `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`.
+- TODO[verify]: open a separate migration work item before redirecting or deleting any
+  legacy top-level runtime route.
 - TODO[verify]: require route-derived `worldId` or an equivalent reviewed scope guard
   before adding any new mutating runtime API.
 - Do not recreate local Codex automations without a new explicit operator request.
@@ -105,11 +108,15 @@ public demo artifact layout, or the Mirror Codex MCP contract.
      boundaries across README and active planning docs.
    - Keep local Mirror-specific automations revoked unless the operator explicitly asks to
      recreate them.
+   - Closed by PR `#414`.
 
 2. Legacy top-level runtime route audit
    - Inventory legacy top-level runtime routes.
-   - Decide whether `/perturb`, `/runtime/<session_id>`, and child routes remain
-     compatibility surfaces, should redirect, or need a later deprecation contract.
+   - Record the Phase 52 Legacy Top-Level Runtime Route Audit in
+     `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`.
+   - Keep `/perturb`, `/runtime/<session_id>`, and child routes as Fog Harbor-defaulted
+     legacy compatibility surfaces unless a later reviewed migration work item changes
+     that posture.
    - Preserve public demo, plugin, private-beta, and async-runtime boundaries.
 
 3. Runtime mutation guard regression baseline
@@ -151,13 +158,13 @@ Phase 52 must stay aligned with `mirror.md` and `AGENTS.md`:
 
 ## Validation Commands
 
-For `#411`, run:
+For `#412`, run:
 
 ```powershell
-python -m pytest backend/tests/test_phase52_successor_gate.py backend/tests/test_phase51_successor_gate.py backend/tests/test_phase51_runtime_guard_note.py backend/tests/test_automation.py::test_classify_paths_marks_phase_queue_docs_protected -q
+python -m pytest backend/tests/test_phase52_legacy_route_audit_note.py backend/tests/test_phase52_successor_gate.py backend/tests/test_phase51_route_contract_note.py backend/tests/test_phase51_runtime_guard_note.py -q
 python scripts/check_no_secrets.py
 python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
-python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-51-successor-gate-2026-05-18.md docs/plans/phase-52-successor-gate-2026-05-18.md backend/tests/test_phase51_successor_gate.py backend/tests/test_phase52_successor_gate.py backend/tests/test_automation.py
+python -m backend.app.cli classify-lane --files README.md docs/architecture/contracts.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-51-successor-gate-2026-05-18.md docs/plans/phase-52-successor-gate-2026-05-18.md docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md backend/tests/test_phase52_legacy_route_audit_note.py backend/tests/test_phase52_successor_gate.py
 git diff --check
 ./make.ps1 test
 ./make.ps1 eval-demo

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -73,11 +73,13 @@ Local phase audits currently report:
   - open and blocked
   - labeled `lane:protected-core` because it is the protected closeout gate
 - `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate`
-  - current protected-core repo-truth work item
-  - syncs durable docs to Phase 52 after Phase 51 closeout
+  - closed by PR `#414`
+  - synced durable docs to Phase 52 after Phase 51 closeout
 - `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`
-  - open and blocked until the repo-truth sync lands
+  - current protected-core route-containment work item
+  - Phase 52 Legacy Top-Level Runtime Route Audit
   - audits legacy top-level runtime routes before any route is presented as the private-beta main path
+  - route audit note: `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`
 - `#413` `Phase 52: strengthen runtime mutation guard regression baseline`
   - open and blocked until the legacy route audit lands
   - strengthens runtime mutation guard regression coverage


### PR DESCRIPTION
## Summary
- Adds the Phase 52 legacy top-level runtime route audit note for `#412`.
- Clarifies `docs/architecture/contracts.md` that top-level `/perturb` and `/runtime/...` remain Fog Harbor-defaulted legacy compatibility surfaces, not canonical private-beta route owners.
- Syncs Phase 52 queue docs from `#411` closed by PR `#414` to `#412` as the current route-containment work item.

Closes #412

## Validation
- `python -m pytest backend/tests/test_phase52_legacy_route_audit_note.py backend/tests/test_phase52_successor_gate.py backend/tests/test_phase51_route_contract_note.py backend/tests/test_phase51_runtime_guard_note.py -q` -> 16 passed
- `python -m pytest backend/tests/test_frontend_runtime_error_redaction.py::test_runtime_composer_generate_request_includes_world_id backend/tests/test_frontend_runtime_error_redaction.py::test_runtime_workspace_loader_rejects_route_session_world_mismatch backend/tests/test_cli.py::test_generate_branch_rejects_expected_world_mismatch backend/tests/test_cli.py::test_rollback_session_rejects_expected_world_mismatch -q` -> 4 passed
- `python scripts/check_no_secrets.py` -> passed
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` -> ready, `#412` current
- `python -m backend.app.cli classify-lane --files README.md docs/architecture/contracts.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-51-successor-gate-2026-05-18.md docs/plans/phase-52-successor-gate-2026-05-18.md docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md backend/tests/test_phase52_legacy_route_audit_note.py backend/tests/test_phase52_successor_gate.py` -> protected-core
- `git diff --check` -> passed
- `./make.ps1 test` -> 125 passed
- `./make.ps1 eval-demo` -> pass 23/23