### PR TITLE
Phase 52 runtime guard regression baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,11 +255,14 @@ session or node manifests that conflict with route `worldId` or `sessionId`. See
 Phase 52 Legacy Route Containment and Runtime Scope Audit: Phase 51 is closed after PR
 `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime
 Readiness Gate`; private-beta route ownership and world-scoped session guards remain ratified by Phase 51. Phase 52 is the active approved successor queue. Repo-truth sync closed
-through PR `#414`; the current work item is the Phase 52 Legacy Top-Level Runtime Route
-Audit for `#412`, recorded in
-`docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`. It audits
-legacy top-level runtime routes before runtime mutation guard regression coverage without
-widening public demo, plugin, Hosted GPT/BYOK, or async contracts. See
+through PR `#414`; the Phase 52 Legacy Top-Level Runtime Route Audit for `#412` closed
+through PR `#415` and is recorded in
+`docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`. The current work item is
+the Phase 52 Runtime Mutation Guard Regression Baseline for `#413`, recorded in
+`docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`. It strengthens
+runtime mutation guard regression coverage for route-derived `worldId` and public-demo
+blocking after the legacy top-level runtime routes audit, without widening public demo,
+plugin, Hosted GPT/BYOK, or async contracts. See
 `docs/plans/phase-52-successor-gate-2026-05-18.md`.
 
 ---
@@ -297,7 +300,7 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - Phase 49 is closed after PR `#395`, issue `#383`, and milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; completed work items were `#384`, `#386`, `#388`, `#390`, `#392`, and `#394`.
 - Phase 50 is closed after PR `#402`, issue `#396`, and milestone `Phase 50 - Runtime Orchestration Measurement and Product Boundary`; completed work items were `#397`, `#398`, and `#401`. Phase 50 measured before any `task_id` or worker contract is introduced and kept the private-beta launch hub planning-only for now.
 - Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`; completed work items were `#404`, `#405`, and `#406`.
-- Phase 52 is the active approved successor queue: `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; `audit-github-queue` reports `ready` with `#410` as the blocked exit gate, `#411` closed by PR `#414`, `#412` as the current ready Phase 52 Legacy Top-Level Runtime Route Audit, and `#413` blocked for runtime mutation guard regression coverage until the legacy route audit lands. The route audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`; Phase 52 does not widen public demo, plugin, Hosted GPT/BYOK, or async contracts.
+- Phase 52 is the active approved successor queue: `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; `audit-github-queue` reports `ready` with `#410` as the blocked exit gate, `#411` closed by PR `#414`, `#412` closed by PR `#415`, and `#413` as the current ready Phase 52 Runtime Mutation Guard Regression Baseline. The legacy top-level runtime routes audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`; the runtime guard note lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`; Phase 52 does not widen public demo, plugin, Hosted GPT/BYOK, or async contracts and keeps route-derived `worldId` guard coverage in scope.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
 - Fog Harbor remains the canonical demo world; `museum-night` is the minimal transfer world used to prove the pipeline is not single-world-only.
 

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -596,6 +596,59 @@ def test_cli_generate_branch_passes_expected_world_guard(
     assert captured["beta_user_id"] == "beta-user"
 
 
+def test_cli_rollback_session_passes_expected_world_guard(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    captured: dict[str, str | Path | None] = {}
+
+    def fake_rollback_session(
+        session_id: str,
+        node_id: str,
+        *,
+        repo_root: Path | None = None,
+        artifacts_root: Path | None = None,
+        expected_world_id: str | None = None,
+    ):
+        captured.update(
+            {
+                "session_id": session_id,
+                "node_id": node_id,
+                "repo_root": repo_root,
+                "artifacts_root": artifacts_root,
+                "expected_world_id": expected_world_id,
+            }
+        )
+        return sessions_service.start_session(
+            "fog-harbor-east-gate",
+            "scenario_baseline",
+            repo_root=get_settings().repo_root,
+            artifacts_root=tmp_path,
+        )
+
+    monkeypatch.setattr(cli_module, "rollback_session", fake_rollback_session)
+
+    assert (
+        main(
+            [
+                "rollback-session",
+                "--world",
+                "fog-harbor-east-gate",
+                "--session",
+                "session_demo",
+                "--to",
+                "node_root",
+                "--artifacts-root",
+                str(tmp_path),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert captured["expected_world_id"] == "fog-harbor-east-gate"
+    assert captured["node_id"] == "node_root"
+
+
 def test_cli_generate_branch_uses_session_decision_model(tmp_path: Path, capsys) -> None:
     settings = get_settings()
     assert main(["ingest", str(settings.manifest_path), "--out", str(tmp_path / "ingest")]) == 0

--- a/backend/tests/test_phase52_runtime_guard_regression_note.py
+++ b/backend/tests/test_phase52_runtime_guard_regression_note.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+NOTE_PATH = Path("docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md")
+
+
+def test_phase52_runtime_guard_regression_note_exists_with_required_sections() -> None:
+    assert NOTE_PATH.exists()
+
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    required_sections = [
+        "# Phase 52 Runtime Mutation Guard Regression Baseline",
+        "Issue: `#413`",
+        "## Decision",
+        "## Existing Guard Inventory",
+        "## Regression Locks",
+        "## Follow-Up Gate",
+        "## Non-Goals",
+        "## Validation Commands",
+    ]
+    for section in required_sections:
+        assert section in note
+
+
+def test_phase52_runtime_guard_regression_note_records_guard_posture() -> None:
+    assert NOTE_PATH.exists()
+
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    required_phrases = [
+        "Public-demo mutation routes stay disabled when `MIRROR_PUBLIC_DEMO_MODE=1` and `MIRROR_ALLOW_ANONYMOUS_RUNS` is not `1`",
+        "`/api/runtime/start-session`, `/api/runtime/generate-branch`, `/api/runtime/rollback-session`, and `/api/worlds/create` remain private-beta mutation APIs",
+        "Product and web-wrapper mutation calls must pass route-derived `worldId` or an equivalent reviewed scope guard",
+        "Direct local CLI calls may omit `--world` for compatibility when the operator provides an explicit artifacts root",
+        "backend session services must reject expected-world mismatches before branch generation or rollback",
+        "`RuntimeSessionActions` sends `worldId` with rollback requests",
+        "`scripts/smoke_public_demo_web.py` keeps live public-demo `403` coverage",
+        "No new mutating runtime API is added in `#413`",
+        "No public demo, plugin, Hosted GPT, BYOK, upload, auth, billing, database, object storage, quota, or async contract is widened",
+        "Do not implement async workers, queues, `task_id`, retry, status, cleanup",
+        "TODO[verify]: require a reviewed scope guard before adding any new mutating runtime API",
+    ]
+    for phrase in required_phrases:
+        assert phrase in note
+
+
+def test_architecture_contract_records_phase52_runtime_guard_baseline() -> None:
+    contract = Path("docs/architecture/contracts.md").read_text(encoding="utf-8")
+
+    required_phrases = [
+        "Product and web-wrapper mutation calls must pass route-derived `worldId` or an equivalent reviewed scope guard.",
+        "Every new mutating runtime API must include public-demo blocking and a reviewed world/session scope guard before it is implemented.",
+        "The Phase 52 runtime mutation guard regression baseline lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`.",
+    ]
+    for phrase in required_phrases:
+        assert phrase in contract
+
+
+def test_runtime_mutation_api_routes_keep_public_demo_blocking_before_cli_calls() -> None:
+    route_invocations = {
+        Path("frontend/src/app/api/runtime/start-session/route.ts"): "startRuntimeSession(",
+        Path("frontend/src/app/api/runtime/generate-branch/route.ts"): "generateRuntimeBranch(",
+        Path("frontend/src/app/api/runtime/rollback-session/route.ts"): "rollbackRuntimeSession(",
+        Path("frontend/src/app/api/worlds/create/route.ts"): "createRuntimeWorld(",
+    }
+
+    for path, invocation in route_invocations.items():
+        source = path.read_text(encoding="utf-8")
+        guard_index = source.index("if (publicDemoMutationsDisabled())")
+        invocation_index = source.index(invocation)
+
+        assert "publicDemoDisabledMessage" in source, path.as_posix()
+        assert "{ status: 403 }" in source, path.as_posix()
+        assert guard_index < invocation_index, path.as_posix()
+
+
+def test_runtime_session_mutation_api_routes_require_and_pass_world_id() -> None:
+    route_requirements = {
+        Path("frontend/src/app/api/runtime/start-session/route.ts"): "startRuntimeSession(\n      body.worldId,",
+        Path("frontend/src/app/api/runtime/generate-branch/route.ts"): "generateRuntimeBranch(body.worldId,",
+        Path("frontend/src/app/api/runtime/rollback-session/route.ts"): "rollbackRuntimeSession(body.worldId,",
+    }
+
+    for path, invocation in route_requirements.items():
+        source = path.read_text(encoding="utf-8")
+        assert "worldId?: string;" in source, path.as_posix()
+        assert "if (!body.worldId" in source, path.as_posix()
+        assert invocation in source, path.as_posix()
+
+
+def test_product_web_wrappers_keep_route_derived_world_id_on_mutations() -> None:
+    composer = Path("frontend/src/app/components/preset-perturbation-composer.tsx").read_text(
+        encoding="utf-8"
+    )
+    minimal_home = Path("frontend/src/app/components/minimal-home-shell.tsx").read_text(
+        encoding="utf-8"
+    )
+    runtime_actions = Path("frontend/src/app/components/runtime-session-actions.tsx").read_text(
+        encoding="utf-8"
+    )
+    world_runtime_page = Path(
+        "frontend/src/app/worlds/[worldId]/runtime/[sessionId]/page.tsx"
+    ).read_text(encoding="utf-8")
+    runtime_cli = Path("frontend/src/app/lib/runtime-cli.ts").read_text(encoding="utf-8")
+
+    start_body = composer.split('fetch("/api/runtime/start-session"', maxsplit=1)[1].split(
+        "scenarioId:", maxsplit=1
+    )[0]
+    generate_body = composer.split('fetch("/api/runtime/generate-branch"', maxsplit=1)[1].split(
+        "sessionId:", maxsplit=1
+    )[0]
+    minimal_generate_body = minimal_home.split(
+        'fetch("/api/runtime/generate-branch"', maxsplit=1
+    )[1].split("sessionId:", maxsplit=1)[0]
+    minimal_rollback_body = minimal_home.split(
+        'fetch("/api/runtime/rollback-session"', maxsplit=1
+    )[1].split("sessionId:", maxsplit=1)[0]
+
+    for body in [start_body, generate_body, minimal_generate_body, minimal_rollback_body]:
+        assert "worldId," in body
+
+    runtime_action_rollback_body = runtime_actions.split(
+        'fetch("/api/runtime/rollback-session"', maxsplit=1
+    )[1].split("sessionId,", maxsplit=1)[0]
+    assert "worldId," in runtime_action_rollback_body
+    assert "worldId={worldId}" in world_runtime_page
+    assert "returnHref={`/worlds/${worldId}/perturb" in world_runtime_page
+
+    start_args = runtime_cli.split('    "start-session",', maxsplit=1)[1].split("  ];", maxsplit=1)[0]
+    generate_args = runtime_cli.split('    "generate-branch",', maxsplit=1)[1].split("  ];", maxsplit=1)[0]
+    rollback_args = runtime_cli.split('    "rollback-session",', maxsplit=1)[1].split("  ]);", maxsplit=1)[0]
+
+    for command_args in [start_args, generate_args, rollback_args]:
+        assert '"--world"' in command_args
+        assert "worldId" in command_args
+
+
+def test_backend_expected_world_guard_regressions_remain_tracked() -> None:
+    cli_tests = Path("backend/tests/test_cli.py").read_text(encoding="utf-8")
+    required_tests = [
+        "def test_generate_branch_rejects_expected_world_mismatch",
+        "def test_rollback_session_rejects_expected_world_mismatch",
+        "def test_cli_generate_branch_passes_expected_world_guard",
+        "def test_cli_rollback_session_passes_expected_world_guard",
+    ]
+    for test_name in required_tests:
+        assert test_name in cli_tests
+
+
+def test_public_demo_smoke_keeps_mutation_403_checks() -> None:
+    smoke = Path("scripts/smoke_public_demo_web.py").read_text(encoding="utf-8")
+    required_endpoints = [
+        '"/api/runtime/start-session"',
+        '"/api/runtime/generate-branch"',
+        '"/api/runtime/rollback-session"',
+        '"/api/worlds/create"',
+    ]
+
+    for endpoint in required_endpoints:
+        endpoint_block = smoke.split(endpoint, maxsplit=1)[1].split(")", maxsplit=1)[0]
+        assert "403" in endpoint_block
+
+
+def test_active_phase52_docs_point_to_runtime_guard_regression_work() -> None:
+    required_docs = [
+        Path("README.md"),
+        Path("docs/plans/current-state-baseline.md"),
+        Path("docs/plans/phase-execution-queue.md"),
+        Path("docs/plans/automation-roadmap.md"),
+        Path("docs/plans/phase-52-successor-gate-2026-05-18.md"),
+    ]
+
+    for path in required_docs:
+        text = path.read_text(encoding="utf-8")
+        assert "`#410`" in text
+        assert "`#411`" in text
+        assert "`#412`" in text
+        assert "`#413`" in text
+        assert "Phase 52 Runtime Mutation Guard Regression Baseline" in text
+        assert "`docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`" in text
+        assert "runtime mutation guard regression" in text
+        assert "route-derived `worldId`" in text
+        assert "legacy top-level runtime routes" in text
+        assert (
+            "public/plugin/async" in text
+            or "public demo, plugin, Hosted GPT/BYOK, or async" in text
+        )

--- a/backend/tests/test_phase52_successor_gate.py
+++ b/backend/tests/test_phase52_successor_gate.py
@@ -12,8 +12,8 @@ def test_phase52_successor_gate_exists_with_required_sections() -> None:
     gate = PHASE52_GATE_PATH.read_text(encoding="utf-8")
     required_sections = [
         "# Phase 52 Successor Gate",
-        "Issue: `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`",
-        "Current work item: `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`",
+        "Issue: `#413` `Phase 52: strengthen runtime mutation guard regression baseline`",
+        "Current work item: `#413` `Phase 52: strengthen runtime mutation guard regression baseline`",
         "## Phase 51 Closeout Evidence",
         "## Phase 52 Operational Queue",
         "## Protected-Core Lane Coverage",
@@ -40,8 +40,8 @@ def test_phase52_successor_gate_records_queue_and_boundaries() -> None:
         "Status: blocked closeout gate for Phase 52.",
         "Status: closed by PR",
         "Status: current ready work item.",
-        "Status: blocked until the legacy route audit lands.",
         "Phase 52 Legacy Top-Level Runtime Route Audit",
+        "Phase 52 Runtime Mutation Guard Regression Baseline",
         "Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`",
         "legacy top-level runtime routes",
         "route-derived `worldId`",
@@ -56,6 +56,7 @@ def test_phase52_successor_gate_records_queue_and_boundaries() -> None:
         "Do not recreate local Codex automations without a new explicit operator request",
         "`docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`",
         "`docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`",
+        "`docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`",
         "`docs/plans/phase-52-successor-gate-2026-05-18.md`",
     ]
     for phrase in required_phrases:
@@ -81,6 +82,8 @@ def test_active_state_docs_point_to_phase52_queue() -> None:
         assert "`#413`" in text
         assert "Phase 52 Legacy Top-Level Runtime Route Audit" in text
         assert "`docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`" in text
+        assert "Phase 52 Runtime Mutation Guard Regression Baseline" in text
+        assert "`docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`" in text
         assert "legacy top-level runtime routes" in text
         assert "runtime mutation guard regression" in text
         assert (

--- a/docs/architecture/contracts.md
+++ b/docs/architecture/contracts.md
@@ -513,6 +513,9 @@ All IDs must be serializable, stable across files, and traceable in `artifacts/`
 - Lineage node manifests must also match the route `worldId` and `sessionId` before the workspace can render.
 - Direct local CLI calls may omit `--world` for compatibility when the operator provides an explicit artifacts root.
 - Product and web-wrapper mutation calls must pass `--world`; when `--world` is provided, backend services must reject mismatches before branch generation or rollback.
+- Product and web-wrapper mutation calls must pass route-derived `worldId` or an equivalent reviewed scope guard.
+- Every new mutating runtime API must include public-demo blocking and a reviewed world/session scope guard before it is implemented.
+- The Phase 52 runtime mutation guard regression baseline lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`.
 - TODO[verify]: require the same route-derived world guard review before adding any new
   world-scoped runtime mutation surface.
 

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -176,9 +176,9 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit` is open.
 - `#410` `Phase 52 exit gate` is open, blocked, and protected-core.
 - `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate` is closed by PR `#414`.
-- `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract` is the current ready Phase 52 Legacy Top-Level Runtime Route Audit.
-- `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is blocked until the legacy route audit lands.
-- Phase 52 focuses on legacy top-level runtime routes and runtime mutation guard regression coverage without widening public/plugin/async contracts. The route audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`, and the gate note lives in `docs/plans/phase-52-successor-gate-2026-05-18.md`.
+- `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract` is closed by PR `#415`; this completed the Phase 52 Legacy Top-Level Runtime Route Audit.
+- `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is the current ready Phase 52 Runtime Mutation Guard Regression Baseline.
+- Phase 52 focuses on legacy top-level runtime routes and runtime mutation guard regression coverage without widening public/plugin/async contracts. The route audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`, the runtime guard note lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`, route-derived `worldId` coverage remains in scope, and the gate note lives in `docs/plans/phase-52-successor-gate-2026-05-18.md`.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -271,13 +271,15 @@ This note records the completed Phase 51 route/runtime-readiness closeout and th
   - `gh issue list --milestone "Phase 52 - Legacy Route Containment and Runtime Scope Audit" --state all`
     - `#410` `Phase 52 exit gate` is `open`, `blocked`, and `lane:protected-core`
     - `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate` is `closed` by PR `#414`
-    - `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract` is the current `status:ready` protected-core work item
-    - `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is `open` and blocked until the legacy route audit lands
+    - `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract` is `closed` by PR `#415`
+    - `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is the current `status:ready` protected-core work item
   - Phase 52 successor gate:
-    - Phase 52 Legacy Top-Level Runtime Route Audit is the current protected route-containment audit surface
+    - Phase 52 Legacy Top-Level Runtime Route Audit is the completed protected route-containment audit surface
     - `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md` records the route audit note
-    - legacy top-level runtime routes remain the current protected route-containment audit surface
-    - runtime mutation guard regression coverage remains the follow-up after route audit
+    - Phase 52 Runtime Mutation Guard Regression Baseline is the current protected guard-regression surface
+    - `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md` records the runtime guard note
+    - legacy top-level runtime routes remain explicitly contained
+    - runtime mutation guard regression coverage keeps route-derived `worldId` and public-demo blocking in scope
     - `docs/plans/phase-52-successor-gate-2026-05-18.md` records the active gate note
 
 ## Trusted Source Of Truth
@@ -324,10 +326,11 @@ This note records the completed Phase 51 route/runtime-readiness closeout and th
 - The durable route ownership contract lives in `docs/architecture/contracts.md` and `docs/decisions/ADR-0011-private-beta-route-ownership.md`.
 - Phase 51 Runtime Readiness and World-Scoped Guard Verification keeps synchronous v1 generation, records route-derived `worldId` mutation guards, and lives in `docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`.
 - `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate` is closed by PR `#414`.
-- `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract` is the current ready Phase 52 Legacy Top-Level Runtime Route Audit.
-- `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is blocked until `#412` lands.
+- `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract` is closed by PR `#415`.
+- `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is the current ready Phase 52 Runtime Mutation Guard Regression Baseline.
 - Phase 52 focuses on legacy top-level runtime routes and runtime mutation guard regression coverage without widening public/plugin/async contracts.
 - The Phase 52 Legacy Top-Level Runtime Route Audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`.
+- The Phase 52 Runtime Mutation Guard Regression Baseline note lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md` and keeps route-derived `worldId` guard coverage in scope.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.

--- a/docs/plans/phase-51-successor-gate-2026-05-18.md
+++ b/docs/plans/phase-51-successor-gate-2026-05-18.md
@@ -217,9 +217,9 @@ Phase 52 is the active approved successor queue:
 - `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate`
   is closed by PR `#414`.
 - `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`
-  is the current ready Phase 52 Legacy Top-Level Runtime Route Audit.
-- `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is blocked until
-  the legacy route audit lands.
+  is closed by PR `#415`.
+- `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is the current
+  ready Phase 52 Runtime Mutation Guard Regression Baseline.
 
 Phase 52 keeps legacy top-level runtime routes and runtime mutation guard regression as
 protected-core follow-up surfaces. It does not widen public/plugin/async contracts, implement
@@ -227,9 +227,10 @@ a launch hub, replace `/`, or change session/node/report/claim/trace/compare art
 contracts.
 
 The active Phase 52 successor-gate baseline lives in
-`docs/plans/phase-52-successor-gate-2026-05-18.md`, and the Phase 52 Legacy Top-Level
-Runtime Route Audit note lives in
-`docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`.
+`docs/plans/phase-52-successor-gate-2026-05-18.md`, and the Phase 52 Legacy Top-Level Runtime Route Audit note lives in
+`docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`. The Phase 52 Runtime
+Mutation Guard Regression Baseline note lives in
+`docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`.
 
 For `#405`, run:
 

--- a/docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md
+++ b/docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md
@@ -1,0 +1,71 @@
+# Phase 52 Runtime Mutation Guard Regression Baseline
+
+Date: 2026-05-18
+
+Issue: `#413` `Phase 52: strengthen runtime mutation guard regression baseline`
+
+## Decision
+
+`#413` strengthens the regression baseline for existing runtime mutation guard behavior. It does not add a new mutation surface and does not change runtime semantics.
+
+Public-demo mutation routes stay disabled when `MIRROR_PUBLIC_DEMO_MODE=1` and `MIRROR_ALLOW_ANONYMOUS_RUNS` is not `1`. `/api/runtime/start-session`, `/api/runtime/generate-branch`, `/api/runtime/rollback-session`, and `/api/worlds/create` remain private-beta mutation APIs.
+
+Product and web-wrapper mutation calls must pass route-derived `worldId` or an equivalent reviewed scope guard. Direct local CLI calls may omit `--world` for compatibility when the operator provides an explicit artifacts root, but backend session services must reject expected-world mismatches before branch generation or rollback whenever an expected world is supplied.
+
+No new mutating runtime API is added in `#413`.
+
+## Existing Guard Inventory
+
+- `frontend/src/app/api/runtime/start-session/route.ts`, `frontend/src/app/api/runtime/generate-branch/route.ts`, `frontend/src/app/api/runtime/rollback-session/route.ts`, and `frontend/src/app/api/worlds/create/route.ts` import `publicDemoMutationsDisabled()` and return `403` before invoking CLI wrappers.
+- Runtime session mutation API routes require `worldId` in the request body before calling `startRuntimeSession`, `generateRuntimeBranch`, or `rollbackRuntimeSession`.
+- `frontend/src/app/components/preset-perturbation-composer.tsx` sends route-derived `worldId` to start-session and generate-branch requests.
+- `frontend/src/app/components/minimal-home-shell.tsx` sends route-derived `worldId` to generate-branch and rollback-session requests.
+- `RuntimeSessionActions` sends `worldId` with rollback requests, and world-scoped runtime pages pass route-derived `worldId` into that component.
+- `frontend/src/app/lib/runtime-cli.ts` passes `--world` to start-session, generate-branch, and rollback-session CLI calls.
+- `backend/tests/test_cli.py` tracks expected-world mismatch rejection for branch generation and rollback, plus expected-world forwarding from the CLI.
+- `scripts/smoke_public_demo_web.py` keeps live public-demo `403` coverage for start-session, generate-branch, rollback-session, and create-world.
+
+## Regression Locks
+
+- Static frontend tests lock the four mutation API route files to public-demo blocking before CLI invocation.
+- Static frontend tests lock runtime session mutation APIs to require and pass `worldId`.
+- Static frontend tests lock product/web-wrapper mutation calls to carry route-derived `worldId`.
+- Static frontend tests lock runtime CLI wrappers to pass `--world` for session start, branch generation, and rollback.
+- Backend CLI tests continue to lock expected-world mismatch rejection before branch generation or rollback.
+- Backend CLI tests lock expected-world forwarding for branch generation and rollback commands.
+- Static tests keep the public-demo smoke script's live `403` mutation endpoint coverage visible.
+- The durable contract now requires a reviewed public-demo and world/session scope guard before any future mutating runtime API can be implemented.
+
+## Follow-Up Gate
+
+- TODO[verify]: require a reviewed scope guard before adding any new mutating runtime API.
+- TODO[verify]: require route-derived `worldId` or an equivalent reviewed scope guard before adding any new product/web-wrapper mutation path.
+- TODO[verify]: rerun hosted/private-beta model measurements before introducing async task semantics.
+- TODO[verify]: open a separate migration work item before redirecting or deleting any legacy top-level runtime route.
+
+## Non-Goals
+
+- Do not implement a launch hub in `#413`.
+- Do not replace `/` or widen the public path.
+- Do not change public demo behavior.
+- Do not change Mirror Codex plugin MCP tools or resources.
+- Do not add mutating Mirror Codex MCP tools.
+- Do not add Hosted GPT, BYOK, upload, auth, billing, database, object storage, or quota behavior to the public path or plugin path.
+- Do not implement async workers, queues, `task_id`, retry, status, cleanup, checkpoint mutation/deletion, or restore semantics.
+- Do not change scenario DSL, claim labels, report claim `evidence_ids`, run trace shape, compare artifact shape, session/node manifest shape, public demo artifact layout, or plugin MCP contract.
+- Do not build real-person personas, digital doubles, political persuasion, law-enforcement, hiring, credit, medical, or judicial decision systems.
+- Do not present Mirror as real-world prediction or package simulation output as certain real-world conclusions.
+
+No public demo, plugin, Hosted GPT, BYOK, upload, auth, billing, database, object storage, quota, or async contract is widened.
+
+## Validation Commands
+
+```powershell
+python -m pytest backend/tests/test_phase52_runtime_guard_regression_note.py backend/tests/test_phase52_successor_gate.py backend/tests/test_phase52_legacy_route_audit_note.py backend/tests/test_phase51_runtime_guard_note.py backend/tests/test_frontend_runtime_error_redaction.py::test_runtime_composer_generate_request_includes_world_id backend/tests/test_frontend_runtime_error_redaction.py::test_minimal_home_runtime_mutations_include_world_id backend/tests/test_frontend_runtime_error_redaction.py::test_runtime_cli_passes_expected_world_to_mutating_session_commands backend/tests/test_cli.py::test_generate_branch_rejects_expected_world_mismatch backend/tests/test_cli.py::test_rollback_session_rejects_expected_world_mismatch backend/tests/test_cli.py::test_cli_generate_branch_passes_expected_world_guard backend/tests/test_cli.py::test_cli_rollback_session_passes_expected_world_guard -q
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+python -m backend.app.cli classify-lane --files README.md docs/architecture/contracts.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-51-successor-gate-2026-05-18.md docs/plans/phase-52-successor-gate-2026-05-18.md docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md backend/tests/test_phase52_runtime_guard_regression_note.py backend/tests/test_phase52_successor_gate.py backend/tests/test_cli.py
+git diff --check
+./make.ps1 test
+./make.ps1 eval-demo
+```

--- a/docs/plans/phase-52-successor-gate-2026-05-18.md
+++ b/docs/plans/phase-52-successor-gate-2026-05-18.md
@@ -2,16 +2,17 @@
 
 Date: 2026-05-18
 
-Issue: `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`
+Issue: `#413` `Phase 52: strengthen runtime mutation guard regression baseline`
 
-Current work item: `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`
+Current work item: `#413` `Phase 52: strengthen runtime mutation guard regression baseline`
 
 This note records the post-Phase-51 baseline and the Phase 52 successor queue. Phase 52
 is a protected-core route-containment and runtime-scope audit phase. It has synced repo
 truth after the Phase 51 closeout, now audits legacy top-level runtime routes through the
-Phase 52 Legacy Top-Level Runtime Route Audit, and then strengthens runtime mutation
-guard regression coverage. It is not a launch-hub, public-path, plugin, async-runtime, or
+Phase 52 Legacy Top-Level Runtime Route Audit, and now strengthens runtime mutation
+guard regression coverage through the Phase 52 Runtime Mutation Guard Regression Baseline. It is not a launch-hub, public-path, plugin, async-runtime, or
 schema-expansion phase.
+It does not widen public/plugin/async contracts.
 
 This gate is recorded at `docs/plans/phase-52-successor-gate-2026-05-18.md`.
 
@@ -50,17 +51,17 @@ Active GitHub objects:
   - Scope: synced tracked docs to Phase 52 after closing Phase 51.
 - `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`
   - Lane: `protected-core`.
-  - Status: current ready work item.
-  - Scope: audit legacy top-level runtime routes before presenting any route as the
+  - Status: closed by PR `#415`.
+  - Scope: audited legacy top-level runtime routes before presenting any route as the
     private-beta main path.
 - `#413` `Phase 52: strengthen runtime mutation guard regression baseline`
   - Lane: `protected-core`.
-  - Status: blocked until the legacy route audit lands.
+  - Status: current ready work item.
   - Scope: strengthen regression coverage for runtime mutation guard boundaries.
 
 `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
 with Phase 52 as the only open milestone, `#410` as the protected blocked exit gate, and
-`#412` as the current ready work item.
+`#413` as the current ready work item.
 
 ## Protected-Core Lane Coverage
 
@@ -95,6 +96,8 @@ public demo artifact layout, or the Mirror Codex MCP contract.
   `worldId` guards for private-beta mutation paths.
 - Phase 52 Legacy Top-Level Runtime Route Audit is recorded in
   `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`.
+- Phase 52 Runtime Mutation Guard Regression Baseline is recorded in
+  `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`.
 - TODO[verify]: open a separate migration work item before redirecting or deleting any
   legacy top-level runtime route.
 - TODO[verify]: require route-derived `worldId` or an equivalent reviewed scope guard
@@ -118,11 +121,14 @@ public demo artifact layout, or the Mirror Codex MCP contract.
      legacy compatibility surfaces unless a later reviewed migration work item changes
      that posture.
    - Preserve public demo, plugin, private-beta, and async-runtime boundaries.
+   - Closed by PR `#415`.
 
 3. Runtime mutation guard regression baseline
    - Strengthen coverage that product/web-wrapper mutation calls pass route-derived
      `worldId` or an equivalent reviewed scope guard.
    - Preserve public-demo blocking and backend expected-world mismatch rejection.
+   - Record the Phase 52 Runtime Mutation Guard Regression Baseline in
+     `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`.
 
 ## Blueprint Boundary
 
@@ -158,13 +164,13 @@ Phase 52 must stay aligned with `mirror.md` and `AGENTS.md`:
 
 ## Validation Commands
 
-For `#412`, run:
+For `#413`, run:
 
 ```powershell
-python -m pytest backend/tests/test_phase52_legacy_route_audit_note.py backend/tests/test_phase52_successor_gate.py backend/tests/test_phase51_route_contract_note.py backend/tests/test_phase51_runtime_guard_note.py -q
+python -m pytest backend/tests/test_phase52_runtime_guard_regression_note.py backend/tests/test_phase52_successor_gate.py backend/tests/test_phase52_legacy_route_audit_note.py backend/tests/test_phase51_runtime_guard_note.py backend/tests/test_frontend_runtime_error_redaction.py::test_runtime_composer_generate_request_includes_world_id backend/tests/test_frontend_runtime_error_redaction.py::test_minimal_home_runtime_mutations_include_world_id backend/tests/test_frontend_runtime_error_redaction.py::test_runtime_cli_passes_expected_world_to_mutating_session_commands backend/tests/test_cli.py::test_generate_branch_rejects_expected_world_mismatch backend/tests/test_cli.py::test_rollback_session_rejects_expected_world_mismatch backend/tests/test_cli.py::test_cli_generate_branch_passes_expected_world_guard backend/tests/test_cli.py::test_cli_rollback_session_passes_expected_world_guard -q
 python scripts/check_no_secrets.py
 python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
-python -m backend.app.cli classify-lane --files README.md docs/architecture/contracts.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-51-successor-gate-2026-05-18.md docs/plans/phase-52-successor-gate-2026-05-18.md docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md backend/tests/test_phase52_legacy_route_audit_note.py backend/tests/test_phase52_successor_gate.py
+python -m backend.app.cli classify-lane --files README.md docs/architecture/contracts.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-51-successor-gate-2026-05-18.md docs/plans/phase-52-successor-gate-2026-05-18.md docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md backend/tests/test_phase52_runtime_guard_regression_note.py backend/tests/test_phase52_successor_gate.py backend/tests/test_cli.py
 git diff --check
 ./make.ps1 test
 ./make.ps1 eval-demo

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -76,13 +76,16 @@ Local phase audits currently report:
   - closed by PR `#414`
   - synced durable docs to Phase 52 after Phase 51 closeout
 - `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`
-  - current protected-core route-containment work item
+  - closed by PR `#415`
   - Phase 52 Legacy Top-Level Runtime Route Audit
   - audits legacy top-level runtime routes before any route is presented as the private-beta main path
   - route audit note: `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`
 - `#413` `Phase 52: strengthen runtime mutation guard regression baseline`
-  - open and blocked until the legacy route audit lands
+  - current protected-core guard-regression work item
+  - Phase 52 Runtime Mutation Guard Regression Baseline
   - strengthens runtime mutation guard regression coverage
+  - keeps route-derived `worldId` and public-demo mutation blocking covered
+  - runtime guard note: `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`
 - boundary posture
   - Phase 52 does not widen public/plugin/async contracts.
 - phase gate baseline


### PR DESCRIPTION
## Summary
- Add the Phase 52 #413 runtime mutation guard regression baseline note.
- Lock public-demo mutation blocking, route-derived `worldId`, RuntimeSessionActions rollback `worldId`, CLI `--world` / expected-world forwarding, and public-demo smoke 403 coverage into tests/docs.
- Keep this stage scoped to regression baseline only: no new mutating API, no public/plugin/Hosted/BYOK scope widening.

Closes #413.

## Validation
- `python -m pytest backend/tests/test_phase52_runtime_guard_regression_note.py backend/tests/test_phase52_successor_gate.py backend/tests/test_phase52_legacy_route_audit_note.py backend/tests/test_phase51_runtime_guard_note.py backend/tests/test_frontend_runtime_error_redaction.py::test_runtime_composer_generate_request_includes_world_id backend/tests/test_frontend_runtime_error_redaction.py::test_minimal_home_runtime_mutations_include_world_id backend/tests/test_frontend_runtime_error_redaction.py::test_runtime_cli_passes_expected_world_to_mutating_session_commands backend/tests/test_cli.py::test_generate_branch_rejects_expected_world_mismatch backend/tests/test_cli.py::test_rollback_session_rejects_expected_world_mismatch backend/tests/test_cli.py::test_cli_generate_branch_passes_expected_world_guard backend/tests/test_cli.py::test_cli_rollback_session_passes_expected_world_guard -q` -> 27 passed
- `python scripts/check_no_secrets.py` -> passed
- `python -m backend.app.cli audit-github-queue` -> ready, #413 current
- `python -m backend.app.cli classify-lane --files ...` -> protected-core / risk:core-contract
- `git diff --check` -> exit 0; CRLF warnings only
- `./make.ps1 test` -> 135 passed
- `./make.ps1 eval-demo` -> 23/23 checks passed