### PR TITLE
Phase 53 transfer assumption audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,12 +267,14 @@ plugin, Hosted GPT/BYOK, or async contracts. See
 Phase 53 Transfer Generalization and Third-World Readiness: Phase 53 is the active
 approved successor queue after the Phase 52 closeout. `audit-github-queue` reports
 `ready` with milestone `Phase 53 - Transfer Generalization and Third-World Readiness`,
-blocked exit gate `#418`, and current ready work item `#419` `Phase 53: sync repo truth
-after Phase 52 closeout and define transfer gate`. Follow-up work items `#420` and `#421`
-remain blocked until the transfer gate is synced. Phase 53 focuses on bounded transfer
+blocked exit gate `#418`, and current ready work item `#420` `Phase 53: audit transfer
+assumptions and third-world readiness constraints`. `#419` closed the initial transfer
+gate sync, and `#421` remains blocked until the transfer-assumption audit closes.
+Phase 53 focuses on bounded transfer
 generalization and third-world readiness, without widening public demo, plugin, Hosted
 GPT/BYOK, launch hub, async, or runtime mutation boundaries. See
-`docs/plans/phase-53-successor-gate-2026-05-19.md`.
+`docs/plans/phase-53-successor-gate-2026-05-19.md` and
+`docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`.
 
 ---
 
@@ -306,12 +308,13 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - The completed Phase 51 successor gate lives in [docs/plans/phase-51-successor-gate-2026-05-18.md](docs/plans/phase-51-successor-gate-2026-05-18.md).
 - The completed Phase 52 successor gate lives in [docs/plans/phase-52-successor-gate-2026-05-18.md](docs/plans/phase-52-successor-gate-2026-05-18.md).
 - The active Phase 53 Successor Gate lives in [docs/plans/phase-53-successor-gate-2026-05-19.md](docs/plans/phase-53-successor-gate-2026-05-19.md).
+- The current Phase 53 Transfer Assumption Audit lives in [docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md](docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md).
 - Phase 48 is closed after PR `#382`, issue `#375`, and milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
 - Phase 49 is closed after PR `#395`, issue `#383`, and milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; completed work items were `#384`, `#386`, `#388`, `#390`, `#392`, and `#394`.
 - Phase 50 is closed after PR `#402`, issue `#396`, and milestone `Phase 50 - Runtime Orchestration Measurement and Product Boundary`; completed work items were `#397`, `#398`, and `#401`. Phase 50 measured before any `task_id` or worker contract is introduced and kept the private-beta launch hub planning-only for now.
 - Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`; completed work items were `#404`, `#405`, and `#406`.
 - Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; completed work items were `#411`, `#412`, and `#413`. Before Phase 53 was opened, `audit-github-queue` reported the formal paused stop-state with no active milestone. The legacy top-level runtime routes audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`; the runtime guard note lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`; Phase 52 did not widen public demo, plugin, Hosted GPT/BYOK, or async contracts and keeps route-derived `worldId` guard coverage in scope.
-- Phase 53 is the active approved successor queue: `Phase 53 - Transfer Generalization and Third-World Readiness`; `audit-github-queue` reports `ready` with `#418` as the blocked exit gate, `#419` as the current ready Phase 53: sync repo truth after Phase 52 closeout and define transfer gate, and `#420`/`#421` blocked. Phase 53 focuses on bounded transfer generalization and third-world readiness without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries.
+- Phase 53 is the active approved successor queue: `Phase 53 - Transfer Generalization and Third-World Readiness`; `audit-github-queue` reports `ready` with `#418` as the blocked exit gate, `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` as the current ready work item, `#419` closed by PR `#422`, and `#421` blocked. Phase 53 focuses on bounded transfer generalization and third-world readiness without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
 - Fog Harbor remains the canonical demo world; `museum-night` is the minimal transfer world used to prove the pipeline is not single-world-only.
 

--- a/backend/tests/test_phase53_successor_gate.py
+++ b/backend/tests/test_phase53_successor_gate.py
@@ -13,7 +13,7 @@ def test_phase53_successor_gate_exists_with_required_sections() -> None:
     required_sections = [
         "# Phase 53 Successor Gate",
         "Issue: `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`",
-        "Current work item: `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`",
+        "Current work item: `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`",
         "## Phase 52 Closeout Evidence",
         "## Phase 53 Operational Queue",
         "## Transfer-Generalization Scope",
@@ -40,7 +40,8 @@ def test_phase53_successor_gate_records_queue_and_boundaries() -> None:
         "`#421` `Phase 53: add bounded third-world transfer readiness evidence`",
         "Status: blocked closeout gate for Phase 53.",
         "Status: current ready work item.",
-        "Status: blocked until `#419` closes.",
+        "Status: closed by PR `#422`.",
+        "Status: blocked until `#420` closes.",
         "Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`",
         "bounded transfer generalization",
         "third-world readiness",
@@ -76,7 +77,7 @@ def test_active_state_docs_point_to_phase53_queue() -> None:
         assert "`#421`" in text
         assert "Phase 53 Successor Gate" in text
         assert "`docs/plans/phase-53-successor-gate-2026-05-19.md`" in text
-        assert "Phase 53: sync repo truth after Phase 52 closeout and define transfer gate" in text
+        assert "Phase 53: audit transfer assumptions and third-world readiness constraints" in text
         assert "current ready" in text
         assert "bounded transfer generalization" in text
         assert "third-world readiness" in text

--- a/backend/tests/test_phase53_transfer_assumption_audit.py
+++ b/backend/tests/test_phase53_transfer_assumption_audit.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.app.evals.service import DEFAULT_TRANSFER_WORLD_IDS
+from backend.app.worlds import CANONICAL_DEMO_WORLD_ID
+
+
+AUDIT_NOTE = Path("docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md")
+
+
+def test_phase53_transfer_assumption_audit_records_supported_and_blocked_claims() -> None:
+    text = AUDIT_NOTE.read_text(encoding="utf-8")
+
+    required_phrases = [
+        "# Phase 53 Transfer Assumption Audit",
+        "Issue: `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`",
+        "Current work item: `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`",
+        "## Supported Claims",
+        "Mirror has a two-world transfer proof across `fog-harbor-east-gate` and `museum-night`.",
+        "`eval-transfer` proves Mirror is not single-world-only.",
+        "## Blocked Claims",
+        "Do not claim broad transfer readiness beyond the current two-world proof.",
+        "Do not claim third-world readiness before `#421` adds evidence or a reviewed compatibility contract.",
+        "Do not claim every future world will work without additional contracts.",
+        "## Third-World Readiness Criteria",
+        "original, fictional, or explicitly authorized",
+        "world-local `config/simulation_rules.yaml`",
+        "Every report claim must keep both `label` and `evidence_ids`.",
+        "pass `python -m backend.app.cli eval-world --world <world_id>`",
+    ]
+
+    for phrase in required_phrases:
+        assert phrase in text
+
+
+def test_transfer_assumption_audit_stays_aligned_with_eval_transfer_defaults() -> None:
+    assert DEFAULT_TRANSFER_WORLD_IDS == [CANONICAL_DEMO_WORLD_ID, "museum-night"]
+
+    text = AUDIT_NOTE.read_text(encoding="utf-8")
+    for world_id in DEFAULT_TRANSFER_WORLD_IDS:
+        assert f"`{world_id}`" in text
+    assert "DEFAULT_TRANSFER_WORLD_IDS" in text
+    assert "two-world proof" in text
+    assert "third-world readiness" in text
+
+
+def test_transfer_assumption_audit_avoids_unbounded_readiness_phrasing() -> None:
+    text = AUDIT_NOTE.read_text(encoding="utf-8")
+    forbidden_phrases = [
+        "Mirror is transfer-ready",
+        "generalizes to future worlds",
+        "works for every world",
+        "open-world generality",
+        "real-person persona readiness",
+        "The existing proof supports saying that Mirror can run",
+    ]
+
+    for phrase in forbidden_phrases:
+        assert phrase not in text
+
+
+def test_transfer_assumption_audit_preserves_protected_contract_boundaries() -> None:
+    text = AUDIT_NOTE.read_text(encoding="utf-8")
+    required_boundaries = [
+        "scenario DSL",
+        "claim labels",
+        "run trace shape",
+        "compare artifact shape",
+        "session/node manifest shape",
+        "public demo artifact layout",
+        "plugin MCP contract",
+        "public/private routes",
+        "async runtime",
+        "runtime mutation",
+    ]
+
+    for boundary in required_boundaries:
+        assert boundary in text
+
+
+def test_active_docs_point_to_current_phase53_assumption_audit() -> None:
+    required_docs = [
+        Path("README.md"),
+        Path("docs/plans/current-state-baseline.md"),
+        Path("docs/plans/phase-53-successor-gate-2026-05-19.md"),
+        Path("docs/plans/phase-execution-queue.md"),
+        Path("docs/plans/automation-roadmap.md"),
+    ]
+    stale_phrases = [
+        "`#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` is blocked until `#419` closes.",
+        "Status: blocked until `#419` closes.",
+        "`#420`/`#421` blocked",
+    ]
+
+    for path in required_docs:
+        text = path.read_text(encoding="utf-8")
+        assert "docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md" in text
+        assert "`#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`" in text
+        assert "current ready" in text or "Status: current ready work item." in text
+        for phrase in stale_phrases:
+            assert phrase not in text, f"{path} still treats #420 as blocked: {phrase}"

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -182,10 +182,10 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 53 is the active approved successor queue.
 - milestone `Phase 53 - Transfer Generalization and Third-World Readiness` is open.
 - `#418` `Phase 53 exit gate` is open, blocked, and protected-core.
-- `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate` is the current ready Phase 53: sync repo truth after Phase 52 closeout and define transfer gate.
-- `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` is blocked until `#419` closes.
+- `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate` is closed by PR `#422`.
+- `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` is the current ready Phase 53 transfer-assumption audit.
 - `#421` `Phase 53: add bounded third-world transfer readiness evidence` is blocked until `#420` closes.
-- Phase 53 focuses on bounded transfer generalization and third-world readiness without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries. The active Phase 53 Successor Gate lives in `docs/plans/phase-53-successor-gate-2026-05-19.md`.
+- Phase 53 focuses on bounded transfer generalization and third-world readiness without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries. The active Phase 53 Successor Gate lives in `docs/plans/phase-53-successor-gate-2026-05-19.md`; the current transfer-assumption audit lives in `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -285,12 +285,13 @@ This note records the active Phase 53 transfer-generalization successor queue af
     - `docs/plans/phase-52-successor-gate-2026-05-18.md` records the completed gate note
   - `gh issue list --milestone "Phase 53 - Transfer Generalization and Third-World Readiness" --state all`
     - `#418` `Phase 53 exit gate` is `open`, `blocked`, and `lane:protected-core`
-    - `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate` is the current ready Phase 53 protected-core work item
-    - `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` is `open` and `blocked`
+    - `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate` is `closed` by PR `#422`
+    - `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` is the current ready Phase 53 protected-core work item
     - `#421` `Phase 53: add bounded third-world transfer readiness evidence` is `open` and `blocked`
   - Phase 53 Successor Gate:
     - Phase 53 - Transfer Generalization and Third-World Readiness is the active approved successor queue
     - `docs/plans/phase-53-successor-gate-2026-05-19.md` records the active gate note
+    - `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md` records the current transfer assumption audit
     - Phase 53 focuses on bounded transfer generalization and third-world readiness
     - public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries remain unchanged
 
@@ -345,11 +346,12 @@ This note records the active Phase 53 transfer-generalization successor queue af
 - Phase 52 focused on legacy top-level runtime routes and runtime mutation guard regression coverage without widening public/plugin/async contracts.
 - The Phase 52 Legacy Top-Level Runtime Route Audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`.
 - The Phase 52 Runtime Mutation Guard Regression Baseline note lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md` and keeps route-derived `worldId` guard coverage in scope.
-- `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate` is the current ready Phase 53: sync repo truth after Phase 52 closeout and define transfer gate.
-- `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` is blocked until `#419` closes.
+- `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate` is closed by PR `#422`.
+- `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` is the current ready Phase 53 transfer-assumption audit.
 - `#421` `Phase 53: add bounded third-world transfer readiness evidence` is blocked until `#420` closes.
 - Phase 53 focuses on bounded transfer generalization and third-world readiness without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries.
 - The active Phase 53 Successor Gate lives in `docs/plans/phase-53-successor-gate-2026-05-19.md`.
+- The current Phase 53 Transfer Assumption Audit lives in `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.
@@ -363,6 +365,7 @@ This note records the active Phase 53 transfer-generalization successor queue af
 - The completed Phase 51 successor-gate baseline lives in `docs/plans/phase-51-successor-gate-2026-05-18.md`.
 - The completed Phase 52 successor-gate baseline lives in `docs/plans/phase-52-successor-gate-2026-05-18.md`.
 - The active Phase 53 successor-gate baseline lives in `docs/plans/phase-53-successor-gate-2026-05-19.md`.
+- The current Phase 53 transfer-assumption audit baseline lives in `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`.
 - Local untracked private-beta, kernel, and design-system planning files under `docs/plans/...` are candidate inputs only until a PR intentionally promotes them.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.

--- a/docs/plans/phase-53-successor-gate-2026-05-19.md
+++ b/docs/plans/phase-53-successor-gate-2026-05-19.md
@@ -4,7 +4,7 @@ Date: 2026-05-19
 
 Issue: `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`
 
-Current work item: `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`
+Current work item: `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`
 
 This note records the post-Phase-52 baseline and the Phase 53 successor queue. Phase 53
 is a protected-core transfer-generalization and third-world readiness phase. It opens a
@@ -43,12 +43,13 @@ Active GitHub objects:
   - Status: blocked closeout gate for Phase 53.
 - `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`
   - Lane: `protected-core`.
-  - Status: current ready work item.
+  - Status: closed by PR `#422`.
   - Scope: sync durable docs and tests to the active Phase 53 queue.
 - `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`
   - Lane: `protected-core`.
-  - Status: blocked until `#419` closes.
+  - Status: current ready work item.
   - Scope: define allowed and blocked transfer-readiness claims before adding evidence.
+  - Audit note: `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`.
 - `#421` `Phase 53: add bounded third-world transfer readiness evidence`
   - Lane: `protected-core`.
   - Status: blocked until `#420` closes.
@@ -56,7 +57,7 @@ Active GitHub objects:
 
 `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
 with Phase 53 as the only open milestone, `#418` as the protected blocked exit gate, and
-`#419` as the current ready work item.
+`#420` as the current ready work item.
 
 ## Transfer-Generalization Scope
 
@@ -118,6 +119,7 @@ public demo artifact layout, or the Mirror Codex MCP contract.
    - Audit `eval-transfer` and existing transfer assumption language.
    - Record allowed transfer-readiness claims, blocked claims, and evidence gaps.
    - Keep transfer language evidence-bounded and world-bounded.
+   - Current audit note: `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`.
 
 3. Bounded third-world transfer readiness evidence
    - Add a small original/fictional third-world readiness slice or document a reviewed
@@ -161,13 +163,13 @@ Phase 53 must stay aligned with `mirror.md` and `AGENTS.md`:
 
 ## Validation Commands
 
-For `#419`, run:
+For `#420`, run:
 
 ```powershell
-python -m pytest backend/tests/test_phase53_successor_gate.py backend/tests/test_phase52_successor_gate.py -q
+python -m pytest backend/tests/test_phase53_transfer_assumption_audit.py backend/tests/test_phase53_successor_gate.py -q
 python scripts/check_no_secrets.py
 python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
-python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-53-successor-gate-2026-05-19.md backend/tests/test_phase53_successor_gate.py
+python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-53-successor-gate-2026-05-19.md docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md backend/tests/test_phase53_successor_gate.py backend/tests/test_phase53_transfer_assumption_audit.py
 git diff --check
 ./make.ps1 test
 ./make.ps1 eval-demo

--- a/docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md
+++ b/docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md
@@ -1,0 +1,118 @@
+# Phase 53 Transfer Assumption Audit
+
+Date: 2026-05-19
+
+Issue: `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`
+
+Current work item: `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`
+
+This note records the evidence-bounded transfer posture before Phase 53 adds any third-world
+readiness evidence. It audits the current `eval-transfer` proof, identifies what Mirror may
+and may not claim, and defines the criteria that `#421` or a reviewed compatibility-contract
+alternative must satisfy. It does not add the third world, change schema, change scenario DSL,
+change claim labels, change run trace shape, change compare artifact shape, change session/node manifest shape,
+change public demo artifact layout, change plugin MCP contract, change
+public/private routes, add an async runtime, or widen runtime mutation behavior.
+
+## Evidence Inputs
+
+- `docs/plans/phase-49-transfer-assumption-inventory-2026-05-18.md` records the current
+  Fog Harbor-shaped assumptions and says `eval-transfer` is a two-world proof.
+- `docs/decisions/ADR-0005-two-world-transfer-contracts.md` ratifies the current two-world
+  transfer contract and keeps `eval-transfer` as the minimum portability proof.
+- `docs/architecture/contracts.md` defines `eval-transfer` as the dual-world transfer proof
+  across the canonical demo and the current second world.
+- `backend/app/evals/service.py` defines
+  `DEFAULT_TRANSFER_WORLD_IDS = [CANONICAL_DEMO_WORLD_ID, "museum-night"]`.
+- `backend/app/evals/service.py` evaluates transfer worlds through world-local tracked outcomes
+  and records `transfer_proof_world_local` only when each selected world covers its configured
+  outcomes in run summaries and compare deltas.
+- `data/demo/` remains the canonical Fog Harbor fixture.
+- `data/worlds/museum-night/` remains the second bounded fictional transfer fixture.
+
+## Supported Claims
+
+- Mirror has a two-world transfer proof across `fog-harbor-east-gate` and `museum-night`.
+- `eval-transfer` proves Mirror is not single-world-only.
+- The current transfer proof covers the canonical demo and the current second bounded world
+  selected by `DEFAULT_TRANSFER_WORLD_IDS`.
+- Current transfer eval checks are world-local: tracked outcomes come from each world's
+  `config/simulation_rules.yaml`, and report claims are checked for both `label` and
+  `evidence_ids`.
+- The current two-world proof supports saying that the constrained deterministic ingest,
+  graph, persona, scenario, run, compare, report, and eval pipeline has passed across the
+  two selected fictional or explicitly authorized bounded worlds.
+
+## Blocked Claims
+
+- Do not claim broad transfer readiness beyond the current two-world proof.
+- Do not claim third-world readiness before `#421` adds evidence or a reviewed compatibility contract.
+- Do not claim every future world will work without additional contracts.
+- Do not claim unbounded world coverage, real-world forecasts, or readiness for real-person
+  personas.
+- Do not claim transfer eval proves a public launch hub, plugin write path, Hosted GPT/BYOK path,
+  async runtime, worker queue, retry/status contract, or mutating runtime API.
+- Do not claim transfer hardening permits removal or rename of legacy `RunTrace` top-level fields.
+- Do not claim any third-world corpus, persona, or scenario evidence unless it is original,
+  fictional, or explicitly authorized.
+
+## Third-World Readiness Criteria
+
+Before Mirror can claim third-world readiness, the next evidence slice must satisfy all of these:
+
+- Use original, fictional, or explicitly authorized data.
+- Keep world data under `data/worlds/<world_id>/` and generated artifacts under
+  `artifacts/worlds/<world_id>/`.
+- Provide world-local `config/simulation_rules.yaml` with initial state, turn sequence,
+  tracked outcomes, explicit step rules, bounded injection effects, and a default report scenario.
+- Avoid world-specific Python constants for the new world; failures must be driven by generic
+  rule-driven checks.
+- Ensure every world-local tracked outcome appears in run summaries or `final_state`.
+- Ensure every world-local tracked outcome appears in compare outcome deltas.
+- Ensure the default report scenario changes at least one tracked outcome against baseline.
+- Every report claim must keep both `label` and `evidence_ids`.
+- Ensure report claim `evidence_ids` resolve to ingested chunk IDs.
+- pass `python -m backend.app.cli eval-world --world <world_id>`.
+- Pass `./make.ps1 eval-transfer` after either adding the third world to the reviewed transfer
+  set or ratifying why a stronger compatibility contract remains a two-world proof.
+- Preserve scenario DSL, claim labels, run trace shape, compare artifact shape, session/node
+  manifest shape, public demo artifact layout, and plugin MCP contract unless a separate ADR
+  ratifies the change.
+
+## Current Evidence Gaps
+
+- Phase 53 has not yet added a third bounded world.
+- `eval-transfer` currently reports `world_count: 2`; that is enough to show Mirror is not
+  single-world-only, but not enough to claim broad transfer readiness.
+- The current transfer proof relies on `fog-harbor-east-gate` and `museum-night`; it does not
+  show that all future world schemas, evidence corpora, tracked outcomes, or scenario choices
+  are compatible without additional review.
+- No hosted/private-beta runtime timing evidence is created by this audit.
+- No public demo, plugin, launch hub, async runtime, or runtime mutation contract changes are
+  created by this audit.
+
+## Required Follow-Up For `#421`
+
+`#421` should choose exactly one path before claiming third-world readiness:
+
+1. Add a small original/fictional third bounded world and extend the reviewed transfer set.
+2. Ratify a stronger compatibility contract that explains why the current two-world proof is
+   sufficient for the next product decision without claiming third-world readiness.
+
+Either path must keep transfer language evidence-bounded, preserve claim/evidence integrity,
+and avoid real-world forecasts or real-person persona claims.
+
+## Validation Commands
+
+For this audit slice, run:
+
+```powershell
+python -m pytest backend/tests/test_phase53_transfer_assumption_audit.py backend/tests/test_phase53_successor_gate.py -q
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-53-successor-gate-2026-05-19.md docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md backend/tests/test_phase53_transfer_assumption_audit.py
+git diff --check
+./make.ps1 test
+./make.ps1 eval-demo
+./make.ps1 eval-transfer
+```

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -80,12 +80,13 @@ Phase 53 - Transfer Generalization and Third-World Readiness
   - open and blocked
   - labeled `lane:protected-core` because it is the protected closeout gate
 - `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`
-  - current ready protected-core work item
+  - closed by PR `#422`
   - Phase 53: sync repo truth after Phase 52 closeout and define transfer gate
   - syncs durable docs and tests to the active Phase 53 queue
 - `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`
-  - blocked until `#419` closes
+  - current ready protected-core work item
   - defines bounded transfer generalization claims and third-world readiness criteria
+  - records `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`
 - `#421` `Phase 53: add bounded third-world transfer readiness evidence`
   - blocked until `#420` closes
   - adds bounded third-world readiness evidence or a reviewed compatibility-contract alternative
@@ -93,6 +94,7 @@ Phase 53 - Transfer Generalization and Third-World Readiness
   - Phase 53 does not widen public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries.
 - phase gate baseline
   - active Phase 53 Successor Gate: `docs/plans/phase-53-successor-gate-2026-05-19.md`
+  - current Phase 53 Transfer Assumption Audit: `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`
 
 ## Phase 52 Closeout
 


### PR DESCRIPTION
## Summary
- Adds the Phase 53 transfer assumption audit for #420 with supported claims, blocked claims, evidence gaps, and third-world readiness criteria.
- Updates active Phase 53 docs so #419 is closed by PR #422, #420 is current ready, and #421 remains blocked.
- Adds regression tests tying the audit to `DEFAULT_TRANSFER_WORLD_IDS`, current two-world evidence, protected contract boundaries, and unsafe broad-readiness phrasing.
- Does not add a third world or change scenario DSL, claim labels, run trace shape, compare artifacts, artifact layout, routes, plugin behavior, async runtime, or runtime mutation contracts.

Closes #420.

## Validation
- `python -m pytest backend\tests\test_phase53_transfer_assumption_audit.py backend\tests\test_phase53_successor_gate.py backend\tests\test_worlds.py backend\tests\test_cli.py::test_cli_eval_world_outputs_json backend\tests\test_cli.py::test_cli_eval_transfer_outputs_json -q` -> 16 passed
- `python scripts\check_no_secrets.py` -> passed
- `python -m backend.app.cli classify-lane --files README.md backend\tests\test_phase53_successor_gate.py backend\tests\test_phase53_transfer_assumption_audit.py docs\plans\automation-roadmap.md docs\plans\current-state-baseline.md docs\plans\phase-53-successor-gate-2026-05-19.md docs\plans\phase-53-transfer-assumption-audit-2026-05-19.md docs\plans\phase-execution-queue.md` -> lane:protected-core, risk:core-contract
- `gh issue view 420 --json number,state,title,labels,milestone,url` -> open, `status:ready`, Phase 53 milestone
- `git diff --check` -> no whitespace errors (CRLF warnings only)
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` -> ready, active Phase 53 milestone, #420 ready
- `.\make.ps1 test` -> 145 passed
- `.\make.ps1 eval-demo` -> pass 23/23
- `.\make.ps1 eval-transfer` -> pass 40/40, `world_count: 2`, `transfer_proof_world_local: true`

Note: `eval-demo` and `eval-transfer` were run serially because both write under `artifacts/demo`.