### PR TITLE
Phase 52 baseline closeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,11 +254,10 @@ session or node manifests that conflict with route `worldId` or `sessionId`. See
 
 Phase 52 Legacy Route Containment and Runtime Scope Audit: Phase 51 is closed after PR
 `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime
-Readiness Gate`; private-beta route ownership and world-scoped session guards remain ratified by Phase 51. Phase 52 is the active approved successor queue. Repo-truth sync closed
+Readiness Gate`; private-beta route ownership and world-scoped session guards remain ratified by Phase 51. Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; `audit-github-queue` now reports the formal paused stop-state with no active milestone. Repo-truth sync closed
 through PR `#414`; the Phase 52 Legacy Top-Level Runtime Route Audit for `#412` closed
 through PR `#415` and is recorded in
-`docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`. The current work item is
-the Phase 52 Runtime Mutation Guard Regression Baseline for `#413`, recorded in
+`docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`. The Phase 52 Runtime Mutation Guard Regression Baseline for `#413` is closed by PR `#416` and is recorded in
 `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`. It strengthens
 runtime mutation guard regression coverage for route-derived `worldId` and public-demo
 blocking after the legacy top-level runtime routes audit, without widening public demo,
@@ -295,12 +294,12 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - The completed Phase 49 successor gate lives in [docs/plans/phase-49-successor-gate-2026-05-18.md](docs/plans/phase-49-successor-gate-2026-05-18.md).
 - The completed Phase 50 successor gate lives in [docs/plans/phase-50-successor-gate-2026-05-18.md](docs/plans/phase-50-successor-gate-2026-05-18.md).
 - The completed Phase 51 successor gate lives in [docs/plans/phase-51-successor-gate-2026-05-18.md](docs/plans/phase-51-successor-gate-2026-05-18.md).
-- The active Phase 52 successor gate lives in [docs/plans/phase-52-successor-gate-2026-05-18.md](docs/plans/phase-52-successor-gate-2026-05-18.md).
+- The completed Phase 52 successor gate lives in [docs/plans/phase-52-successor-gate-2026-05-18.md](docs/plans/phase-52-successor-gate-2026-05-18.md).
 - Phase 48 is closed after PR `#382`, issue `#375`, and milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
 - Phase 49 is closed after PR `#395`, issue `#383`, and milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; completed work items were `#384`, `#386`, `#388`, `#390`, `#392`, and `#394`.
 - Phase 50 is closed after PR `#402`, issue `#396`, and milestone `Phase 50 - Runtime Orchestration Measurement and Product Boundary`; completed work items were `#397`, `#398`, and `#401`. Phase 50 measured before any `task_id` or worker contract is introduced and kept the private-beta launch hub planning-only for now.
 - Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`; completed work items were `#404`, `#405`, and `#406`.
-- Phase 52 is the active approved successor queue: `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; `audit-github-queue` reports `ready` with `#410` as the blocked exit gate, `#411` closed by PR `#414`, `#412` closed by PR `#415`, and `#413` as the current ready Phase 52 Runtime Mutation Guard Regression Baseline. The legacy top-level runtime routes audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`; the runtime guard note lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`; Phase 52 does not widen public demo, plugin, Hosted GPT/BYOK, or async contracts and keeps route-derived `worldId` guard coverage in scope.
+- Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; completed work items were `#411`, `#412`, and `#413`. `audit-github-queue` now reports the formal paused stop-state with no active milestone. The legacy top-level runtime routes audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`; the runtime guard note lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`; Phase 52 did not widen public demo, plugin, Hosted GPT/BYOK, or async contracts and keeps route-derived `worldId` guard coverage in scope.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
 - Fog Harbor remains the canonical demo world; `museum-night` is the minimal transfer world used to prove the pipeline is not single-world-only.
 

--- a/backend/tests/test_phase52_successor_gate.py
+++ b/backend/tests/test_phase52_successor_gate.py
@@ -12,10 +12,11 @@ def test_phase52_successor_gate_exists_with_required_sections() -> None:
     gate = PHASE52_GATE_PATH.read_text(encoding="utf-8")
     required_sections = [
         "# Phase 52 Successor Gate",
-        "Issue: `#413` `Phase 52: strengthen runtime mutation guard regression baseline`",
-        "Current work item: `#413` `Phase 52: strengthen runtime mutation guard regression baseline`",
+        "Issue: `#410` `Phase 52 exit gate`",
+        "Current work item: none; Phase 52 is closed and the queue is in the formal paused stop-state.",
         "## Phase 51 Closeout Evidence",
         "## Phase 52 Operational Queue",
+        "## Phase 52 Closeout Evidence",
         "## Protected-Core Lane Coverage",
         "## Carried Forward TODO[verify] Items",
         "## Phase 52 Work Package Map",
@@ -37,9 +38,11 @@ def test_phase52_successor_gate_records_queue_and_boundaries() -> None:
         "`#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate`",
         "`#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`",
         "`#413` `Phase 52: strengthen runtime mutation guard regression baseline`",
-        "Status: blocked closeout gate for Phase 52.",
+        "Status: closed after post-merge validation on `main`.",
         "Status: closed by PR",
-        "Status: current ready work item.",
+        "Status: closed by PR `#416`.",
+        "Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`",
+        "formal paused stop-state",
         "Phase 52 Legacy Top-Level Runtime Route Audit",
         "Phase 52 Runtime Mutation Guard Regression Baseline",
         "Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`",
@@ -76,10 +79,12 @@ def test_active_state_docs_point_to_phase52_queue() -> None:
         text = path.read_text(encoding="utf-8")
         assert "Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate" in text
         assert "Phase 52 - Legacy Route Containment and Runtime Scope Audit" in text
+        assert "Phase 52 is closed after PR `#416`, issue `#410`" in text
         assert "`#410`" in text
         assert "`#411`" in text
         assert "`#412`" in text
         assert "`#413`" in text
+        assert "closed by PR `#416`" in text
         assert "Phase 52 Legacy Top-Level Runtime Route Audit" in text
         assert "`docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`" in text
         assert "Phase 52 Runtime Mutation Guard Regression Baseline" in text
@@ -90,3 +95,30 @@ def test_active_state_docs_point_to_phase52_queue() -> None:
             "public/plugin/async" in text
             or "public demo, plugin, Hosted GPT/BYOK, or async" in text
         )
+
+
+def test_active_state_docs_do_not_keep_stale_phase52_ready_language() -> None:
+    required_docs = [
+        Path("README.md"),
+        Path("docs/plans/current-state-baseline.md"),
+        Path("docs/plans/phase-execution-queue.md"),
+        Path("docs/plans/automation-roadmap.md"),
+        Path("docs/plans/phase-51-successor-gate-2026-05-18.md"),
+        Path("docs/plans/phase-52-successor-gate-2026-05-18.md"),
+    ]
+    stale_phrases = [
+        "approved Phase 52 successor queue",
+        "Phase 52 is the active approved successor queue",
+        "active Phase 52 successor",
+        "current ready Phase 52 Runtime Mutation Guard Regression Baseline",
+        "current `status:ready` protected-core work item",
+        "`#410` `Phase 52 exit gate` is `open`, `blocked`",
+        "`#410` `Phase 52 exit gate` is open and blocked",
+        "reports `ready` with Phase 52 as the active milestone",
+        "reports `ready` with `Phase 52 - Legacy Route Containment and Runtime Scope Audit` as the active milestone",
+    ]
+
+    for path in required_docs:
+        text = path.read_text(encoding="utf-8")
+        for phrase in stale_phrases:
+            assert phrase not in text, f"{path} still contains stale Phase 52 state: {phrase}"

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, Phase 47 closeout is complete, Phase 48 closeout is complete, Phase 49 closeout is complete, Phase 50 closeout is complete, Phase 51 closeout is complete, Phase 52 is the active approved successor queue, and the first formal release remains published as `v0.1.0`.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, Phase 47 closeout is complete, Phase 48 closeout is complete, Phase 49 closeout is complete, Phase 50 closeout is complete, Phase 51 closeout is complete, Phase 52 closeout is complete, the queue is in the formal paused stop-state, and the first formal release remains published as `v0.1.0`.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -172,20 +172,20 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - `#406` `Phase 51: verify runtime readiness thresholds and world-scoped session guards` is closed by PR `#409`.
 - Phase 51 Private-Beta Route Ownership Contract: private-beta launch hub remains planning-only and `/worlds/<world_id>` remains the private-beta candidate product path; the route note lives in `docs/plans/phase-51-private-beta-route-contract-2026-05-18.md`, and durable route ownership lives in `docs/architecture/contracts.md` and `docs/decisions/ADR-0011-private-beta-route-ownership.md`.
 - Phase 51 Runtime Readiness and World-Scoped Guard Verification: synchronous v1 generation remains the runtime contract; route-derived `worldId` guards now protect private-beta branch generation, rollback, and world-scoped workspace loading. The guard note lives in `docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`.
-- Phase 52 is the active approved successor queue.
-- milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit` is open.
-- `#410` `Phase 52 exit gate` is open, blocked, and protected-core.
+- Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`.
+- milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit` is closed.
+- `#410` `Phase 52 exit gate` is closed after post-merge validation on `main`.
 - `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate` is closed by PR `#414`.
 - `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract` is closed by PR `#415`; this completed the Phase 52 Legacy Top-Level Runtime Route Audit.
-- `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is the current ready Phase 52 Runtime Mutation Guard Regression Baseline.
-- Phase 52 focuses on legacy top-level runtime routes and runtime mutation guard regression coverage without widening public/plugin/async contracts. The route audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`, the runtime guard note lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`, route-derived `worldId` coverage remains in scope, and the gate note lives in `docs/plans/phase-52-successor-gate-2026-05-18.md`.
+- `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is closed by PR `#416`; this completed the Phase 52 Runtime Mutation Guard Regression Baseline.
+- Phase 52 focused on legacy top-level runtime routes and runtime mutation guard regression coverage without widening public/plugin/async contracts. The route audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`, the runtime guard note lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`, route-derived `worldId` coverage remains in scope, and the gate note lives in `docs/plans/phase-52-successor-gate-2026-05-18.md`.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.
 - `#390` `Phase 49: ratify runtime parent-child compare emission policy` is closed by PR `#391`.
 - `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope` is closed by PR `#393`.
 - `#394` `Phase 49: strengthen transfer eval outcome coverage` is closed by PR `#395`.
-- `audit-github-queue` reports `ready` with Phase 52 as the active milestone.
+- `audit-github-queue` reports the formal paused stop-state with no active milestone.
 - The first formal repository release is published as `v0.1.0`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
@@ -242,5 +242,5 @@ Before builder automation is allowed to write code or auto-merge:
 - Long-running execution must run from isolated worktrees rather than the current `main` checkout.
 - Queue pickup order, one-writer ownership, and branch hygiene should follow `docs/plans/long-running-loop-runbook.md`.
 - When the active milestone exists and the queue reports `ready`, the builder may resume against that milestone only.
-- Phase 52 is the active approved successor queue; do not open a parallel execution queue.
+- No successor queue is active after Phase 52 closeout; do not open a parallel execution queue without a fresh approved milestone and exit gate.
 - When no open milestone exists and `audit-github-queue` reports `paused`, treat that state as an intentional released stop-state rather than a broken queue.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note records the completed Phase 51 route/runtime-readiness closeout and the approved Phase 52 successor queue after the formal `v0.1.0` release baseline.
+This note records the completed Phase 52 legacy-route/runtime-scope audit closeout and the formal paused stop-state after the formal `v0.1.0` release baseline.
 
 ## Snapshot
 
@@ -214,7 +214,7 @@ This note records the completed Phase 51 route/runtime-readiness closeout and th
   - `gh api repos/YSCJRH/mirror-sim/releases`
     - release `v0.1.0` exists and matches the committed release notes baseline
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - queue reports `ready` with `Phase 52 - Legacy Route Containment and Runtime Scope Audit` as the active milestone
+    - queue reports `paused` with no active milestone after the Phase 52 closeout
   - `gh issue list --milestone "Phase 47 - Boundary Readiness and Successor Hygiene" --state all`
     - `#365` `Phase 47 exit gate` is `closed` after merging PR `#374`
     - `#366` `Phase 47: sync repo truth to successor queue` is `closed` after merging PR `#370`
@@ -269,18 +269,20 @@ This note records the completed Phase 51 route/runtime-readiness closeout and th
     - world-scoped workspace loading rejects session or node manifests whose durable world/session ids conflict with route params
     - `docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md` records the guard verification note
   - `gh issue list --milestone "Phase 52 - Legacy Route Containment and Runtime Scope Audit" --state all`
-    - `#410` `Phase 52 exit gate` is `open`, `blocked`, and `lane:protected-core`
+    - `#410` `Phase 52 exit gate` is `closed` after post-merge validation on `main`
     - `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate` is `closed` by PR `#414`
     - `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract` is `closed` by PR `#415`
-    - `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is the current `status:ready` protected-core work item
+    - `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is `closed` by PR `#416`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/52`
+    - milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit` is `closed`
   - Phase 52 successor gate:
     - Phase 52 Legacy Top-Level Runtime Route Audit is the completed protected route-containment audit surface
     - `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md` records the route audit note
-    - Phase 52 Runtime Mutation Guard Regression Baseline is the current protected guard-regression surface
+    - Phase 52 Runtime Mutation Guard Regression Baseline is the completed protected guard-regression surface
     - `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md` records the runtime guard note
     - legacy top-level runtime routes remain explicitly contained
     - runtime mutation guard regression coverage keeps route-derived `worldId` and public-demo blocking in scope
-    - `docs/plans/phase-52-successor-gate-2026-05-18.md` records the active gate note
+    - `docs/plans/phase-52-successor-gate-2026-05-18.md` records the completed gate note
 
 ## Trusted Source Of Truth
 
@@ -302,18 +304,18 @@ This note records the completed Phase 51 route/runtime-readiness closeout and th
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
 - The default workbench path now consumes the canonical compare artifact directly and keeps focused divergent trace surfaces ahead of heavier packet-driven review flows.
 - The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, execution recovery release boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, escalation acknowledgment packets, and escalation closure packets without introducing backend API expansion.
-- The current repository state has completed the Phase 51 route/runtime-readiness queue, preserved `v0.1.0` as the latest published release baseline, and opened the approved Phase 52 successor queue.
+- The current repository state has completed the Phase 52 legacy-route/runtime-scope audit queue, preserved `v0.1.0` as the latest published release baseline, and returned to the formal paused stop-state with no active milestone.
 
 ## Next Entry Point
 
 - Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`.
-- Phase 52 is the active approved successor queue; `audit-github-queue` reports `ready`.
+- Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; `audit-github-queue` reports the formal paused stop-state.
 - The Phase 47 unlock order is resolved: the queue-sync issue is closed after PR `#370`, the boundary-regression report is closed after PR `#371`, the runtime-world safety preflight is closed after PR `#372`, the main-path containment report is closed after PR `#373`, and the exit gate is closed after PR `#374`.
 - The Phase 48 unlock order is resolved: `#376` and `#377` closed through earlier Phase 48 PRs, `#378` and `#379` closed through PR `#382`, and `#375` closed after the post-merge exit-gate reassessment.
 - The Phase 49 unlock order is resolved: `#384` closed through PR `#385`, `#386` closed through PR `#387`, `#388` closed through PR `#389`, `#390` closed through PR `#391`, `#392` closed through PR `#393`, `#394` closed through PR `#395`, and `#383` closed after the post-merge exit-gate reassessment.
 - The Phase 50 unlock order is resolved: `#397` closed through PR `#399`, `#398` closed through PR `#400`, `#401` closed through PR `#402`, and `#396` closed after the post-merge exit-gate reassessment.
-- The active successor milestone is `Phase 52 - Legacy Route Containment and Runtime Scope Audit`.
-- The Phase 52 exit gate is `#410` `Phase 52 exit gate`, which remains the open blocked closeout gate for this phase.
+- The latest closed successor milestone is `Phase 52 - Legacy Route Containment and Runtime Scope Audit`.
+- The Phase 52 exit gate is `#410` `Phase 52 exit gate`, which closed after post-merge validation on `main`.
 - `#397` `Phase 50: sync repo truth after Phase 49 closeout` is closed by PR `#399`.
 - `#398` `Phase 50: measure runtime generation duration before task_id decision` is closed by PR `#400`.
 - `#401` `Phase 50: ratify private-beta launch hub and public-path boundary` is closed by PR `#402`.
@@ -327,8 +329,8 @@ This note records the completed Phase 51 route/runtime-readiness closeout and th
 - Phase 51 Runtime Readiness and World-Scoped Guard Verification keeps synchronous v1 generation, records route-derived `worldId` mutation guards, and lives in `docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`.
 - `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate` is closed by PR `#414`.
 - `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract` is closed by PR `#415`.
-- `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is the current ready Phase 52 Runtime Mutation Guard Regression Baseline.
-- Phase 52 focuses on legacy top-level runtime routes and runtime mutation guard regression coverage without widening public/plugin/async contracts.
+- `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is closed by PR `#416`.
+- Phase 52 focused on legacy top-level runtime routes and runtime mutation guard regression coverage without widening public/plugin/async contracts.
 - The Phase 52 Legacy Top-Level Runtime Route Audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`.
 - The Phase 52 Runtime Mutation Guard Regression Baseline note lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md` and keeps route-derived `worldId` guard coverage in scope.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
@@ -342,7 +344,7 @@ This note records the completed Phase 51 route/runtime-readiness closeout and th
 - The completed Phase 49 successor-gate baseline lives in `docs/plans/phase-49-successor-gate-2026-05-18.md`.
 - The completed Phase 50 successor-gate baseline lives in `docs/plans/phase-50-successor-gate-2026-05-18.md`.
 - The completed Phase 51 successor-gate baseline lives in `docs/plans/phase-51-successor-gate-2026-05-18.md`.
-- The active Phase 52 successor-gate baseline lives in `docs/plans/phase-52-successor-gate-2026-05-18.md`.
+- The completed Phase 52 successor-gate baseline lives in `docs/plans/phase-52-successor-gate-2026-05-18.md`.
 - Local untracked private-beta, kernel, and design-system planning files under `docs/plans/...` are candidate inputs only until a PR intentionally promotes them.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.

--- a/docs/plans/phase-51-successor-gate-2026-05-18.md
+++ b/docs/plans/phase-51-successor-gate-2026-05-18.md
@@ -210,26 +210,26 @@ git diff --check
 
 Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`.
 
-Phase 52 is the active approved successor queue:
+Phase 52 is closed after PR `#416`, issue `#410`, and milestone
+`Phase 52 - Legacy Route Containment and Runtime Scope Audit`; `audit-github-queue`
+reports the formal paused stop-state with no active milestone:
 
 - Milestone: `Phase 52 - Legacy Route Containment and Runtime Scope Audit`.
-- `#410` `Phase 52 exit gate` is open and blocked.
+- `#410` `Phase 52 exit gate` is closed after post-merge validation on `main`.
 - `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate`
   is closed by PR `#414`.
 - `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`
   is closed by PR `#415`.
-- `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is the current
-  ready Phase 52 Runtime Mutation Guard Regression Baseline.
+- `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is closed by PR `#416`.
 
-Phase 52 keeps legacy top-level runtime routes and runtime mutation guard regression as
+Phase 52 kept legacy top-level runtime routes and runtime mutation guard regression as
 protected-core follow-up surfaces. It does not widen public/plugin/async contracts, implement
 a launch hub, replace `/`, or change session/node/report/claim/trace/compare artifact
 contracts.
 
-The active Phase 52 successor-gate baseline lives in
+The completed Phase 52 successor-gate baseline lives in
 `docs/plans/phase-52-successor-gate-2026-05-18.md`, and the Phase 52 Legacy Top-Level Runtime Route Audit note lives in
-`docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`. The Phase 52 Runtime
-Mutation Guard Regression Baseline note lives in
+`docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`. The Phase 52 Runtime Mutation Guard Regression Baseline note lives in
 `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`.
 
 For `#405`, run:

--- a/docs/plans/phase-52-successor-gate-2026-05-18.md
+++ b/docs/plans/phase-52-successor-gate-2026-05-18.md
@@ -2,15 +2,16 @@
 
 Date: 2026-05-18
 
-Issue: `#413` `Phase 52: strengthen runtime mutation guard regression baseline`
+Issue: `#410` `Phase 52 exit gate`
 
-Current work item: `#413` `Phase 52: strengthen runtime mutation guard regression baseline`
+Current work item: none; Phase 52 is closed and the queue is in the formal paused stop-state.
 
-This note records the post-Phase-51 baseline and the Phase 52 successor queue. Phase 52
-is a protected-core route-containment and runtime-scope audit phase. It has synced repo
-truth after the Phase 51 closeout, now audits legacy top-level runtime routes through the
-Phase 52 Legacy Top-Level Runtime Route Audit, and now strengthens runtime mutation
-guard regression coverage through the Phase 52 Runtime Mutation Guard Regression Baseline. It is not a launch-hub, public-path, plugin, async-runtime, or
+This note records the post-Phase-51 baseline, the completed Phase 52 successor queue, and
+the Phase 52 closeout evidence. Phase 52 was a protected-core route-containment and
+runtime-scope audit phase. It synced repo truth after the Phase 51 closeout, audited
+legacy top-level runtime routes through the Phase 52 Legacy Top-Level Runtime Route Audit,
+and strengthened runtime mutation guard regression coverage through the Phase 52 Runtime
+Mutation Guard Regression Baseline. It is not a launch-hub, public-path, plugin, async-runtime, or
 schema-expansion phase.
 It does not widen public/plugin/async contracts.
 
@@ -29,8 +30,9 @@ Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Priv
   `docs/plans/phase-51-private-beta-route-contract-2026-05-18.md`.
 - Phase 51 Runtime Readiness and World-Scoped Guard Verification is recorded in
   `docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`.
-- Queue audit reached the formal paused stop-state after Phase 51 closed, then returned
-  `ready` once Phase 52 was opened with one blocked exit gate and one ready work item.
+- Queue audit reached the formal paused stop-state after Phase 51 closed, returned
+  `ready` while Phase 52 had one blocked exit gate and one ready work item, and returned
+  to the formal paused stop-state after Phase 52 closed.
 
 ## Phase 52 Operational Queue
 
@@ -40,11 +42,11 @@ Phase 52 title:
 Phase 52 - Legacy Route Containment and Runtime Scope Audit
 ```
 
-Active GitHub objects:
+Completed GitHub objects:
 
 - `#410` `Phase 52 exit gate`
   - Lane: `protected-core`.
-  - Status: blocked closeout gate for Phase 52.
+  - Status: closed after post-merge validation on `main`.
 - `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate`
   - Lane: `protected-core`.
   - Status: closed by PR `#414`.
@@ -56,12 +58,28 @@ Active GitHub objects:
     private-beta main path.
 - `#413` `Phase 52: strengthen runtime mutation guard regression baseline`
   - Lane: `protected-core`.
-  - Status: current ready work item.
+  - Status: closed by PR `#416`.
   - Scope: strengthen regression coverage for runtime mutation guard boundaries.
 
-`python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
-with Phase 52 as the only open milestone, `#410` as the protected blocked exit gate, and
-`#413` as the current ready work item.
+`python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `paused`
+with no active milestone after Phase 52 closeout.
+
+## Phase 52 Closeout Evidence
+
+Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`.
+
+Post-merge validation on `main` after PR `#416`:
+
+- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` -> `paused`
+  with no active milestone.
+- `python -m pytest backend/tests/test_phase52_runtime_guard_regression_note.py backend/tests/test_phase52_legacy_route_audit_note.py backend/tests/test_phase52_successor_gate.py -q` -> 16 passed.
+- `python scripts/check_no_secrets.py` -> passed.
+- `python -m backend.app.cli classify-lane --files ...` -> `lane:protected-core`,
+  `risk:core-contract`.
+- `git diff --check` -> exit 0.
+- `npm --prefix frontend run build` -> passed.
+- `./make.ps1 test` -> 135 passed.
+- `./make.ps1 eval-demo` -> pass, 23/23 checks passed.
 
 ## Protected-Core Lane Coverage
 
@@ -129,6 +147,7 @@ public demo artifact layout, or the Mirror Codex MCP contract.
    - Preserve public-demo blocking and backend expected-world mismatch rejection.
    - Record the Phase 52 Runtime Mutation Guard Regression Baseline in
      `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`.
+   - Closed by PR `#416`.
 
 ## Blueprint Boundary
 
@@ -164,7 +183,7 @@ Phase 52 must stay aligned with `mirror.md` and `AGENTS.md`:
 
 ## Validation Commands
 
-For `#413`, run:
+For the Phase 52 closeout baseline, run:
 
 ```powershell
 python -m pytest backend/tests/test_phase52_runtime_guard_regression_note.py backend/tests/test_phase52_successor_gate.py backend/tests/test_phase52_legacy_route_audit_note.py backend/tests/test_phase51_runtime_guard_note.py backend/tests/test_frontend_runtime_error_redaction.py::test_runtime_composer_generate_request_includes_world_id backend/tests/test_frontend_runtime_error_redaction.py::test_minimal_home_runtime_mutations_include_world_id backend/tests/test_frontend_runtime_error_redaction.py::test_runtime_cli_passes_expected_world_to_mutating_session_commands backend/tests/test_cli.py::test_generate_branch_rejects_expected_world_mismatch backend/tests/test_cli.py::test_rollback_session_rejects_expected_world_mismatch backend/tests/test_cli.py::test_cli_generate_branch_passes_expected_world_guard backend/tests/test_cli.py::test_cli_rollback_session_passes_expected_world_guard -q

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 51 route/runtime-readiness closeout, and the approved Phase 52 successor queue.
+This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 52 legacy-route/runtime-scope audit closeout, and the formal paused stop-state with no active successor milestone.
 
 ## Current Gate State
 
@@ -55,7 +55,7 @@ This note records the current post-Day-0 execution status for Mirror after the f
 - Phase 49 exit gate: closed
 - Phase 50 exit gate: closed
 - Phase 51 exit gate: closed
-- Phase 52 exit gate: open and blocked
+- Phase 52 exit gate: closed
 
 Local phase audits currently report:
 
@@ -63,14 +63,17 @@ Local phase audits currently report:
 - `phase2`: pass
 - `phase3`: pass
 
-## Phase 52 Successor Queue
+## Phase 52 Closeout
+
+Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy
+Route Containment and Runtime Scope Audit`.
 
 - `audit-github-queue`
-  - reports `ready` with `Phase 52 - Legacy Route Containment and Runtime Scope Audit` as the active milestone
+  - reports `paused` with no active milestone after Phase 52 closeout
 - milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`
-  - open
+  - closed
 - `#410` `Phase 52 exit gate`
-  - open and blocked
+  - closed after post-merge validation on `main`
   - labeled `lane:protected-core` because it is the protected closeout gate
 - `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate`
   - closed by PR `#414`
@@ -81,15 +84,15 @@ Local phase audits currently report:
   - audits legacy top-level runtime routes before any route is presented as the private-beta main path
   - route audit note: `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`
 - `#413` `Phase 52: strengthen runtime mutation guard regression baseline`
-  - current protected-core guard-regression work item
+  - closed by PR `#416`
   - Phase 52 Runtime Mutation Guard Regression Baseline
   - strengthens runtime mutation guard regression coverage
   - keeps route-derived `worldId` and public-demo mutation blocking covered
   - runtime guard note: `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`
 - boundary posture
-  - Phase 52 does not widen public/plugin/async contracts.
+  - Phase 52 did not widen public/plugin/async contracts.
 - phase gate baseline
-  - active Phase 52 gate note: `docs/plans/phase-52-successor-gate-2026-05-18.md`
+  - completed Phase 52 gate note: `docs/plans/phase-52-successor-gate-2026-05-18.md`
 
 ## Phase 51 Closeout
 
@@ -238,8 +241,8 @@ Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Priv
   - Phase 49 completed as a contract-hardening round
   - Phase 50 completed as a runtime-orchestration measurement and product-boundary round
   - Phase 51 completed as a private-beta route contract and runtime-readiness round
-  - Phase 52 is the active approved successor queue
-  - any work beyond the Phase 52 queue requires a fresh decision against the trigger conditions in `mirror.md`
+  - Phase 52 completed as a legacy-route containment and runtime-scope audit round
+  - any work beyond the closed Phase 52 queue requires a fresh decision against the trigger conditions in `mirror.md`
 
 ## Closeout Snapshot
 
@@ -697,7 +700,7 @@ Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Priv
 - Protected-core changes still require explicit review and must not auto-merge.
 - Long-running execution should assign exactly one writer worktree per issue.
 - When `audit-github-queue` reports `ready`, consume only the currently active milestone and do not parallel-open another execution queue.
-- Phase 52 is the active approved successor queue; do not open a parallel execution queue.
+- No successor queue is active after Phase 52 closeout; do not open a parallel execution queue without a fresh approved milestone and exit gate.
 - The previous local queue follow-up automation has been revoked or left paused per operator request; do not recreate an automation without a new explicit request.
 
 ## Historical Branch Status


### PR DESCRIPTION
## Summary
- Sync durable docs to the actual Phase 52 closeout state after PR #416, issue #410, and milestone 52 were closed.
- Record `audit-github-queue` as the formal paused stop-state with no active milestone.
- Add negative doc assertions so stale Phase 52 active/current-ready/open language does not re-enter the active-state docs.

## Validation
- `python -m pytest backend/tests/test_phase52_successor_gate.py backend/tests/test_phase52_runtime_guard_regression_note.py backend/tests/test_phase52_legacy_route_audit_note.py -q` -> 17 passed
- `python scripts/check_no_secrets.py` -> passed
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` -> paused, no active milestone
- `python -m backend.app.cli classify-lane --files README.md backend/tests/test_phase52_successor_gate.py docs/plans/automation-roadmap.md docs/plans/current-state-baseline.md docs/plans/phase-51-successor-gate-2026-05-18.md docs/plans/phase-52-successor-gate-2026-05-18.md docs/plans/phase-execution-queue.md` -> protected-core / risk:core-contract
- stale Phrase search across target docs -> no matches
- `git diff --check` -> exit 0; CRLF warnings only
- `./make.ps1 test` -> 136 passed
- `./make.ps1 eval-demo` -> 23/23 checks passed

No successor queue is opened by this PR.