### PR TITLE
Phase 53 transfer gate sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ session or node manifests that conflict with route `worldId` or `sessionId`. See
 
 Phase 52 Legacy Route Containment and Runtime Scope Audit: Phase 51 is closed after PR
 `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime
-Readiness Gate`; private-beta route ownership and world-scoped session guards remain ratified by Phase 51. Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; `audit-github-queue` now reports the formal paused stop-state with no active milestone. Repo-truth sync closed
+Readiness Gate`; private-beta route ownership and world-scoped session guards remain ratified by Phase 51. Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; before Phase 53 was opened, `audit-github-queue` reported the formal paused stop-state with no active milestone. Repo-truth sync closed
 through PR `#414`; the Phase 52 Legacy Top-Level Runtime Route Audit for `#412` closed
 through PR `#415` and is recorded in
 `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`. The Phase 52 Runtime Mutation Guard Regression Baseline for `#413` is closed by PR `#416` and is recorded in
@@ -263,6 +263,16 @@ runtime mutation guard regression coverage for route-derived `worldId` and publi
 blocking after the legacy top-level runtime routes audit, without widening public demo,
 plugin, Hosted GPT/BYOK, or async contracts. See
 `docs/plans/phase-52-successor-gate-2026-05-18.md`.
+
+Phase 53 Transfer Generalization and Third-World Readiness: Phase 53 is the active
+approved successor queue after the Phase 52 closeout. `audit-github-queue` reports
+`ready` with milestone `Phase 53 - Transfer Generalization and Third-World Readiness`,
+blocked exit gate `#418`, and current ready work item `#419` `Phase 53: sync repo truth
+after Phase 52 closeout and define transfer gate`. Follow-up work items `#420` and `#421`
+remain blocked until the transfer gate is synced. Phase 53 focuses on bounded transfer
+generalization and third-world readiness, without widening public demo, plugin, Hosted
+GPT/BYOK, launch hub, async, or runtime mutation boundaries. See
+`docs/plans/phase-53-successor-gate-2026-05-19.md`.
 
 ---
 
@@ -295,11 +305,13 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - The completed Phase 50 successor gate lives in [docs/plans/phase-50-successor-gate-2026-05-18.md](docs/plans/phase-50-successor-gate-2026-05-18.md).
 - The completed Phase 51 successor gate lives in [docs/plans/phase-51-successor-gate-2026-05-18.md](docs/plans/phase-51-successor-gate-2026-05-18.md).
 - The completed Phase 52 successor gate lives in [docs/plans/phase-52-successor-gate-2026-05-18.md](docs/plans/phase-52-successor-gate-2026-05-18.md).
+- The active Phase 53 Successor Gate lives in [docs/plans/phase-53-successor-gate-2026-05-19.md](docs/plans/phase-53-successor-gate-2026-05-19.md).
 - Phase 48 is closed after PR `#382`, issue `#375`, and milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
 - Phase 49 is closed after PR `#395`, issue `#383`, and milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; completed work items were `#384`, `#386`, `#388`, `#390`, `#392`, and `#394`.
 - Phase 50 is closed after PR `#402`, issue `#396`, and milestone `Phase 50 - Runtime Orchestration Measurement and Product Boundary`; completed work items were `#397`, `#398`, and `#401`. Phase 50 measured before any `task_id` or worker contract is introduced and kept the private-beta launch hub planning-only for now.
 - Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`; completed work items were `#404`, `#405`, and `#406`.
-- Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; completed work items were `#411`, `#412`, and `#413`. `audit-github-queue` now reports the formal paused stop-state with no active milestone. The legacy top-level runtime routes audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`; the runtime guard note lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`; Phase 52 did not widen public demo, plugin, Hosted GPT/BYOK, or async contracts and keeps route-derived `worldId` guard coverage in scope.
+- Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; completed work items were `#411`, `#412`, and `#413`. Before Phase 53 was opened, `audit-github-queue` reported the formal paused stop-state with no active milestone. The legacy top-level runtime routes audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`; the runtime guard note lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`; Phase 52 did not widen public demo, plugin, Hosted GPT/BYOK, or async contracts and keeps route-derived `worldId` guard coverage in scope.
+- Phase 53 is the active approved successor queue: `Phase 53 - Transfer Generalization and Third-World Readiness`; `audit-github-queue` reports `ready` with `#418` as the blocked exit gate, `#419` as the current ready Phase 53: sync repo truth after Phase 52 closeout and define transfer gate, and `#420`/`#421` blocked. Phase 53 focuses on bounded transfer generalization and third-world readiness without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
 - Fog Harbor remains the canonical demo world; `museum-night` is the minimal transfer world used to prove the pipeline is not single-world-only.
 

--- a/backend/tests/test_phase53_successor_gate.py
+++ b/backend/tests/test_phase53_successor_gate.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+PHASE53_GATE_PATH = Path("docs/plans/phase-53-successor-gate-2026-05-19.md")
+
+
+def test_phase53_successor_gate_exists_with_required_sections() -> None:
+    assert PHASE53_GATE_PATH.exists()
+
+    gate = PHASE53_GATE_PATH.read_text(encoding="utf-8")
+    required_sections = [
+        "# Phase 53 Successor Gate",
+        "Issue: `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`",
+        "Current work item: `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`",
+        "## Phase 52 Closeout Evidence",
+        "## Phase 53 Operational Queue",
+        "## Transfer-Generalization Scope",
+        "## Protected-Core Lane Coverage",
+        "## Carried Forward TODO[verify] Items",
+        "## Phase 53 Work Package Map",
+        "## Blueprint Boundary",
+        "## Non-Goals",
+        "## Validation Commands",
+    ]
+    for section in required_sections:
+        assert section in gate
+
+
+def test_phase53_successor_gate_records_queue_and_boundaries() -> None:
+    assert PHASE53_GATE_PATH.exists()
+
+    gate = PHASE53_GATE_PATH.read_text(encoding="utf-8")
+    required_phrases = [
+        "Phase 53 - Transfer Generalization and Third-World Readiness",
+        "`#418` `Phase 53 exit gate`",
+        "`#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`",
+        "`#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`",
+        "`#421` `Phase 53: add bounded third-world transfer readiness evidence`",
+        "Status: blocked closeout gate for Phase 53.",
+        "Status: current ready work item.",
+        "Status: blocked until `#419` closes.",
+        "Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`",
+        "bounded transfer generalization",
+        "third-world readiness",
+        "Do not claim transfer generalization beyond the evidence that has actually passed",
+        "Do not use real-world data, real-person personas, or digital doubles",
+        "Do not implement a launch hub",
+        "Do not implement async workers, queues, `task_id`, retry, status, cleanup",
+        "Do not change scenario DSL, claim labels, report claim `evidence_ids`, run trace shape",
+        "public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries",
+        "Every report claim must keep both `label` and `evidence_ids`",
+        "`docs/plans/phase-49-transfer-assumption-inventory-2026-05-18.md`",
+        "`docs/plans/phase-52-successor-gate-2026-05-18.md`",
+        "`docs/plans/phase-53-successor-gate-2026-05-19.md`",
+    ]
+    for phrase in required_phrases:
+        assert phrase in gate
+
+
+def test_active_state_docs_point_to_phase53_queue() -> None:
+    required_docs = [
+        Path("README.md"),
+        Path("docs/plans/current-state-baseline.md"),
+        Path("docs/plans/phase-execution-queue.md"),
+        Path("docs/plans/automation-roadmap.md"),
+    ]
+
+    for path in required_docs:
+        text = path.read_text(encoding="utf-8")
+        assert "Phase 53 - Transfer Generalization and Third-World Readiness" in text
+        assert "`#418`" in text
+        assert "`#419`" in text
+        assert "`#420`" in text
+        assert "`#421`" in text
+        assert "Phase 53 Successor Gate" in text
+        assert "`docs/plans/phase-53-successor-gate-2026-05-19.md`" in text
+        assert "Phase 53: sync repo truth after Phase 52 closeout and define transfer gate" in text
+        assert "current ready" in text
+        assert "bounded transfer generalization" in text
+        assert "third-world readiness" in text
+        assert "public demo, plugin, Hosted GPT/BYOK, launch hub, async" in text
+
+
+def test_active_state_docs_do_not_treat_phase52_pause_as_current() -> None:
+    required_docs = [
+        Path("README.md"),
+        Path("docs/plans/current-state-baseline.md"),
+        Path("docs/plans/phase-execution-queue.md"),
+        Path("docs/plans/automation-roadmap.md"),
+    ]
+    stale_current_phrases = [
+        "The current repository state has completed the Phase 52 legacy-route/runtime-scope audit queue, preserved `v0.1.0` as the latest published release baseline, and returned to the formal paused stop-state with no active milestone.",
+        "This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 52 legacy-route/runtime-scope audit closeout, and the formal paused stop-state with no active successor milestone.",
+        "No successor queue is active after Phase 52 closeout; do not open a parallel execution queue without a fresh approved milestone and exit gate.",
+        "`audit-github-queue` now reports the formal paused stop-state",
+        "`audit-github-queue` reports the formal paused stop-state",
+    ]
+
+    for path in required_docs:
+        text = path.read_text(encoding="utf-8")
+        for phrase in stale_current_phrases:
+            assert phrase not in text, f"{path} still treats Phase 52 pause as current: {phrase}"

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, Phase 47 closeout is complete, Phase 48 closeout is complete, Phase 49 closeout is complete, Phase 50 closeout is complete, Phase 51 closeout is complete, Phase 52 closeout is complete, the queue is in the formal paused stop-state, and the first formal release remains published as `v0.1.0`.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, Phase 47 closeout is complete, Phase 48 closeout is complete, Phase 49 closeout is complete, Phase 50 closeout is complete, Phase 51 closeout is complete, Phase 52 closeout is complete, Phase 53 is the active approved successor queue, and the first formal release remains published as `v0.1.0`.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -179,13 +179,20 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract` is closed by PR `#415`; this completed the Phase 52 Legacy Top-Level Runtime Route Audit.
 - `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is closed by PR `#416`; this completed the Phase 52 Runtime Mutation Guard Regression Baseline.
 - Phase 52 focused on legacy top-level runtime routes and runtime mutation guard regression coverage without widening public/plugin/async contracts. The route audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`, the runtime guard note lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`, route-derived `worldId` coverage remains in scope, and the gate note lives in `docs/plans/phase-52-successor-gate-2026-05-18.md`.
+- Phase 53 is the active approved successor queue.
+- milestone `Phase 53 - Transfer Generalization and Third-World Readiness` is open.
+- `#418` `Phase 53 exit gate` is open, blocked, and protected-core.
+- `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate` is the current ready Phase 53: sync repo truth after Phase 52 closeout and define transfer gate.
+- `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` is blocked until `#419` closes.
+- `#421` `Phase 53: add bounded third-world transfer readiness evidence` is blocked until `#420` closes.
+- Phase 53 focuses on bounded transfer generalization and third-world readiness without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries. The active Phase 53 Successor Gate lives in `docs/plans/phase-53-successor-gate-2026-05-19.md`.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.
 - `#390` `Phase 49: ratify runtime parent-child compare emission policy` is closed by PR `#391`.
 - `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope` is closed by PR `#393`.
 - `#394` `Phase 49: strengthen transfer eval outcome coverage` is closed by PR `#395`.
-- `audit-github-queue` reports the formal paused stop-state with no active milestone.
+- `audit-github-queue` reports `ready` with Phase 53 as the active milestone.
 - The first formal repository release is published as `v0.1.0`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
@@ -242,5 +249,5 @@ Before builder automation is allowed to write code or auto-merge:
 - Long-running execution must run from isolated worktrees rather than the current `main` checkout.
 - Queue pickup order, one-writer ownership, and branch hygiene should follow `docs/plans/long-running-loop-runbook.md`.
 - When the active milestone exists and the queue reports `ready`, the builder may resume against that milestone only.
-- No successor queue is active after Phase 52 closeout; do not open a parallel execution queue without a fresh approved milestone and exit gate.
+- Phase 53 is the active approved successor queue; do not open a parallel execution queue.
 - When no open milestone exists and `audit-github-queue` reports `paused`, treat that state as an intentional released stop-state rather than a broken queue.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note records the completed Phase 52 legacy-route/runtime-scope audit closeout and the formal paused stop-state after the formal `v0.1.0` release baseline.
+This note records the active Phase 53 transfer-generalization successor queue after the completed Phase 52 legacy-route/runtime-scope audit closeout and the formal `v0.1.0` release baseline.
 
 ## Snapshot
 
@@ -214,7 +214,7 @@ This note records the completed Phase 52 legacy-route/runtime-scope audit closeo
   - `gh api repos/YSCJRH/mirror-sim/releases`
     - release `v0.1.0` exists and matches the committed release notes baseline
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - queue reports `paused` with no active milestone after the Phase 52 closeout
+    - queue reports `ready` with `Phase 53 - Transfer Generalization and Third-World Readiness` as the active milestone
   - `gh issue list --milestone "Phase 47 - Boundary Readiness and Successor Hygiene" --state all`
     - `#365` `Phase 47 exit gate` is `closed` after merging PR `#374`
     - `#366` `Phase 47: sync repo truth to successor queue` is `closed` after merging PR `#370`
@@ -283,6 +283,16 @@ This note records the completed Phase 52 legacy-route/runtime-scope audit closeo
     - legacy top-level runtime routes remain explicitly contained
     - runtime mutation guard regression coverage keeps route-derived `worldId` and public-demo blocking in scope
     - `docs/plans/phase-52-successor-gate-2026-05-18.md` records the completed gate note
+  - `gh issue list --milestone "Phase 53 - Transfer Generalization and Third-World Readiness" --state all`
+    - `#418` `Phase 53 exit gate` is `open`, `blocked`, and `lane:protected-core`
+    - `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate` is the current ready Phase 53 protected-core work item
+    - `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` is `open` and `blocked`
+    - `#421` `Phase 53: add bounded third-world transfer readiness evidence` is `open` and `blocked`
+  - Phase 53 Successor Gate:
+    - Phase 53 - Transfer Generalization and Third-World Readiness is the active approved successor queue
+    - `docs/plans/phase-53-successor-gate-2026-05-19.md` records the active gate note
+    - Phase 53 focuses on bounded transfer generalization and third-world readiness
+    - public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries remain unchanged
 
 ## Trusted Source Of Truth
 
@@ -304,18 +314,20 @@ This note records the completed Phase 52 legacy-route/runtime-scope audit closeo
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
 - The default workbench path now consumes the canonical compare artifact directly and keeps focused divergent trace surfaces ahead of heavier packet-driven review flows.
 - The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, execution recovery release boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, escalation acknowledgment packets, and escalation closure packets without introducing backend API expansion.
-- The current repository state has completed the Phase 52 legacy-route/runtime-scope audit queue, preserved `v0.1.0` as the latest published release baseline, and returned to the formal paused stop-state with no active milestone.
+- The current repository state has opened the Phase 53 transfer-generalization queue, preserved `v0.1.0` as the latest published release baseline, and kept public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries unchanged.
 
 ## Next Entry Point
 
 - Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`.
-- Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; `audit-github-queue` reports the formal paused stop-state.
+- Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; before Phase 53 was opened, `audit-github-queue` reported the formal paused stop-state.
+- Phase 53 is the active approved successor queue: `Phase 53 - Transfer Generalization and Third-World Readiness`; `audit-github-queue` reports `ready`.
 - The Phase 47 unlock order is resolved: the queue-sync issue is closed after PR `#370`, the boundary-regression report is closed after PR `#371`, the runtime-world safety preflight is closed after PR `#372`, the main-path containment report is closed after PR `#373`, and the exit gate is closed after PR `#374`.
 - The Phase 48 unlock order is resolved: `#376` and `#377` closed through earlier Phase 48 PRs, `#378` and `#379` closed through PR `#382`, and `#375` closed after the post-merge exit-gate reassessment.
 - The Phase 49 unlock order is resolved: `#384` closed through PR `#385`, `#386` closed through PR `#387`, `#388` closed through PR `#389`, `#390` closed through PR `#391`, `#392` closed through PR `#393`, `#394` closed through PR `#395`, and `#383` closed after the post-merge exit-gate reassessment.
 - The Phase 50 unlock order is resolved: `#397` closed through PR `#399`, `#398` closed through PR `#400`, `#401` closed through PR `#402`, and `#396` closed after the post-merge exit-gate reassessment.
-- The latest closed successor milestone is `Phase 52 - Legacy Route Containment and Runtime Scope Audit`.
+- The active successor milestone is `Phase 53 - Transfer Generalization and Third-World Readiness`.
 - The Phase 52 exit gate is `#410` `Phase 52 exit gate`, which closed after post-merge validation on `main`.
+- The Phase 53 exit gate is `#418` `Phase 53 exit gate`, which remains the open blocked closeout gate for this phase.
 - `#397` `Phase 50: sync repo truth after Phase 49 closeout` is closed by PR `#399`.
 - `#398` `Phase 50: measure runtime generation duration before task_id decision` is closed by PR `#400`.
 - `#401` `Phase 50: ratify private-beta launch hub and public-path boundary` is closed by PR `#402`.
@@ -333,6 +345,11 @@ This note records the completed Phase 52 legacy-route/runtime-scope audit closeo
 - Phase 52 focused on legacy top-level runtime routes and runtime mutation guard regression coverage without widening public/plugin/async contracts.
 - The Phase 52 Legacy Top-Level Runtime Route Audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`.
 - The Phase 52 Runtime Mutation Guard Regression Baseline note lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md` and keeps route-derived `worldId` guard coverage in scope.
+- `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate` is the current ready Phase 53: sync repo truth after Phase 52 closeout and define transfer gate.
+- `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` is blocked until `#419` closes.
+- `#421` `Phase 53: add bounded third-world transfer readiness evidence` is blocked until `#420` closes.
+- Phase 53 focuses on bounded transfer generalization and third-world readiness without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries.
+- The active Phase 53 Successor Gate lives in `docs/plans/phase-53-successor-gate-2026-05-19.md`.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.
@@ -345,6 +362,7 @@ This note records the completed Phase 52 legacy-route/runtime-scope audit closeo
 - The completed Phase 50 successor-gate baseline lives in `docs/plans/phase-50-successor-gate-2026-05-18.md`.
 - The completed Phase 51 successor-gate baseline lives in `docs/plans/phase-51-successor-gate-2026-05-18.md`.
 - The completed Phase 52 successor-gate baseline lives in `docs/plans/phase-52-successor-gate-2026-05-18.md`.
+- The active Phase 53 successor-gate baseline lives in `docs/plans/phase-53-successor-gate-2026-05-19.md`.
 - Local untracked private-beta, kernel, and design-system planning files under `docs/plans/...` are candidate inputs only until a PR intentionally promotes them.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.

--- a/docs/plans/phase-53-successor-gate-2026-05-19.md
+++ b/docs/plans/phase-53-successor-gate-2026-05-19.md
@@ -1,0 +1,175 @@
+# Phase 53 Successor Gate
+
+Date: 2026-05-19
+
+Issue: `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`
+
+Current work item: `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`
+
+This note records the post-Phase-52 baseline and the Phase 53 successor queue. Phase 53
+is a protected-core transfer-generalization and third-world readiness phase. It opens a
+bounded transfer generalization gate before Mirror claims transfer behavior beyond the
+currently proven Fog Harbor and museum-night worlds. It is not a launch-hub, public-path,
+plugin, Hosted GPT/BYOK, async-runtime, schema-expansion, or runtime-mutation phase.
+
+This gate is recorded at `docs/plans/phase-53-successor-gate-2026-05-19.md`.
+
+## Phase 52 Closeout Evidence
+
+Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`.
+
+- PR `#414` closed `#411` `Phase 52: sync repo truth after Phase 51 closeout and define successor gate`.
+- PR `#415` closed `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract`.
+- PR `#416` closed `#413` `Phase 52: strengthen runtime mutation guard regression baseline`.
+- Issue `#410` `Phase 52 exit gate` is closed after post-merge validation on `main`.
+- Milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit` is closed.
+- The completed Phase 52 successor gate lives in
+  `docs/plans/phase-52-successor-gate-2026-05-18.md`.
+- Queue audit reached the formal paused stop-state after Phase 52 closed, then returned
+  `ready` once Phase 53 was opened with one blocked exit gate and one ready work item.
+
+## Phase 53 Operational Queue
+
+Phase 53 title:
+
+```text
+Phase 53 - Transfer Generalization and Third-World Readiness
+```
+
+Active GitHub objects:
+
+- `#418` `Phase 53 exit gate`
+  - Lane: `protected-core`.
+  - Status: blocked closeout gate for Phase 53.
+- `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`
+  - Lane: `protected-core`.
+  - Status: current ready work item.
+  - Scope: sync durable docs and tests to the active Phase 53 queue.
+- `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`
+  - Lane: `protected-core`.
+  - Status: blocked until `#419` closes.
+  - Scope: define allowed and blocked transfer-readiness claims before adding evidence.
+- `#421` `Phase 53: add bounded third-world transfer readiness evidence`
+  - Lane: `protected-core`.
+  - Status: blocked until `#420` closes.
+  - Scope: add bounded third-world readiness evidence or ratify a stronger compatibility contract.
+
+`python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
+with Phase 53 as the only open milestone, `#418` as the protected blocked exit gate, and
+`#419` as the current ready work item.
+
+## Transfer-Generalization Scope
+
+Phase 53 moves Mirror toward bounded transfer generalization and third-world readiness.
+The current `eval-transfer` path proves Mirror is not single-world-only, but the project
+must not claim transfer generalization beyond the evidence that has actually passed.
+
+Phase 53 starts from the existing transfer assumption inventory in
+`docs/plans/phase-49-transfer-assumption-inventory-2026-05-18.md`. It keeps Fog Harbor as
+the canonical demo world and museum-night as the minimal transfer world while defining
+what evidence is needed for a third bounded world or an explicitly reviewed compatibility
+contract.
+
+Do not claim transfer generalization beyond the evidence that has actually passed.
+Any third-world evidence must use original, fictional, or explicitly authorized data and
+must keep every report claim linked through `label` and `evidence_ids`.
+
+## Protected-Core Lane Coverage
+
+Phase 53 work is protected-core by default when it touches transfer claims, eval
+contracts, report evidence, world fixtures, queue governance, or durable project posture.
+The lane policy already protects:
+
+- `docs/architecture/contracts.md`
+- `docs/decisions/`
+- `docs/plans/automation-roadmap.md`
+- `docs/plans/current-state-baseline.md`
+- `docs/plans/phase-`
+- `data/demo/`
+- `data/worlds/`
+- `evals/`
+
+This protection is operational governance. It does not itself change scenario DSL,
+perturbation payloads, session/node manifests, `decision_trace.jsonl`, compare artifacts,
+public demo artifact layout, or the Mirror Codex MCP contract.
+
+## Carried Forward TODO[verify] Items
+
+- TODO[verify]: Codex UI tool-card evidence remains open until a clean Codex app session
+  shows observable MCP tool or resource cards/traces for the Mirror Codex plugin.
+- TODO[verify]: rerun hosted/private-beta model measurements before introducing async task semantics.
+- TODO[verify]: open a separate migration work item before redirecting or deleting any
+  legacy top-level runtime route.
+- TODO[verify]: require route-derived `worldId` or an equivalent reviewed scope guard
+  before adding any new mutating runtime API.
+- TODO[verify]: do not promote untracked April/private-beta planning notes as durable
+  truth without a reviewed PR.
+- Do not recreate local Codex automations without a new explicit operator request.
+
+## Phase 53 Work Package Map
+
+1. Repo-truth sync after Phase 52 closeout and transfer gate definition
+   - Record Phase 52 closure, Phase 53 queue objects, validation, and carried-forward
+     boundaries across README and active planning docs.
+   - Define the bounded transfer generalization and third-world readiness successor gate.
+   - Keep public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries unchanged.
+
+2. Transfer assumptions and third-world readiness constraints
+   - Audit `eval-transfer` and existing transfer assumption language.
+   - Record allowed transfer-readiness claims, blocked claims, and evidence gaps.
+   - Keep transfer language evidence-bounded and world-bounded.
+
+3. Bounded third-world transfer readiness evidence
+   - Add a small original/fictional third-world readiness slice or document a reviewed
+     compatibility-contract alternative.
+   - Strengthen eval/report coverage only within the ratified contracts.
+   - Preserve claim/evidence integrity.
+
+## Blueprint Boundary
+
+Phase 53 must stay aligned with `mirror.md` and `AGENTS.md`:
+
+- Mirror is a constrained, evidence-backed, replayable what-if sandbox for fictional or
+  explicitly authorized worlds.
+- Do not present Mirror as a real-world prediction machine.
+- Do not build real-person personas or digital doubles.
+- Do not build political persuasion, law-enforcement scoring, hiring, credit, medical, or
+  judicial decision systems.
+- Do not use real-world data, real-person personas, or digital doubles.
+- Every report claim must keep both `label` and `evidence_ids`.
+- Durable contract changes require `docs/architecture/contracts.md` updates and an ADR when
+  the contract is long-lived.
+
+## Non-Goals
+
+- Do not implement a launch hub in Phase 53.
+- Do not replace `/` or widen the public path.
+- Do not change public demo behavior.
+- Do not change Mirror Codex plugin MCP tools or resources.
+- Do not add mutating Mirror Codex MCP tools.
+- Do not add Hosted GPT, BYOK, upload, auth, billing, database, object storage, or quota
+  behavior to the public path or plugin path.
+- Do not implement async workers, queues, `task_id`, retry, status, cleanup, checkpoint
+  mutation/deletion, or restore semantics.
+- Do not change scenario DSL, claim labels, report claim `evidence_ids`, run trace shape,
+  compare artifact shape, session/node manifest shape, public demo artifact layout, or
+  plugin MCP contract.
+- Do not redirect or delete legacy top-level runtime routes in Phase 53 unless a separate
+  reviewed migration work item first changes that posture.
+- Do not claim third-world readiness before the third-world evidence or compatibility
+  contract has passed review and validation.
+
+## Validation Commands
+
+For `#419`, run:
+
+```powershell
+python -m pytest backend/tests/test_phase53_successor_gate.py backend/tests/test_phase52_successor_gate.py -q
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-53-successor-gate-2026-05-19.md backend/tests/test_phase53_successor_gate.py
+git diff --check
+./make.ps1 test
+./make.ps1 eval-demo
+./make.ps1 eval-transfer
+```

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 52 legacy-route/runtime-scope audit closeout, and the formal paused stop-state with no active successor milestone.
+This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 52 legacy-route/runtime-scope audit closeout, and the active Phase 53 transfer-generalization successor queue.
 
 ## Current Gate State
 
@@ -56,12 +56,43 @@ This note records the current post-Day-0 execution status for Mirror after the f
 - Phase 50 exit gate: closed
 - Phase 51 exit gate: closed
 - Phase 52 exit gate: closed
+- Phase 53 exit gate: open and blocked
 
 Local phase audits currently report:
 
 - `phase1`: pass
 - `phase2`: pass
 - `phase3`: pass
+
+## Phase 53 Successor Queue
+
+Phase 53 title:
+
+```text
+Phase 53 - Transfer Generalization and Third-World Readiness
+```
+
+- `audit-github-queue`
+  - reports `ready` with `Phase 53 - Transfer Generalization and Third-World Readiness` as the active milestone
+- milestone `Phase 53 - Transfer Generalization and Third-World Readiness`
+  - open
+- `#418` `Phase 53 exit gate`
+  - open and blocked
+  - labeled `lane:protected-core` because it is the protected closeout gate
+- `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`
+  - current ready protected-core work item
+  - Phase 53: sync repo truth after Phase 52 closeout and define transfer gate
+  - syncs durable docs and tests to the active Phase 53 queue
+- `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`
+  - blocked until `#419` closes
+  - defines bounded transfer generalization claims and third-world readiness criteria
+- `#421` `Phase 53: add bounded third-world transfer readiness evidence`
+  - blocked until `#420` closes
+  - adds bounded third-world readiness evidence or a reviewed compatibility-contract alternative
+- boundary posture
+  - Phase 53 does not widen public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries.
+- phase gate baseline
+  - active Phase 53 Successor Gate: `docs/plans/phase-53-successor-gate-2026-05-19.md`
 
 ## Phase 52 Closeout
 
@@ -242,7 +273,8 @@ Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Priv
   - Phase 50 completed as a runtime-orchestration measurement and product-boundary round
   - Phase 51 completed as a private-beta route contract and runtime-readiness round
   - Phase 52 completed as a legacy-route containment and runtime-scope audit round
-  - any work beyond the closed Phase 52 queue requires a fresh decision against the trigger conditions in `mirror.md`
+  - Phase 53 is the active approved successor queue for bounded transfer generalization and third-world readiness
+  - any work beyond the Phase 53 queue requires a fresh decision against the trigger conditions in `mirror.md`
 
 ## Closeout Snapshot
 
@@ -700,7 +732,7 @@ Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Priv
 - Protected-core changes still require explicit review and must not auto-merge.
 - Long-running execution should assign exactly one writer worktree per issue.
 - When `audit-github-queue` reports `ready`, consume only the currently active milestone and do not parallel-open another execution queue.
-- No successor queue is active after Phase 52 closeout; do not open a parallel execution queue without a fresh approved milestone and exit gate.
+- Phase 53 is the active approved successor queue; do not open a parallel execution queue.
 - The previous local queue follow-up automation has been revoked or left paused per operator request; do not recreate an automation without a new explicit request.
 
 ## Historical Branch Status


### PR DESCRIPTION
## Summary
- Syncs durable repo-truth docs to the active Phase 53 transfer-generalization queue.
- Adds the Phase 53 Successor Gate note and regression tests for stale Phase 52 paused-state wording.
- Records #418 as the blocked exit gate, #419 as the current ready item, and #420/#421 as blocked follow-ups.
- Keeps public demo, plugin, Hosted GPT/BYOK, launch hub, async, runtime mutation, schema, claim, trace, compare, session-manifest, and artifact-layout boundaries unchanged.

Closes #419.

## Validation
- `python -m pytest backend\tests\test_phase53_successor_gate.py backend\tests\test_phase52_successor_gate.py -q` -> 8 passed
- `python scripts\check_no_secrets.py` -> passed
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` -> ready, active Phase 53 milestone, #419 ready
- `python -m backend.app.cli classify-lane --files README.md docs\plans\current-state-baseline.md docs\plans\automation-roadmap.md docs\plans\phase-execution-queue.md docs\plans\phase-53-successor-gate-2026-05-19.md backend\tests\test_phase53_successor_gate.py` -> lane:protected-core, risk:core-contract
- `git diff --check` -> no whitespace errors (CRLF warnings only)
- `.\make.ps1 test` -> 140 passed
- `.\make.ps1 eval-demo` -> pass 23/23
- `.\make.ps1 eval-transfer` -> pass 40/40

Note: `eval-demo` and `eval-transfer` were run serially because both write under `artifacts/demo`.