### PR TITLE
Phase 53 third-world transfer evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Extra transfer proof:
 
 ```bash
 python -m backend.app.cli eval-world --world museum-night
+python -m backend.app.cli eval-world --world library-rain
 ```
 
 ## Optional Private-Beta Model Path
@@ -267,14 +268,16 @@ plugin, Hosted GPT/BYOK, or async contracts. See
 Phase 53 Transfer Generalization and Third-World Readiness: Phase 53 is the active
 approved successor queue after the Phase 52 closeout. `audit-github-queue` reports
 `ready` with milestone `Phase 53 - Transfer Generalization and Third-World Readiness`,
-blocked exit gate `#418`, and current ready work item `#420` `Phase 53: audit transfer
-assumptions and third-world readiness constraints`. `#419` closed the initial transfer
-gate sync, and `#421` remains blocked until the transfer-assumption audit closes.
-Phase 53 focuses on bounded transfer
-generalization and third-world readiness, without widening public demo, plugin, Hosted
-GPT/BYOK, launch hub, async, or runtime mutation boundaries. See
-`docs/plans/phase-53-successor-gate-2026-05-19.md` and
-`docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`.
+blocked exit gate `#418`, and current ready work item `#421` `Phase 53: add bounded
+third-world transfer readiness evidence`. `#419` closed the initial transfer gate sync,
+and `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`
+closed the transfer-assumption audit by PR `#423`. `#421` adds `library-rain`
+as the third original fictional bounded world in the reviewed transfer set. Phase 53
+focuses on bounded transfer generalization and third-world readiness, without widening
+public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries.
+See `docs/plans/phase-53-successor-gate-2026-05-19.md`,
+`docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`, and
+`docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`.
 
 ---
 
@@ -282,6 +285,7 @@ GPT/BYOK, launch hub, async, or runtime mutation boundaries. See
 
 - Canonical Fog Harbor artifacts under `artifacts/demo/`
 - Second-world transfer artifacts under `artifacts/worlds/museum-night/`
+- Third-world transfer artifacts under `artifacts/worlds/library-rain/`
 - Transfer summary under `artifacts/transfer/summary.json`
 - Review workbench reading from the canonical compare/evidence/eval path
 
@@ -292,6 +296,7 @@ Useful artifact checkpoints:
 - `artifacts/demo/report/claims.json`
 - `artifacts/demo/eval/summary.json`
 - `artifacts/worlds/museum-night/eval/summary.json`
+- `artifacts/worlds/library-rain/eval/summary.json`
 
 For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-walkthrough.md](docs/demo/fog-harbor-walkthrough.md).
 
@@ -309,14 +314,15 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - The completed Phase 52 successor gate lives in [docs/plans/phase-52-successor-gate-2026-05-18.md](docs/plans/phase-52-successor-gate-2026-05-18.md).
 - The active Phase 53 Successor Gate lives in [docs/plans/phase-53-successor-gate-2026-05-19.md](docs/plans/phase-53-successor-gate-2026-05-19.md).
 - The current Phase 53 Transfer Assumption Audit lives in [docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md](docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md).
+- The current Phase 53 Third-World Transfer Evidence note lives in [docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md](docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md).
 - Phase 48 is closed after PR `#382`, issue `#375`, and milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
 - Phase 49 is closed after PR `#395`, issue `#383`, and milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; completed work items were `#384`, `#386`, `#388`, `#390`, `#392`, and `#394`.
 - Phase 50 is closed after PR `#402`, issue `#396`, and milestone `Phase 50 - Runtime Orchestration Measurement and Product Boundary`; completed work items were `#397`, `#398`, and `#401`. Phase 50 measured before any `task_id` or worker contract is introduced and kept the private-beta launch hub planning-only for now.
 - Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`; completed work items were `#404`, `#405`, and `#406`.
 - Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; completed work items were `#411`, `#412`, and `#413`. Before Phase 53 was opened, `audit-github-queue` reported the formal paused stop-state with no active milestone. The legacy top-level runtime routes audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`; the runtime guard note lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`; Phase 52 did not widen public demo, plugin, Hosted GPT/BYOK, or async contracts and keeps route-derived `worldId` guard coverage in scope.
-- Phase 53 is the active approved successor queue: `Phase 53 - Transfer Generalization and Third-World Readiness`; `audit-github-queue` reports `ready` with `#418` as the blocked exit gate, `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` as the current ready work item, `#419` closed by PR `#422`, and `#421` blocked. Phase 53 focuses on bounded transfer generalization and third-world readiness without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries.
+- Phase 53 is the active approved successor queue: `Phase 53 - Transfer Generalization and Third-World Readiness`; `audit-github-queue` reports `ready` with `#418` as the blocked exit gate, `#421` `Phase 53: add bounded third-world transfer readiness evidence` as the current ready work item, `#419` closed by PR `#422`, and `#420` closed by PR `#423`. Phase 53 focuses on bounded transfer generalization and third-world readiness without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries, and `library-rain` is the current third-world evidence slice.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
-- Fog Harbor remains the canonical demo world; `museum-night` is the minimal transfer world used to prove the pipeline is not single-world-only.
+- Fog Harbor remains the canonical demo world; `museum-night` and `library-rain` are the selected bounded transfer worlds used to prove the pipeline has passed across three selected bounded fictional worlds.
 
 ---
 
@@ -327,7 +333,7 @@ mirror-sim
 ├── backend/          # CLI, pipeline, eval, and automation services
 ├── frontend/         # world-scoped web product plus legacy review/demo surfaces
 ├── data/demo/        # canonical Fog Harbor demo
-├── data/worlds/      # additional bounded worlds such as museum-night
+├── data/worlds/      # additional bounded worlds such as museum-night and library-rain
 ├── docs/             # plans, ADRs, contracts, walkthroughs, release notes
 ├── evals/            # assertions and eval assets
 └── scripts/          # bootstrap and utility scripts

--- a/backend/app/evals/service.py
+++ b/backend/app/evals/service.py
@@ -25,7 +25,7 @@ from backend.app.world_query import inspect_world
 from backend.app.worlds import CANONICAL_DEMO_WORLD_ID, WorldPaths, resolve_world_paths
 
 
-DEFAULT_TRANSFER_WORLD_IDS = [CANONICAL_DEMO_WORLD_ID, "museum-night"]
+DEFAULT_TRANSFER_WORLD_IDS = [CANONICAL_DEMO_WORLD_ID, "museum-night", "library-rain"]
 
 
 def _compare(op: str, left: Any, right: Any) -> bool:

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1185,10 +1185,12 @@ def test_cli_eval_transfer_outputs_json(capsys) -> None:
     payload = json.loads(capsys.readouterr().out)
     assert payload["world_id"] == "transfer"
     assert payload["status"] == "pass"
-    assert payload["metrics"]["tracked_outcome_count"] == 13
-    assert payload["metrics"]["tracked_outcome_fields_covered"] == 13
-    assert payload["metrics"]["compare_outcome_fields_covered"] == 13
-    assert payload["metrics"]["transfer_worlds_with_default_report_delta"] == 2
+    assert payload["metrics"]["world_count"] == 3
+    assert payload["metrics"]["scenario_count"] == 8
+    assert payload["metrics"]["tracked_outcome_count"] == 18
+    assert payload["metrics"]["tracked_outcome_fields_covered"] == 18
+    assert payload["metrics"]["compare_outcome_fields_covered"] == 18
+    assert payload["metrics"]["transfer_worlds_with_default_report_delta"] == 3
     assert payload["metrics"]["transfer_proof_world_local"] is True
 
 

--- a/backend/tests/test_decision_kernel.py
+++ b/backend/tests/test_decision_kernel.py
@@ -224,6 +224,7 @@ def test_product_templates_plus_parameters_resolve_to_world_contracts() -> None:
     product_paths = [
         Path("data/demo/config/product.json"),
         Path("data/worlds/museum-night/config/product.json"),
+        Path("data/worlds/library-rain/config/product.json"),
     ]
 
     for product_path in product_paths:

--- a/backend/tests/test_phase53_successor_gate.py
+++ b/backend/tests/test_phase53_successor_gate.py
@@ -13,7 +13,7 @@ def test_phase53_successor_gate_exists_with_required_sections() -> None:
     required_sections = [
         "# Phase 53 Successor Gate",
         "Issue: `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`",
-        "Current work item: `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`",
+        "Current work item: `#421` `Phase 53: add bounded third-world transfer readiness evidence`",
         "## Phase 52 Closeout Evidence",
         "## Phase 53 Operational Queue",
         "## Transfer-Generalization Scope",
@@ -41,10 +41,12 @@ def test_phase53_successor_gate_records_queue_and_boundaries() -> None:
         "Status: blocked closeout gate for Phase 53.",
         "Status: current ready work item.",
         "Status: closed by PR `#422`.",
-        "Status: blocked until `#420` closes.",
+        "Status: closed by PR `#423`.",
         "Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`",
         "bounded transfer generalization",
         "third-world readiness",
+        "`library-rain`",
+        "`docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`",
         "Do not claim transfer generalization beyond the evidence that has actually passed",
         "Do not use real-world data, real-person personas, or digital doubles",
         "Do not implement a launch hub",
@@ -78,7 +80,9 @@ def test_active_state_docs_point_to_phase53_queue() -> None:
         assert "Phase 53 Successor Gate" in text
         assert "`docs/plans/phase-53-successor-gate-2026-05-19.md`" in text
         assert "Phase 53: audit transfer assumptions and third-world readiness constraints" in text
+        assert "Phase 53: add bounded third-world transfer readiness evidence" in text
         assert "current ready" in text
+        assert "`library-rain`" in text
         assert "bounded transfer generalization" in text
         assert "third-world readiness" in text
         assert "public demo, plugin, Hosted GPT/BYOK, launch hub, async" in text

--- a/backend/tests/test_phase53_third_world_evidence.py
+++ b/backend/tests/test_phase53_third_world_evidence.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+EVIDENCE_NOTE = Path("docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md")
+
+
+def test_phase53_third_world_evidence_note_records_library_rain() -> None:
+    text = EVIDENCE_NOTE.read_text(encoding="utf-8")
+    required_phrases = [
+        "# Phase 53 Third-World Transfer Evidence",
+        "Issue: `#421` `Phase 53: add bounded third-world transfer readiness evidence`",
+        "Current work item: `#421` `Phase 53: add bounded third-world transfer readiness evidence`",
+        "`library-rain`",
+        "original fictional bounded world",
+        "`DEFAULT_TRANSFER_WORLD_IDS`",
+        "`fog-harbor-east-gate`",
+        "`museum-night`",
+        "`library-rain`",
+        "`world_count: 3`",
+        "`tracked_outcome_count: 18`",
+        "`transfer_proof_world_local: true`",
+        "Every report claim must keep both `label` and `evidence_ids`.",
+        "does not change scenario DSL, claim labels, run trace shape, compare artifact shape",
+    ]
+
+    for phrase in required_phrases:
+        assert phrase in text
+
+
+def test_active_docs_point_to_phase53_third_world_evidence() -> None:
+    required_docs = [
+        Path("README.md"),
+        Path("docs/plans/current-state-baseline.md"),
+        Path("docs/plans/phase-53-successor-gate-2026-05-19.md"),
+        Path("docs/plans/phase-execution-queue.md"),
+        Path("docs/plans/automation-roadmap.md"),
+    ]
+
+    for path in required_docs:
+        text = path.read_text(encoding="utf-8")
+        assert "docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md" in text
+        assert "`#421` `Phase 53: add bounded third-world transfer readiness evidence`" in text
+        assert "`library-rain`" in text
+        assert "current ready" in text or "Status: current ready work item." in text
+
+
+def test_phase53_third_world_contract_and_adr_record_reviewed_world_set() -> None:
+    contract = Path("docs/architecture/contracts.md").read_text(encoding="utf-8")
+    adr = Path("docs/decisions/ADR-0012-third-world-transfer-evidence.md").read_text(
+        encoding="utf-8"
+    )
+
+    required_contract_phrases = [
+        "`python -m backend.app.cli eval-transfer` runs the reviewed transfer-world proof",
+        "`fog-harbor-east-gate`",
+        "`museum-night`",
+        "`library-rain`",
+        "three selected bounded fictional worlds",
+        "does not claim future-world readiness",
+    ]
+    required_adr_phrases = [
+        "# ADR-0012: Third-World Transfer Evidence",
+        "- Accepted",
+        "`library-rain`",
+        "original fictional bounded world",
+        "`DEFAULT_TRANSFER_WORLD_IDS`",
+        "`docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`",
+        "does not change scenario DSL, claim labels, run trace shape, compare artifact shape",
+        "does not claim future-world readiness",
+    ]
+
+    for phrase in required_contract_phrases:
+        assert phrase in contract
+    for phrase in required_adr_phrases:
+        assert phrase in adr

--- a/backend/tests/test_phase53_transfer_assumption_audit.py
+++ b/backend/tests/test_phase53_transfer_assumption_audit.py
@@ -15,14 +15,17 @@ def test_phase53_transfer_assumption_audit_records_supported_and_blocked_claims(
     required_phrases = [
         "# Phase 53 Transfer Assumption Audit",
         "Issue: `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`",
-        "Current work item: `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`",
+        "Audit slice: `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`",
+        "Current follow-up: `#421` `Phase 53: add bounded third-world transfer readiness evidence`",
         "## Supported Claims",
-        "Mirror has a two-world transfer proof across `fog-harbor-east-gate` and `museum-night`.",
+        "At `#420` completion, Mirror had a two-world transfer proof across `fog-harbor-east-gate` and `museum-night`.",
         "`eval-transfer` proves Mirror is not single-world-only.",
         "## Blocked Claims",
-        "Do not claim broad transfer readiness beyond the current two-world proof.",
-        "Do not claim third-world readiness before `#421` adds evidence or a reviewed compatibility contract.",
+        "Do not claim broad transfer readiness beyond the reviewed transfer world set.",
+        "Do not claim future-world readiness from `#421`'s `library-rain` evidence.",
         "Do not claim every future world will work without additional contracts.",
+        "## #421 Update",
+        "`library-rain`",
         "## Third-World Readiness Criteria",
         "original, fictional, or explicitly authorized",
         "world-local `config/simulation_rules.yaml`",
@@ -35,13 +38,14 @@ def test_phase53_transfer_assumption_audit_records_supported_and_blocked_claims(
 
 
 def test_transfer_assumption_audit_stays_aligned_with_eval_transfer_defaults() -> None:
-    assert DEFAULT_TRANSFER_WORLD_IDS == [CANONICAL_DEMO_WORLD_ID, "museum-night"]
+    assert DEFAULT_TRANSFER_WORLD_IDS == [CANONICAL_DEMO_WORLD_ID, "museum-night", "library-rain"]
 
     text = AUDIT_NOTE.read_text(encoding="utf-8")
     for world_id in DEFAULT_TRANSFER_WORLD_IDS:
         assert f"`{world_id}`" in text
     assert "DEFAULT_TRANSFER_WORLD_IDS" in text
     assert "two-world proof" in text
+    assert "three selected bounded worlds" in text
     assert "third-world readiness" in text
 
 
@@ -91,12 +95,15 @@ def test_active_docs_point_to_current_phase53_assumption_audit() -> None:
         "`#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` is blocked until `#419` closes.",
         "Status: blocked until `#419` closes.",
         "`#420`/`#421` blocked",
+        "`#421` `Phase 53: add bounded third-world transfer readiness evidence` is blocked until `#420` closes.",
     ]
 
     for path in required_docs:
         text = path.read_text(encoding="utf-8")
         assert "docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md" in text
         assert "`#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`" in text
+        assert "closed by PR `#423`" in text
+        assert "`#421` `Phase 53: add bounded third-world transfer readiness evidence`" in text
         assert "current ready" in text or "Status: current ready work item." in text
         for phrase in stale_phrases:
             assert phrase not in text, f"{path} still treats #420 as blocked: {phrase}"

--- a/backend/tests/test_worlds.py
+++ b/backend/tests/test_worlds.py
@@ -4,7 +4,7 @@ import json
 from dataclasses import replace
 from pathlib import Path
 
-from backend.app.evals.service import evaluate_transfer_world, run_world_eval
+from backend.app.evals.service import DEFAULT_TRANSFER_WORLD_IDS, evaluate_transfer_world, run_world_eval
 from backend.app.simulation.rules import load_simulation_plan
 from backend.app.worlds import CANONICAL_DEMO_WORLD_ID, resolve_world_paths
 
@@ -13,15 +13,31 @@ def _museum_world_paths(artifacts_root: Path):
     return replace(resolve_world_paths("museum-night"), artifacts_root=artifacts_root)
 
 
+def _library_world_paths(artifacts_root: Path):
+    return replace(resolve_world_paths("library-rain"), artifacts_root=artifacts_root)
+
+
+def test_default_transfer_world_set_includes_third_bounded_world() -> None:
+    assert DEFAULT_TRANSFER_WORLD_IDS == [
+        CANONICAL_DEMO_WORLD_ID,
+        "museum-night",
+        "library-rain",
+    ]
+
+
 def test_resolve_world_paths_supports_canonical_and_transfer_world() -> None:
     demo_paths = resolve_world_paths(CANONICAL_DEMO_WORLD_ID)
     museum_paths = resolve_world_paths("museum-night")
+    library_paths = resolve_world_paths("library-rain")
 
     assert demo_paths.data_root.name == "demo"
     assert demo_paths.artifacts_root.name == "demo"
     assert museum_paths.data_root.name == "museum-night"
     assert museum_paths.artifacts_root.name == "museum-night"
     assert museum_paths.simulation_rules_path.name == "simulation_rules.yaml"
+    assert library_paths.data_root.name == "library-rain"
+    assert library_paths.artifacts_root.name == "library-rain"
+    assert library_paths.simulation_rules_path.name == "simulation_rules.yaml"
 
 
 def test_transfer_world_simulation_rules_load() -> None:
@@ -31,11 +47,32 @@ def test_transfer_world_simulation_rules_load() -> None:
     assert plan.default_report_scenario == "checklist_delayed"
     assert len(plan.turn_sequence) == 8
 
+    library_plan = load_simulation_plan(resolve_world_paths("library-rain").simulation_rules_path)
+    assert library_plan.world_id == "library-rain"
+    assert library_plan.compare_id == "scenario_library_rain_matrix"
+    assert library_plan.default_report_scenario == "catalog_delayed"
+    assert len(library_plan.turn_sequence) == 8
+
 
 def test_museum_night_world_eval_passes(tmp_path: Path) -> None:
     result = run_world_eval("museum-night", artifacts_root=tmp_path / "museum-night")
     assert result.status == "pass"
     assert result.world_id == "museum-night"
+    assert result.metrics["scenario_count"] == 2
+    assert result.metrics["tracked_outcome_count"] == 5
+    assert result.metrics["tracked_outcome_fields_covered"] == 5
+    assert result.metrics["compare_outcome_fields_covered"] == 5
+    assert result.metrics["changed_tracked_outcome_count"] >= 1
+    assert result.metrics["default_report_changed_outcome_count"] >= 1
+    assert result.metrics["transfer_proof_world_local"] is True
+    assert Path(result.artifact_paths["report"]).exists()
+    assert Path(result.artifact_paths["eval"]).exists()
+
+
+def test_library_rain_world_eval_passes(tmp_path: Path) -> None:
+    result = run_world_eval("library-rain", artifacts_root=tmp_path / "library-rain")
+    assert result.status == "pass"
+    assert result.world_id == "library-rain"
     assert result.metrics["scenario_count"] == 2
     assert result.metrics["tracked_outcome_count"] == 5
     assert result.metrics["tracked_outcome_fields_covered"] == 5

--- a/data/worlds/library-rain/config/decision_schema.yaml
+++ b/data/worlds/library-rain/config/decision_schema.yaml
@@ -1,0 +1,55 @@
+world_id: library-rain
+schema_version: "2026-04-22"
+allowed_action_types:
+  - inspect
+  - inform
+  - delay
+  - publish
+  - request
+  - hide
+  - move
+timing_tokens:
+  - roof_watch_window
+  - first_route_warning
+  - before_catalog_publication
+  - reading_room_window
+perturbations:
+  - kind: delay_document
+    target_sources:
+      - document
+    actor_sources:
+      - persona
+      - entity
+    timing_tokens:
+      - before_catalog_publication
+    required_parameters:
+      delay_turns: int
+    optional_parameters:
+      cause: str
+  - kind: block_contact
+    target_sources:
+      - persona
+    actor_sources:
+      - persona
+    timing_tokens:
+      - first_route_warning
+    required_parameters: {}
+    optional_parameters:
+      cause: str
+  - kind: resource_failure
+    target_sources:
+      - entity
+    actor_sources:
+      - persona
+      - entity
+    timing_tokens:
+      - roof_watch_window
+    required_parameters:
+      duration_turns: int
+    optional_parameters:
+      cause: str
+decision_kernel:
+  prompt_version: "rule-bounded-v1"
+  max_attempts: 2
+  fallback_strategy: first_legal_choice
+  model_env_var: MIRROR_DECISION_MODEL

--- a/data/worlds/library-rain/config/product.json
+++ b/data/worlds/library-rain/config/product.json
@@ -1,0 +1,152 @@
+{
+  "world_id": "library-rain",
+  "world_name": "Library Rain",
+  "world_name_i18n": {
+    "zh-CN": "雨中图书馆"
+  },
+  "world_summary": "A bounded archive reading-room world where roof-risk evidence, catalog-card timing, and visitor routing compete during a fixed rain archive event.",
+  "world_summary_i18n": {
+    "zh-CN": "一个受约束的档案阅览室世界：屋顶风险证据、目录卡时机和访客动线在固定雨档案活动中相互牵制。"
+  },
+  "baseline_scenario_id": "scenario_library_rain_baseline",
+  "baseline_title": "Baseline Rain Archive Reading Room",
+  "baseline_title_i18n": {
+    "zh-CN": "雨档案阅览室基线"
+  },
+  "baseline_description": "The baseline assumes the catalog cards arrive on time and the archive team can choose a dry reading-room route without extra injected disruption.",
+  "baseline_description_i18n": {
+    "zh-CN": "基线假设目录卡按时到达，档案团队可以在没有额外扰动的情况下选择干燥的阅览室动线。"
+  },
+  "decision_defaults": {
+    "provider": "openai_compatible",
+    "model": ""
+  },
+  "outcome_labels": {
+    "catalog_public_turn": "Catalog publication",
+    "relocation_turn": "Reading-room relocation",
+    "reading_room_status": "Reading-room status",
+    "relocation_triggered": "Relocation trigger",
+    "risk_known_by": "Roof-risk knowledge spread"
+  },
+  "outcome_labels_i18n": {
+    "zh-CN": {
+      "catalog_public_turn": "目录公开",
+      "relocation_turn": "阅览室改道",
+      "reading_room_status": "阅览室状态",
+      "relocation_triggered": "改道触发",
+      "risk_known_by": "屋顶风险知情范围"
+    }
+  },
+  "perturbation_options": [
+    {
+      "key": "catalog_delayed",
+      "title": "Delay the catalog cards",
+      "title_i18n": {
+        "zh-CN": "延迟目录卡"
+      },
+      "description": "Delay the catalog-card tray before it reaches the reading-room handoff.",
+      "description_i18n": {
+        "zh-CN": "让目录卡托盘在进入阅览室交接之前延迟。"
+      },
+      "kind": "Document delay",
+      "kind_i18n": {
+        "zh-CN": "文档延迟"
+      },
+      "target": "Catalog cards",
+      "target_i18n": {
+        "zh-CN": "目录卡"
+      },
+      "timing": "Before catalog publication",
+      "timing_i18n": {
+        "zh-CN": "目录公开之前"
+      },
+      "summary": "Delay the catalog-card tray before it reaches the reading-room handoff.",
+      "summary_i18n": {
+        "zh-CN": "让目录卡托盘晚一点进入阅览室交接。"
+      },
+      "runtime": {
+        "kind": "delay_document",
+        "targetId": "doc_catalog_cards",
+        "actorId": "persona_lina_quill",
+        "timing": "before_catalog_publication",
+        "parameters": {
+          "delay_turns": 2,
+          "cause": "sorting_tray_backlog"
+        }
+      }
+    },
+    {
+      "key": "route_warning_blocked",
+      "title": "Block the first route warning",
+      "title_i18n": {
+        "zh-CN": "阻断第一次动线预警"
+      },
+      "description": "Block the first warning path from the visitor desk to the archive coordinator.",
+      "description_i18n": {
+        "zh-CN": "阻断访客台发往档案协调人的第一条预警路径。"
+      },
+      "kind": "Contact block",
+      "kind_i18n": {
+        "zh-CN": "联系阻断"
+      },
+      "target": "Archive coordinator warning path",
+      "target_i18n": {
+        "zh-CN": "档案协调人预警路径"
+      },
+      "timing": "First route warning",
+      "timing_i18n": {
+        "zh-CN": "第一次动线预警"
+      },
+      "summary": "Block the first route warning toward the archive coordinator.",
+      "summary_i18n": {
+        "zh-CN": "阻断发往档案协调人的第一条动线预警。"
+      },
+      "runtime": {
+        "kind": "block_contact",
+        "targetId": "persona_mara_vale",
+        "actorId": "persona_arun_slate",
+        "timing": "first_route_warning",
+        "parameters": {
+          "cause": "front_desk_signal_gap"
+        }
+      }
+    },
+    {
+      "key": "roof_watch_failure",
+      "title": "Degrade the roof-watch window",
+      "title_i18n": {
+        "zh-CN": "削弱屋顶巡查窗口"
+      },
+      "description": "Create a short communication/resource failure while the north-roof risk is being assessed.",
+      "description_i18n": {
+        "zh-CN": "在北侧屋顶风险评估期间制造一次短暂的通信/资源故障。"
+      },
+      "kind": "Resource failure",
+      "kind_i18n": {
+        "zh-CN": "资源故障"
+      },
+      "target": "North roof",
+      "target_i18n": {
+        "zh-CN": "北侧屋顶"
+      },
+      "timing": "Roof-watch window",
+      "timing_i18n": {
+        "zh-CN": "屋顶巡查窗口"
+      },
+      "summary": "Degrade the north-roof warning window.",
+      "summary_i18n": {
+        "zh-CN": "让北侧屋顶预警窗口变得更脆弱。"
+      },
+      "runtime": {
+        "kind": "resource_failure",
+        "targetId": "entity_north_roof",
+        "actorId": "persona_theo_finch",
+        "timing": "roof_watch_window",
+        "parameters": {
+          "duration_turns": 2,
+          "cause": "rain_line_static"
+        }
+      }
+    }
+  ]
+}

--- a/data/worlds/library-rain/config/simulation_rules.yaml
+++ b/data/worlds/library-rain/config/simulation_rules.yaml
@@ -1,0 +1,225 @@
+world_id: library-rain
+compare_id: scenario_library_rain_matrix
+default_report_scenario: catalog_delayed
+communications_down_field: communications_down_until
+blocked_contacts_field: blocked_contacts
+turn_sequence:
+  - persona_theo_finch
+  - persona_arun_slate
+  - persona_lina_quill
+  - persona_mara_vale
+  - persona_arun_slate
+  - persona_lina_quill
+  - persona_mara_vale
+  - persona_arun_slate
+initial_state:
+  reading_room_status: scheduled
+  catalog_available_turn: 3
+  catalog_public: false
+  catalog_public_turn: null
+  relocation_requested: false
+  relocation_triggered: false
+  relocation_turn: null
+  roof_status: leaking
+  risk_known_by: []
+  communications_status: stable
+  communications_down_until: 0
+  blocked_contacts: []
+tracked_outcomes:
+  - field: catalog_public_turn
+    label: Catalog publication turn
+    action_types:
+      - publish
+  - field: relocation_turn
+    label: Reading-room relocation turn
+    action_types:
+      - move
+  - field: reading_room_status
+    label: Reading-room status
+    action_types:
+      - hide
+      - move
+  - field: relocation_triggered
+    label: Relocation trigger state
+    action_types:
+      - move
+  - field: risk_known_by
+    label: Roof-risk knowledge spread
+    action_types:
+      - inspect
+      - inform
+injection_rules:
+  - kind: delay_document
+    operation: add_int
+    field: catalog_available_turn
+    param: delay_turns
+    note_template: "{injection_id}: catalog cards availability delayed by {delay_turns} turn(s)."
+  - kind: resource_failure
+    operation: max_int
+    field: communications_down_until
+    param: duration_turns
+    note_template: "{injection_id}: archive communications degraded for {duration_turns} turn(s)."
+  - kind: block_contact
+    operation: append_contact
+    field: blocked_contacts
+    note_template: "{injection_id}: contact blocked between {actor_id} and {target_id}."
+steps:
+  - turn_index: 1
+    choices:
+      - action:
+          action_type: inspect
+          target_id: entity_north_roof
+          rationale: Theo Finch inspects the north roof before visitors gather under the reading-room skylight.
+          updates:
+            - kind: union_actor_entity
+              field: risk_known_by
+  - turn_index: 2
+    choices:
+      - when:
+          - kind: communication_available
+            target_id: persona_mara_vale
+        action:
+          action_type: inform
+          target_id: persona_mara_vale
+          rationale: Arun Slate sends the first route warning toward the archive coordinator.
+          updates:
+            - kind: union_actor_entity
+              field: risk_known_by
+      - action:
+          action_type: delay
+          target_id: persona_mara_vale
+          rationale: The visitor-route warning is delayed by a desk communication problem.
+          updates:
+            - kind: set
+              field: communications_status
+              value: degraded
+  - turn_index: 3
+    choices:
+      - when:
+          - kind: turn_gte_state
+            field: catalog_available_turn
+        action:
+          action_type: publish
+          target_id: entity_catalog_cards
+          rationale: Lina Quill publishes the catalog cards into the reading-room handoff.
+          updates:
+            - kind: set
+              field: catalog_public
+              value: true
+            - kind: set_current_turn
+              field: catalog_public_turn
+      - action:
+          action_type: delay
+          target_id: entity_catalog_cards
+          rationale: Lina Quill cannot surface the catalog cards yet and holds the sorting tray.
+  - turn_index: 4
+    choices:
+      - when:
+          - kind: state_truthy
+            field: catalog_public
+        action:
+          action_type: request
+          target_id: entity_reading_room
+          rationale: Mara Vale requests a reading-room relocation once catalog and roof evidence align.
+          updates:
+            - kind: set
+              field: relocation_requested
+              value: true
+      - action:
+          action_type: request
+          target_id: entity_catalog_cards
+          rationale: Mara Vale asks for the missing catalog evidence before moving the public route.
+  - turn_index: 5
+    choices:
+      - when:
+          - kind: state_truthy
+            field: relocation_requested
+        action:
+          action_type: move
+          target_id: entity_reading_room
+          rationale: Arun Slate moves the visitor line into the dry annex route.
+          updates:
+            - kind: set
+              field: relocation_triggered
+              value: true
+            - kind: set_current_turn
+              field: relocation_turn
+            - kind: set
+              field: reading_room_status
+              value: relocated
+      - action:
+          action_type: hide
+          target_id: entity_reading_room
+          rationale: Arun Slate keeps the public reading room scheduled while waiting for firmer evidence.
+          updates:
+            - kind: set
+              field: reading_room_status
+              value: scheduled
+  - turn_index: 6
+    choices:
+      - when:
+          - kind: state_falsy
+            field: catalog_public
+          - kind: turn_gte_state
+            field: catalog_available_turn
+        action:
+          action_type: publish
+          target_id: entity_catalog_cards
+          rationale: Lina Quill surfaces the backup catalog cards after the delay clears.
+          updates:
+            - kind: set
+              field: catalog_public
+              value: true
+            - kind: set_current_turn
+              field: catalog_public_turn
+      - action:
+          action_type: inform
+          target_id: persona_mara_vale
+          rationale: Lina Quill keeps the reading-room team aligned while the cards remain late.
+  - turn_index: 7
+    choices:
+      - when:
+          - kind: state_truthy
+            field: catalog_public
+          - kind: state_falsy
+            field: relocation_requested
+        action:
+          action_type: request
+          target_id: entity_reading_room
+          rationale: Mara Vale renews the relocation request once the catalog cards become visible.
+          updates:
+            - kind: set
+              field: relocation_requested
+              value: true
+      - action:
+          action_type: inspect
+          target_id: entity_north_roof
+          rationale: Mara Vale keeps checking the roof-risk evidence while the public route remains open.
+  - turn_index: 8
+    choices:
+      - when:
+          - kind: state_truthy
+            field: relocation_requested
+          - kind: state_falsy
+            field: relocation_triggered
+        action:
+          action_type: move
+          target_id: entity_reading_room
+          rationale: Arun Slate relocates the reading room at the last dry routing point.
+          updates:
+            - kind: set
+              field: relocation_triggered
+              value: true
+            - kind: set_current_turn
+              field: relocation_turn
+            - kind: set
+              field: reading_room_status
+              value: relocated
+      - action:
+          action_type: hide
+          target_id: entity_reading_room
+          rationale: Arun Slate keeps the scheduled reading-room path after the roof window stabilizes.
+          updates:
+            - kind: set
+              field: reading_room_status
+              value: scheduled

--- a/data/worlds/library-rain/config/world_model.yaml
+++ b/data/worlds/library-rain/config/world_model.yaml
@@ -1,0 +1,419 @@
+world_id: library-rain
+entities:
+  - entity_id: entity_mara_vale
+    name: Mara Vale
+    type: person
+    aliases:
+      - mara vale
+      - archive coordinator
+  - entity_id: entity_theo_finch
+    name: Theo Finch
+    type: person
+    aliases:
+      - theo finch
+      - roof steward
+  - entity_id: entity_lina_quill
+    name: Lina Quill
+    type: person
+    aliases:
+      - lina quill
+      - catalog clerk
+  - entity_id: entity_arun_slate
+    name: Arun Slate
+    type: person
+    aliases:
+      - arun slate
+      - visitor marshal
+      - front desk
+  - entity_id: entity_north_roof
+    name: North Roof
+    type: infrastructure
+    aliases:
+      - north roof
+      - roof leak
+      - drip line
+  - entity_id: entity_catalog_cards
+    name: Catalog Cards
+    type: document
+    aliases:
+      - catalog cards
+      - card index
+      - sorting tray
+  - entity_id: entity_reading_room
+    name: Public Reading Room
+    type: location
+    aliases:
+      - public reading room
+      - reading room
+      - dry annex
+  - entity_id: entity_visitor_line
+    name: Visitor Line
+    type: event
+    aliases:
+      - visitor line
+      - route board
+      - north aisle
+
+relations:
+  - relation_id: relation_theo_inspects_roof
+    source_entity_id: entity_theo_finch
+    relation_type: inspects
+    target_entity_id: entity_north_roof
+    match:
+      all:
+        - theo finch
+        - north roof
+      any:
+        - roof leak
+        - drip line
+        - inspected
+  - relation_id: relation_lina_controls_catalog
+    source_entity_id: entity_lina_quill
+    relation_type: controls
+    target_entity_id: entity_catalog_cards
+    match:
+      all:
+        - lina quill
+        - catalog cards
+      any:
+        - sorting tray
+        - card index
+        - publish
+  - relation_id: relation_mara_protects_room
+    source_entity_id: entity_mara_vale
+    relation_type: protects
+    target_entity_id: entity_reading_room
+    match:
+      all:
+        - mara vale
+      any:
+        - public reading room
+        - reading night
+        - stay open
+  - relation_id: relation_arun_manages_line
+    source_entity_id: entity_arun_slate
+    relation_type: manages
+    target_entity_id: entity_visitor_line
+    match:
+      all:
+        - arun slate
+        - visitor line
+      any:
+        - front desk
+        - route board
+        - dry annex
+
+events:
+  - event_id: event_roof_leak
+    name: North Roof Leak Narrows The Reading-Room Window
+    kind: facilities_risk
+    participant_entity_ids:
+      - entity_theo_finch
+      - entity_north_roof
+      - entity_reading_room
+    match:
+      any:
+        - north roof leak
+        - roof leak
+        - drip line
+        - rainwater
+  - event_id: event_catalog_delay
+    name: Catalog Card Delay Slows Visitor Routing
+    kind: document_delay
+    participant_entity_ids:
+      - entity_lina_quill
+      - entity_catalog_cards
+      - entity_reading_room
+    match:
+      any:
+        - catalog cards
+        - sorting tray
+        - card index
+        - arrive late
+  - event_id: event_reading_room_pressure
+    name: Reading Night Pressure Keeps The Room Scheduled
+    kind: schedule_pressure
+    participant_entity_ids:
+      - entity_mara_vale
+      - entity_reading_room
+      - entity_visitor_line
+    match:
+      any:
+        - rain archive reading
+        - reading night
+        - public reading room
+        - stay open
+  - event_id: event_route_bottleneck
+    name: Visitor Line Bottleneck Raises A Relocation Decision
+    kind: route_pressure
+    participant_entity_ids:
+      - entity_arun_slate
+      - entity_visitor_line
+      - entity_reading_room
+      - entity_north_roof
+    match:
+      any:
+        - visitor line
+        - route board
+        - north aisle
+        - dry annex
+
+personas:
+  - persona_id: persona_mara_vale
+    entity_id: entity_mara_vale
+    public_role:
+      text: Archive coordinator responsible for the rain archive reading.
+      evidence:
+        entity_ids:
+          - entity_mara_vale
+          - entity_reading_room
+        relation_ids:
+          - relation_mara_protects_room
+    goals:
+      - text: Keep the reading night credible without routing visitors under avoidable roof risk.
+        evidence:
+          event_ids:
+            - event_reading_room_pressure
+            - event_route_bottleneck
+      - text: Get a clear signal about whether the roof leak and catalog delay justify relocation.
+        evidence:
+          event_ids:
+            - event_roof_leak
+            - event_catalog_delay
+    constraints:
+      - text: Depends on Theo Finch, Lina Quill, and Arun Slate for operational truth.
+        evidence:
+          relation_ids:
+            - relation_theo_inspects_roof
+            - relation_lina_controls_catalog
+            - relation_arun_manages_line
+      - text: Faces pressure to keep the public reading room scheduled.
+        evidence:
+          event_ids:
+            - event_reading_room_pressure
+    known_facts:
+      - text: The reading night memo assumes the public reading room can open on time.
+        evidence:
+          event_ids:
+            - event_reading_room_pressure
+      - text: A visitor-line reroute would visibly change the reading-room plan.
+        evidence:
+          event_ids:
+            - event_route_bottleneck
+    private_info:
+      - text: Mara Vale will accept relocation if catalog and roof evidence line up clearly enough.
+        evidence:
+          event_ids:
+            - event_roof_leak
+            - event_catalog_delay
+    relationships:
+      - target_id: persona_arun_slate
+        kind: relies_on
+        evidence:
+          relation_ids:
+            - relation_arun_manages_line
+          event_ids:
+            - event_route_bottleneck
+      - target_id: persona_theo_finch
+        kind: trusts
+        evidence:
+          relation_ids:
+            - relation_theo_inspects_roof
+          event_ids:
+            - event_roof_leak
+
+  - persona_id: persona_theo_finch
+    entity_id: entity_theo_finch
+    public_role:
+      text: Roof steward watching the north roof before the public reading begins.
+      evidence:
+        entity_ids:
+          - entity_theo_finch
+          - entity_north_roof
+        relation_ids:
+          - relation_theo_inspects_roof
+    goals:
+      - text: Keep visitors out from under the roof leak before the rain archive reading fills.
+        evidence:
+          event_ids:
+            - event_roof_leak
+            - event_route_bottleneck
+      - text: Make the roof warning visible before the route board locks in.
+        evidence:
+          event_ids:
+            - event_roof_leak
+            - event_reading_room_pressure
+    constraints:
+      - text: Can inspect the roof leak but cannot relocate the reading room alone.
+        evidence:
+          relation_ids:
+            - relation_theo_inspects_roof
+          event_ids:
+            - event_roof_leak
+      - text: Needs catalog and route evidence before the relocation becomes credible.
+        evidence:
+          event_ids:
+            - event_catalog_delay
+            - event_route_bottleneck
+    known_facts:
+      - text: The north roof drip line is crossing the north aisle.
+        evidence:
+          event_ids:
+            - event_roof_leak
+      - text: A delayed catalog handoff would keep visitors near the damp route longer.
+        evidence:
+          event_ids:
+            - event_catalog_delay
+            - event_route_bottleneck
+    private_info:
+      - text: Theo Finch believes the leak can stay bounded if visitors move before the long queue forms.
+        evidence:
+          event_ids:
+            - event_roof_leak
+            - event_route_bottleneck
+    relationships:
+      - target_id: persona_mara_vale
+        kind: warns
+        evidence:
+          relation_ids:
+            - relation_mara_protects_room
+          event_ids:
+            - event_reading_room_pressure
+      - target_id: persona_arun_slate
+        kind: coordinates_with
+        evidence:
+          relation_ids:
+            - relation_arun_manages_line
+          event_ids:
+            - event_route_bottleneck
+
+  - persona_id: persona_lina_quill
+    entity_id: entity_lina_quill
+    public_role:
+      text: Catalog clerk carrying the card index into the reading-room handoff.
+      evidence:
+        entity_ids:
+          - entity_lina_quill
+          - entity_catalog_cards
+        relation_ids:
+          - relation_lina_controls_catalog
+    goals:
+      - text: Publish the catalog cards before visitors need a route explanation.
+        evidence:
+          event_ids:
+            - event_catalog_delay
+            - event_route_bottleneck
+      - text: Keep the catalog sequence useful if the reading room moves to the dry annex.
+        evidence:
+          event_ids:
+            - event_catalog_delay
+            - event_reading_room_pressure
+    constraints:
+      - text: Depends on the sorting tray before she can publish the card index.
+        evidence:
+          relation_ids:
+            - relation_lina_controls_catalog
+          event_ids:
+            - event_catalog_delay
+      - text: Has no authority to move the visitor route without Mara Vale.
+        evidence:
+          event_ids:
+            - event_reading_room_pressure
+            - event_route_bottleneck
+    known_facts:
+      - text: The catalog cards explain which boxes can move to the dry annex.
+        evidence:
+          event_ids:
+            - event_catalog_delay
+      - text: The front desk needs the card index before the route board changes.
+        evidence:
+          event_ids:
+            - event_catalog_delay
+            - event_route_bottleneck
+    private_info:
+      - text: Lina Quill has a backup card order if the sorting tray clears late.
+        evidence:
+          relation_ids:
+            - relation_lina_controls_catalog
+          event_ids:
+            - event_catalog_delay
+    relationships:
+      - target_id: persona_mara_vale
+        kind: briefs
+        evidence:
+          relation_ids:
+            - relation_mara_protects_room
+            - relation_lina_controls_catalog
+          event_ids:
+            - event_reading_room_pressure
+      - target_id: persona_arun_slate
+        kind: coordinates_with
+        evidence:
+          relation_ids:
+            - relation_arun_manages_line
+          event_ids:
+            - event_route_bottleneck
+
+  - persona_id: persona_arun_slate
+    entity_id: entity_arun_slate
+    public_role:
+      text: Visitor marshal managing the route board and front-desk line.
+      evidence:
+        entity_ids:
+          - entity_arun_slate
+          - entity_visitor_line
+        relation_ids:
+          - relation_arun_manages_line
+    goals:
+      - text: Move the visitor line before the north aisle becomes crowded.
+        evidence:
+          event_ids:
+            - event_route_bottleneck
+            - event_roof_leak
+      - text: Surface the route change without overruling the archive coordinator.
+        evidence:
+          event_ids:
+            - event_route_bottleneck
+            - event_reading_room_pressure
+    constraints:
+      - text: Needs a credible reason before changing the public route board.
+        evidence:
+          event_ids:
+            - event_route_bottleneck
+            - event_reading_room_pressure
+      - text: Can move the route but cannot publish catalog evidence.
+        evidence:
+          relation_ids:
+            - relation_lina_controls_catalog
+            - relation_arun_manages_line
+    known_facts:
+      - text: The visitor line will pause under the north aisle if the board stays unchanged.
+        evidence:
+          event_ids:
+            - event_route_bottleneck
+      - text: The dry annex route becomes easier to explain once catalog cards are public.
+        evidence:
+          event_ids:
+            - event_catalog_delay
+            - event_route_bottleneck
+    private_info:
+      - text: Arun Slate prepared a quiet annex route in case the roof warning becomes public.
+        evidence:
+          event_ids:
+            - event_route_bottleneck
+            - event_roof_leak
+    relationships:
+      - target_id: persona_mara_vale
+        kind: reports_to
+        evidence:
+          relation_ids:
+            - relation_mara_protects_room
+          event_ids:
+            - event_reading_room_pressure
+      - target_id: persona_lina_quill
+        kind: coordinates_with
+        evidence:
+          relation_ids:
+            - relation_lina_controls_catalog
+          event_ids:
+            - event_catalog_delay

--- a/data/worlds/library-rain/corpus/docs/catalog_cards.md
+++ b/data/worlds/library-rain/corpus/docs/catalog_cards.md
@@ -1,0 +1,12 @@
+# Catalog Card Sorting Note
+
+Lina Quill records that the catalog cards are still in the sorting tray beside the
+catalog table. The card index is the only compact guide that tells visitors which
+boxes can move to the dry annex without losing the reading order.
+
+Lina Quill can publish the catalog cards once the sorting tray clears. If the cards
+arrive late, the public reading room relocation will lack a clean explanation for
+visitors already waiting near the north aisle.
+
+The catalog-card note asks Mara Vale to wait for the card index before changing the
+route.

--- a/data/worlds/library-rain/corpus/docs/operations_board.md
+++ b/data/worlds/library-rain/corpus/docs/operations_board.md
@@ -1,0 +1,12 @@
+# Archive Operations Board Summary
+
+The operations board ties together the rain archive reading, north roof leak,
+catalog cards, and visitor line.
+
+Mara Vale protects the public reading room schedule but will move the event if
+Theo Finch confirms the north roof risk and Lina Quill publishes the catalog cards.
+Arun Slate manages the visitor line and can move the route board to the dry annex.
+
+The board says the safest signal is a shared route update: roof watch, catalog card
+handoff, and visitor line reroute should become visible before the first long queue
+forms at the front desk.

--- a/data/worlds/library-rain/corpus/docs/program_memo.md
+++ b/data/worlds/library-rain/corpus/docs/program_memo.md
@@ -1,0 +1,11 @@
+# Program Memo For The Rain Archive Reading
+
+Mara Vale wants the public reading room to stay open for the rain archive reading
+night, but only if the visitor route can stay dry enough for the front desk.
+
+The memo says the reading night depends on catalog cards reaching the public handoff
+before visitors enter the north aisle. Mara Vale asks Theo Finch, Lina Quill, and
+Arun Slate to keep the route board current before the first visitor line forms.
+
+The public reading room can move to the dry annex if the north roof leak and catalog
+cards point to the same risk window.

--- a/data/worlds/library-rain/corpus/docs/roof_watch.md
+++ b/data/worlds/library-rain/corpus/docs/roof_watch.md
@@ -1,0 +1,12 @@
+# North Roof Watch Log
+
+Theo Finch inspected the north roof after the roof leak widened along the skylight
+drip line. The north roof seam is not failing, but rainwater is crossing the old
+plaster channel faster than the reading-room mats can absorb.
+
+Theo Finch notes that the drip line sits above the north aisle where the visitor
+line would pause before the archive reading. If the catalog cards are late, the
+visitor route will wait under the damp patch for too long.
+
+The roof watch log recommends one more inspection before the public reading room
+opens.

--- a/data/worlds/library-rain/corpus/docs/visitor_route.md
+++ b/data/worlds/library-rain/corpus/docs/visitor_route.md
@@ -1,0 +1,11 @@
+# Visitor Route Desk Note
+
+Arun Slate watches the visitor line at the front desk while the rain archive reading
+opens. The route board currently points guests through the north aisle, but the
+visitor line can move to the dry annex if the roof warning becomes official.
+
+Arun Slate says the visitor line must not pause under the north roof drip line.
+The front desk can redirect the route once Mara Vale requests a reading-room move.
+
+The desk note keeps the public reading room scheduled until catalog cards and roof
+evidence line up.

--- a/data/worlds/library-rain/corpus/manifest.yaml
+++ b/data/worlds/library-rain/corpus/manifest.yaml
@@ -1,0 +1,43 @@
+world_id: library-rain
+title: Library Rain Reading Room Review
+docs:
+  - document_id: doc_program_memo
+    title: Program Memo For The Rain Archive Reading
+    kind: memo
+    path: docs/program_memo.md
+    created_at: "1913-03-18T15:10:00Z"
+    metadata:
+      author: mara_vale
+      channel: archive_office
+  - document_id: doc_roof_watch
+    title: North Roof Watch Log
+    kind: facilities_log
+    path: docs/roof_watch.md
+    created_at: "1913-03-18T16:05:00Z"
+    metadata:
+      author: theo_finch
+      channel: roof_desk
+  - document_id: doc_catalog_cards
+    title: Catalog Card Sorting Note
+    kind: catalog_note
+    path: docs/catalog_cards.md
+    created_at: "1913-03-18T16:35:00Z"
+    metadata:
+      author: lina_quill
+      channel: catalog_table
+  - document_id: doc_visitor_route
+    title: Visitor Route Desk Note
+    kind: route_note
+    path: docs/visitor_route.md
+    created_at: "1913-03-18T17:00:00Z"
+    metadata:
+      author: arun_slate
+      channel: front_desk
+  - document_id: doc_operations_board
+    title: Archive Operations Board Summary
+    kind: operations_note
+    path: docs/operations_board.md
+    created_at: "1913-03-18T17:20:00Z"
+    metadata:
+      author: evening_manager
+      channel: operations_board

--- a/data/worlds/library-rain/scenarios/baseline.yaml
+++ b/data/worlds/library-rain/scenarios/baseline.yaml
@@ -1,0 +1,14 @@
+scenario_id: scenario_library_rain_baseline
+world_id: library-rain
+title: Baseline Rain Archive Reading Room
+description: >
+  The baseline branch assumes the catalog cards reach Lina Quill on time and the
+  archive team can choose a dry reading-room route without extra injected disruption.
+seed: 17
+turn_budget: 8
+branch_count: 1
+evaluation_questions:
+  - Who gathers enough roof-risk evidence to justify relocating the reading room?
+  - Do the catalog cards surface before Arun Slate commits to the visitor route?
+  - Is the reading room relocated before the visitor line reaches the damp north aisle?
+injections: []

--- a/data/worlds/library-rain/scenarios/catalog_delayed.yaml
+++ b/data/worlds/library-rain/scenarios/catalog_delayed.yaml
@@ -1,0 +1,24 @@
+scenario_id: scenario_library_rain_catalog_delayed
+world_id: library-rain
+title: Catalog Delay Pushes The Reading-Room Move Back
+description: >
+  The catalog-card tray slips behind the front-desk handoff, so Lina Quill cannot
+  publish the catalog evidence on the baseline turn and the relocation decision arrives later.
+seed: 17
+turn_budget: 8
+branch_count: 1
+evaluation_questions:
+  - How much later do the catalog cards surface?
+  - Does the delayed catalog postpone the reading-room relocation?
+  - Which action chain keeps the public reading path scheduled longest?
+injections:
+  - injection_id: inj_catalog_delayed
+    kind: delay_document
+    target_id: doc_catalog_cards
+    actor_id: persona_lina_quill
+    params:
+      delay_turns: 2
+      cause: sorting_tray_backlog
+    rationale: >
+      The catalog-card tray arrives two turns late, so the catalog clerk cannot put
+      the visitor route evidence into circulation on the baseline turn.

--- a/docs/architecture/contracts.md
+++ b/docs/architecture/contracts.md
@@ -564,7 +564,9 @@ artifacts/worlds/<world_id>/
 
 - `python -m backend.app.cli eval-demo` remains the canonical Fog Harbor regression command.
 - `python -m backend.app.cli eval-world --world <world_id>` runs the bounded world pipeline plus transfer eval for one world.
-- `python -m backend.app.cli eval-transfer` runs the dual-world transfer proof across the canonical demo and the current second world.
+- `python -m backend.app.cli eval-transfer` runs the reviewed transfer-world proof across the canonical demo and current bounded transfer worlds.
+  The current default reviewed set is `fog-harbor-east-gate`, `museum-night`, and `library-rain`.
+  This proves the pipeline has passed across three selected bounded fictional worlds; it does not claim future-world readiness.
 - Transfer eval summaries must include:
   - `world_id`
   - `scenario_count`

--- a/docs/decisions/ADR-0012-third-world-transfer-evidence.md
+++ b/docs/decisions/ADR-0012-third-world-transfer-evidence.md
@@ -1,0 +1,46 @@
+# ADR-0012: Third-World Transfer Evidence
+
+## Status
+
+- Accepted
+
+## Context
+
+ADR-0005 ratified the two-world transfer contract: `eval-transfer` had to pass both the
+canonical Fog Harbor demo and `museum-night` before Mirror could claim it was not
+single-world-only.
+
+Phase 53 issue `#420` then audited the transfer language and recorded that the two-world
+proof was still not third-world readiness. Phase 53 issue `#421` chooses the evidence path:
+add a small original fictional bounded world and keep the proof world-local instead of making
+a broad transfer claim.
+
+## Decision
+
+- Add `library-rain` as the third original fictional bounded world.
+- Extend `DEFAULT_TRANSFER_WORLD_IDS` to:
+  - `fog-harbor-east-gate`
+  - `museum-night`
+  - `library-rain`
+- Keep each selected world's data under its reviewed world root:
+  - canonical Fog Harbor data remains under `data/demo/`
+  - `museum-night` remains under `data/worlds/museum-night/`
+  - `library-rain` lives under `data/worlds/library-rain/`
+- Keep the transfer proof rule-driven and world-local:
+  - tracked outcomes come from each world's `config/simulation_rules.yaml`
+  - default report scenarios stay world-local
+  - report claims must keep both `label` and `evidence_ids`
+- Record the Phase 53 evidence slice in
+  `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`.
+- This decision does not change scenario DSL, claim labels, run trace shape, compare artifact shape,
+  session/node manifest shape, public demo artifact layout, or plugin MCP contract.
+
+## Consequences
+
+- `eval-transfer` now proves the deterministic ingest, graph, persona, scenario, run, compare,
+  report, and eval pipeline across three selected bounded fictional worlds.
+- The proof is stronger than ADR-0005's two-world minimum, but it does not claim future-world readiness.
+- Public demo, plugin, Hosted GPT/BYOK, launch hub, async runtime, and runtime mutation boundaries
+  remain unchanged.
+- Future transfer claims still need either more reviewed bounded worlds or a separate compatibility
+  contract before claiming broader generalization.

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -183,9 +183,9 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - milestone `Phase 53 - Transfer Generalization and Third-World Readiness` is open.
 - `#418` `Phase 53 exit gate` is open, blocked, and protected-core.
 - `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate` is closed by PR `#422`.
-- `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` is the current ready Phase 53 transfer-assumption audit.
-- `#421` `Phase 53: add bounded third-world transfer readiness evidence` is blocked until `#420` closes.
-- Phase 53 focuses on bounded transfer generalization and third-world readiness without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries. The active Phase 53 Successor Gate lives in `docs/plans/phase-53-successor-gate-2026-05-19.md`; the current transfer-assumption audit lives in `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`.
+- `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` is closed by PR `#423`.
+- `#421` `Phase 53: add bounded third-world transfer readiness evidence` is the current ready Phase 53 transfer evidence work item and records `library-rain`.
+- Phase 53 focuses on bounded transfer generalization and third-world readiness without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries. The active Phase 53 Successor Gate lives in `docs/plans/phase-53-successor-gate-2026-05-19.md`; the transfer-assumption audit lives in `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`; the current third-world evidence note lives in `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -286,12 +286,13 @@ This note records the active Phase 53 transfer-generalization successor queue af
   - `gh issue list --milestone "Phase 53 - Transfer Generalization and Third-World Readiness" --state all`
     - `#418` `Phase 53 exit gate` is `open`, `blocked`, and `lane:protected-core`
     - `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate` is `closed` by PR `#422`
-    - `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` is the current ready Phase 53 protected-core work item
-    - `#421` `Phase 53: add bounded third-world transfer readiness evidence` is `open` and `blocked`
+    - `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` is `closed` by PR `#423`
+    - `#421` `Phase 53: add bounded third-world transfer readiness evidence` is the current ready Phase 53 protected-core work item
   - Phase 53 Successor Gate:
     - Phase 53 - Transfer Generalization and Third-World Readiness is the active approved successor queue
     - `docs/plans/phase-53-successor-gate-2026-05-19.md` records the active gate note
-    - `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md` records the current transfer assumption audit
+    - `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md` records the completed transfer assumption audit
+    - `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md` records the current `library-rain` third-world evidence slice
     - Phase 53 focuses on bounded transfer generalization and third-world readiness
     - public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries remain unchanged
 
@@ -347,11 +348,12 @@ This note records the active Phase 53 transfer-generalization successor queue af
 - The Phase 52 Legacy Top-Level Runtime Route Audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`.
 - The Phase 52 Runtime Mutation Guard Regression Baseline note lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md` and keeps route-derived `worldId` guard coverage in scope.
 - `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate` is closed by PR `#422`.
-- `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` is the current ready Phase 53 transfer-assumption audit.
-- `#421` `Phase 53: add bounded third-world transfer readiness evidence` is blocked until `#420` closes.
+- `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` is closed by PR `#423`.
+- `#421` `Phase 53: add bounded third-world transfer readiness evidence` is the current ready Phase 53 transfer evidence work item.
 - Phase 53 focuses on bounded transfer generalization and third-world readiness without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries.
 - The active Phase 53 Successor Gate lives in `docs/plans/phase-53-successor-gate-2026-05-19.md`.
 - The current Phase 53 Transfer Assumption Audit lives in `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`.
+- The current Phase 53 Third-World Transfer Evidence note lives in `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md` and records `library-rain`.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.
@@ -366,6 +368,7 @@ This note records the active Phase 53 transfer-generalization successor queue af
 - The completed Phase 52 successor-gate baseline lives in `docs/plans/phase-52-successor-gate-2026-05-18.md`.
 - The active Phase 53 successor-gate baseline lives in `docs/plans/phase-53-successor-gate-2026-05-19.md`.
 - The current Phase 53 transfer-assumption audit baseline lives in `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`.
+- The current Phase 53 third-world evidence baseline lives in `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md` and records `library-rain`.
 - Local untracked private-beta, kernel, and design-system planning files under `docs/plans/...` are candidate inputs only until a PR intentionally promotes them.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.

--- a/docs/plans/phase-53-successor-gate-2026-05-19.md
+++ b/docs/plans/phase-53-successor-gate-2026-05-19.md
@@ -4,7 +4,7 @@ Date: 2026-05-19
 
 Issue: `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`
 
-Current work item: `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`
+Current work item: `#421` `Phase 53: add bounded third-world transfer readiness evidence`
 
 This note records the post-Phase-52 baseline and the Phase 53 successor queue. Phase 53
 is a protected-core transfer-generalization and third-world readiness phase. It opens a
@@ -47,17 +47,18 @@ Active GitHub objects:
   - Scope: sync durable docs and tests to the active Phase 53 queue.
 - `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`
   - Lane: `protected-core`.
-  - Status: current ready work item.
+  - Status: closed by PR `#423`.
   - Scope: define allowed and blocked transfer-readiness claims before adding evidence.
   - Audit note: `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`.
 - `#421` `Phase 53: add bounded third-world transfer readiness evidence`
   - Lane: `protected-core`.
-  - Status: blocked until `#420` closes.
-  - Scope: add bounded third-world readiness evidence or ratify a stronger compatibility contract.
+  - Status: current ready work item.
+  - Scope: add bounded third-world readiness evidence through `library-rain` or ratify a stronger compatibility contract.
+  - Evidence note: `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`.
 
 `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
 with Phase 53 as the only open milestone, `#418` as the protected blocked exit gate, and
-`#420` as the current ready work item.
+`#421` as the current ready work item.
 
 ## Transfer-Generalization Scope
 
@@ -69,7 +70,8 @@ Phase 53 starts from the existing transfer assumption inventory in
 `docs/plans/phase-49-transfer-assumption-inventory-2026-05-18.md`. It keeps Fog Harbor as
 the canonical demo world and museum-night as the minimal transfer world while defining
 what evidence is needed for a third bounded world or an explicitly reviewed compatibility
-contract.
+contract. `#421` adds `library-rain` as the third original fictional bounded world and
+records the evidence in `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`.
 
 Do not claim transfer generalization beyond the evidence that has actually passed.
 Any third-world evidence must use original, fictional, or explicitly authorized data and
@@ -119,13 +121,14 @@ public demo artifact layout, or the Mirror Codex MCP contract.
    - Audit `eval-transfer` and existing transfer assumption language.
    - Record allowed transfer-readiness claims, blocked claims, and evidence gaps.
    - Keep transfer language evidence-bounded and world-bounded.
-   - Current audit note: `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`.
+   - Completed audit note: `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`.
 
 3. Bounded third-world transfer readiness evidence
    - Add a small original/fictional third-world readiness slice or document a reviewed
      compatibility-contract alternative.
    - Strengthen eval/report coverage only within the ratified contracts.
    - Preserve claim/evidence integrity.
+   - Current evidence note: `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`.
 
 ## Blueprint Boundary
 
@@ -158,18 +161,18 @@ Phase 53 must stay aligned with `mirror.md` and `AGENTS.md`:
   plugin MCP contract.
 - Do not redirect or delete legacy top-level runtime routes in Phase 53 unless a separate
   reviewed migration work item first changes that posture.
-- Do not claim third-world readiness before the third-world evidence or compatibility
-  contract has passed review and validation.
+- Do not claim readiness beyond the three selected bounded fictional worlds before additional
+  evidence or a compatibility contract has passed review and validation.
 
 ## Validation Commands
 
-For `#420`, run:
+For `#421`, run:
 
 ```powershell
-python -m pytest backend/tests/test_phase53_transfer_assumption_audit.py backend/tests/test_phase53_successor_gate.py -q
+python -m pytest backend/tests/test_worlds.py backend/tests/test_cli.py::test_cli_eval_transfer_outputs_json backend/tests/test_decision_kernel.py::test_product_templates_plus_parameters_resolve_to_world_contracts backend/tests/test_phase53_third_world_evidence.py backend/tests/test_phase53_transfer_assumption_audit.py backend/tests/test_phase53_successor_gate.py -q
 python scripts/check_no_secrets.py
 python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
-python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-53-successor-gate-2026-05-19.md docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md backend/tests/test_phase53_successor_gate.py backend/tests/test_phase53_transfer_assumption_audit.py
+python -m backend.app.cli classify-lane --files README.md docs/architecture/contracts.md docs/decisions/ADR-0012-third-world-transfer-evidence.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-53-successor-gate-2026-05-19.md docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md backend/app/evals/service.py backend/tests/test_cli.py backend/tests/test_decision_kernel.py backend/tests/test_phase53_successor_gate.py backend/tests/test_phase53_third_world_evidence.py backend/tests/test_phase53_transfer_assumption_audit.py backend/tests/test_worlds.py data/worlds/library-rain/config/decision_schema.yaml data/worlds/library-rain/config/product.json data/worlds/library-rain/config/simulation_rules.yaml data/worlds/library-rain/config/world_model.yaml data/worlds/library-rain/corpus/manifest.yaml data/worlds/library-rain/scenarios/baseline.yaml data/worlds/library-rain/scenarios/catalog_delayed.yaml
 git diff --check
 ./make.ps1 test
 ./make.ps1 eval-demo

--- a/docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md
+++ b/docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md
@@ -1,0 +1,87 @@
+# Phase 53 Third-World Transfer Evidence
+
+Date: 2026-05-19
+
+Issue: `#421` `Phase 53: add bounded third-world transfer readiness evidence`
+
+Current work item: `#421` `Phase 53: add bounded third-world transfer readiness evidence`
+
+This note records the Phase 53 third-world evidence slice. The slice adds `library-rain`
+as an original fictional bounded world and extends `DEFAULT_TRANSFER_WORLD_IDS` to:
+
+- `fog-harbor-east-gate`
+- `museum-night`
+- `library-rain`
+
+The resulting proof says Mirror has passed across three selected bounded fictional worlds.
+It does not claim broad transfer readiness, future-world readiness, real-world prediction,
+real-person persona readiness, or launch/runtime/plugin readiness.
+
+## Evidence Slice
+
+- `data/worlds/library-rain/` is a small fictional archive reading-room world.
+- `config/simulation_rules.yaml` defines the world-local turn sequence, tracked outcomes,
+  bounded injection effects, and default report scenario.
+- `scenarios/baseline.yaml` and `scenarios/catalog_delayed.yaml` provide the two reviewed
+  branches for the third world.
+- `corpus/manifest.yaml` and `corpus/docs/*.md` provide original fictional source material.
+- `config/product.json` keeps product-facing perturbation templates aligned with the
+  world-local decision schema.
+
+Tracked `library-rain` outcomes:
+
+- `catalog_public_turn`
+- `relocation_turn`
+- `reading_room_status`
+- `relocation_triggered`
+- `risk_known_by`
+
+Expected aggregate `eval-transfer` evidence after the third world is included:
+
+- `world_count: 3`
+- `scenario_count: 8`
+- `tracked_outcome_count: 18`
+- `transfer_worlds_with_default_report_delta: 3`
+- `transfer_proof_world_local: true`
+
+Every report claim must keep both `label` and `evidence_ids`.
+
+## Contract Boundary
+
+This slice updates the reviewed transfer-world set and records that durable change in
+`docs/architecture/contracts.md` and `docs/decisions/ADR-0012-third-world-transfer-evidence.md`.
+
+It does not change scenario DSL, claim labels, run trace shape, compare artifact shape,
+session/node manifest shape, public demo artifact layout, plugin MCP contract, public/private
+routes, Hosted GPT/BYOK behavior, async runtime, or runtime mutation behavior.
+
+## Claim Boundary
+
+Allowed wording:
+
+- Mirror has passed the deterministic pipeline across three selected bounded fictional worlds.
+- `eval-transfer` is still evidence-bounded and world-local.
+- `library-rain` adds third-world evidence for the current reviewed transfer set.
+
+Blocked wording:
+
+- Mirror is broadly transfer-ready.
+- Mirror works for future worlds without additional review.
+- Transfer eval proves real-world prediction, real-person persona readiness, public launch hub
+  readiness, plugin write readiness, Hosted GPT/BYOK readiness, async runtime readiness, or
+  mutating runtime API readiness.
+
+## Validation Commands
+
+For this evidence slice, run:
+
+```powershell
+python -m pytest backend/tests/test_worlds.py backend/tests/test_cli.py::test_cli_eval_transfer_outputs_json backend/tests/test_decision_kernel.py::test_product_templates_plus_parameters_resolve_to_world_contracts backend/tests/test_phase53_third_world_evidence.py backend/tests/test_phase53_transfer_assumption_audit.py backend/tests/test_phase53_successor_gate.py -q
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+python -m backend.app.cli classify-lane --files README.md docs/architecture/contracts.md docs/decisions/ADR-0012-third-world-transfer-evidence.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-53-successor-gate-2026-05-19.md docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md backend/app/evals/service.py backend/tests/test_cli.py backend/tests/test_decision_kernel.py backend/tests/test_phase53_successor_gate.py backend/tests/test_phase53_third_world_evidence.py backend/tests/test_phase53_transfer_assumption_audit.py backend/tests/test_worlds.py data/worlds/library-rain/config/decision_schema.yaml data/worlds/library-rain/config/product.json data/worlds/library-rain/config/simulation_rules.yaml data/worlds/library-rain/config/world_model.yaml data/worlds/library-rain/corpus/manifest.yaml data/worlds/library-rain/scenarios/baseline.yaml data/worlds/library-rain/scenarios/catalog_delayed.yaml
+git diff --check
+./make.ps1 test
+./make.ps1 eval-demo
+./make.ps1 eval-transfer
+```

--- a/docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md
+++ b/docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md
@@ -4,15 +4,16 @@ Date: 2026-05-19
 
 Issue: `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`
 
-Current work item: `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`
+Audit slice: `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`
 
-This note records the evidence-bounded transfer posture before Phase 53 adds any third-world
-readiness evidence. It audits the current `eval-transfer` proof, identifies what Mirror may
-and may not claim, and defines the criteria that `#421` or a reviewed compatibility-contract
-alternative must satisfy. It does not add the third world, change schema, change scenario DSL,
-change claim labels, change run trace shape, change compare artifact shape, change session/node manifest shape,
-change public demo artifact layout, change plugin MCP contract, change
-public/private routes, add an async runtime, or widen runtime mutation behavior.
+Current follow-up: `#421` `Phase 53: add bounded third-world transfer readiness evidence`
+
+This note records the evidence-bounded transfer posture established by `#420`, then records
+the `#421` update that adds third-world evidence through `library-rain`. It audits what
+Mirror may and may not claim from the reviewed transfer proof. It does not change schema,
+scenario DSL, claim labels, run trace shape, compare artifact shape, session/node manifest
+shape, public demo artifact layout, plugin MCP contract, public/private routes, add an async
+runtime, or widen runtime mutation behavior. The session/node manifest shape remains unchanged.
 
 ## Evidence Inputs
 
@@ -20,33 +21,36 @@ public/private routes, add an async runtime, or widen runtime mutation behavior.
   Fog Harbor-shaped assumptions and says `eval-transfer` is a two-world proof.
 - `docs/decisions/ADR-0005-two-world-transfer-contracts.md` ratifies the current two-world
   transfer contract and keeps `eval-transfer` as the minimum portability proof.
-- `docs/architecture/contracts.md` defines `eval-transfer` as the dual-world transfer proof
-  across the canonical demo and the current second world.
-- `backend/app/evals/service.py` defines
+- At `#420` completion, `docs/architecture/contracts.md` defined `eval-transfer` as the
+  dual-world transfer proof across the canonical demo and the current second world.
+- At `#420` completion, `backend/app/evals/service.py` defined
   `DEFAULT_TRANSFER_WORLD_IDS = [CANONICAL_DEMO_WORLD_ID, "museum-night"]`.
+- After `#421`, `backend/app/evals/service.py` defines
+  `DEFAULT_TRANSFER_WORLD_IDS = [CANONICAL_DEMO_WORLD_ID, "museum-night", "library-rain"]`.
 - `backend/app/evals/service.py` evaluates transfer worlds through world-local tracked outcomes
   and records `transfer_proof_world_local` only when each selected world covers its configured
   outcomes in run summaries and compare deltas.
 - `data/demo/` remains the canonical Fog Harbor fixture.
 - `data/worlds/museum-night/` remains the second bounded fictional transfer fixture.
+- `data/worlds/library-rain/` is the third original fictional bounded transfer fixture.
 
 ## Supported Claims
 
-- Mirror has a two-world transfer proof across `fog-harbor-east-gate` and `museum-night`.
+- At `#420` completion, Mirror had a two-world transfer proof across `fog-harbor-east-gate` and `museum-night`.
 - `eval-transfer` proves Mirror is not single-world-only.
-- The current transfer proof covers the canonical demo and the current second bounded world
-  selected by `DEFAULT_TRANSFER_WORLD_IDS`.
+- After `#421`, the current transfer proof covers the three selected bounded worlds
+  selected by `DEFAULT_TRANSFER_WORLD_IDS`: `fog-harbor-east-gate`, `museum-night`, and
+  `library-rain`.
 - Current transfer eval checks are world-local: tracked outcomes come from each world's
   `config/simulation_rules.yaml`, and report claims are checked for both `label` and
   `evidence_ids`.
-- The current two-world proof supports saying that the constrained deterministic ingest,
-  graph, persona, scenario, run, compare, report, and eval pipeline has passed across the
-  two selected fictional or explicitly authorized bounded worlds.
+- The current proof supports saying that the constrained deterministic ingest, graph, persona,
+  scenario, run, compare, report, and eval pipeline has passed across three selected bounded worlds.
 
 ## Blocked Claims
 
-- Do not claim broad transfer readiness beyond the current two-world proof.
-- Do not claim third-world readiness before `#421` adds evidence or a reviewed compatibility contract.
+- Do not claim broad transfer readiness beyond the reviewed transfer world set.
+- Do not claim future-world readiness from `#421`'s `library-rain` evidence.
 - Do not claim every future world will work without additional contracts.
 - Do not claim unbounded world coverage, real-world forecasts, or readiness for real-person
   personas.
@@ -79,28 +83,35 @@ Before Mirror can claim third-world readiness, the next evidence slice must sati
   manifest shape, public demo artifact layout, and plugin MCP contract unless a separate ADR
   ratifies the change.
 
+## #421 Update
+
+`#421` chooses the evidence path rather than the defer-and-ratify path. It adds `library-rain`
+as an original fictional bounded world, extends the reviewed transfer set to three selected
+bounded worlds, and records the durable transfer contract update in
+`docs/architecture/contracts.md` and
+`docs/decisions/ADR-0012-third-world-transfer-evidence.md`.
+
+The `#421` evidence note is
+`docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`.
+
 ## Current Evidence Gaps
 
-- Phase 53 has not yet added a third bounded world.
-- `eval-transfer` currently reports `world_count: 2`; that is enough to show Mirror is not
-  single-world-only, but not enough to claim broad transfer readiness.
-- The current transfer proof relies on `fog-harbor-east-gate` and `museum-night`; it does not
-  show that all future world schemas, evidence corpora, tracked outcomes, or scenario choices
-  are compatible without additional review.
+- Phase 53 now has a third bounded world, `library-rain`, but this still does not support a
+  broad future-world readiness claim.
+- `eval-transfer` now targets `world_count: 3`; that is enough to show Mirror has passed
+  across three selected bounded fictional worlds, but not enough to claim broad transfer readiness.
+- The current transfer proof relies on `fog-harbor-east-gate`, `museum-night`, and `library-rain`;
+  it does not show that all future world schemas, evidence corpora, tracked outcomes, or scenario
+  choices are compatible without additional review.
 - No hosted/private-beta runtime timing evidence is created by this audit.
 - No public demo, plugin, launch hub, async runtime, or runtime mutation contract changes are
   created by this audit.
 
 ## Required Follow-Up For `#421`
 
-`#421` should choose exactly one path before claiming third-world readiness:
-
-1. Add a small original/fictional third bounded world and extend the reviewed transfer set.
-2. Ratify a stronger compatibility contract that explains why the current two-world proof is
-   sufficient for the next product decision without claiming third-world readiness.
-
-Either path must keep transfer language evidence-bounded, preserve claim/evidence integrity,
-and avoid real-world forecasts or real-person persona claims.
+`#421` chose path 1: add a small original/fictional third bounded world and extend the reviewed
+transfer set. Future phases must still keep transfer language evidence-bounded, preserve
+claim/evidence integrity, and avoid real-world forecasts or real-person persona claims.
 
 ## Validation Commands
 

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -84,17 +84,19 @@ Phase 53 - Transfer Generalization and Third-World Readiness
   - Phase 53: sync repo truth after Phase 52 closeout and define transfer gate
   - syncs durable docs and tests to the active Phase 53 queue
 - `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`
-  - current ready protected-core work item
+  - closed by PR `#423`
   - defines bounded transfer generalization claims and third-world readiness criteria
   - records `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`
 - `#421` `Phase 53: add bounded third-world transfer readiness evidence`
-  - blocked until `#420` closes
-  - adds bounded third-world readiness evidence or a reviewed compatibility-contract alternative
+  - current ready protected-core work item
+  - adds bounded third-world readiness evidence through `library-rain` or a reviewed compatibility-contract alternative
+  - records `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`
 - boundary posture
   - Phase 53 does not widen public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries.
 - phase gate baseline
   - active Phase 53 Successor Gate: `docs/plans/phase-53-successor-gate-2026-05-19.md`
   - current Phase 53 Transfer Assumption Audit: `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`
+  - current Phase 53 Third-World Transfer Evidence: `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`
 
 ## Phase 52 Closeout
 


### PR DESCRIPTION
## Summary
- Add library-rain as a third original fictional bounded transfer world with corpus, scenarios, simulation rules, decision schema, and product perturbation metadata.
- Extend DEFAULT_TRANSFER_WORLD_IDS and eval-transfer expectations to the three reviewed worlds.
- Record the durable transfer contract in contracts.md, ADR-0012, and Phase 53 evidence/status docs while keeping claims world-bounded.

## Test Plan
- [x] python -m pytest backend\\tests\\test_worlds.py backend\\tests\\test_cli.py::test_cli_eval_transfer_outputs_json backend\\tests\\test_decision_kernel.py::test_product_templates_plus_parameters_resolve_to_world_contracts backend\\tests\\test_phase53_third_world_evidence.py backend\\tests\\test_phase53_transfer_assumption_audit.py backend\\tests\\test_phase53_successor_gate.py -q
- [x] python -m backend.app.cli eval-world --world library-rain
- [x] python scripts\\check_no_secrets.py
- [x] python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
- [x] python -m backend.app.cli classify-lane --files README.md docs/architecture/contracts.md docs/decisions/ADR-0012-third-world-transfer-evidence.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-53-successor-gate-2026-05-19.md docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md backend/app/evals/service.py backend/tests/test_cli.py backend/tests/test_decision_kernel.py backend/tests/test_phase53_successor_gate.py backend/tests/test_phase53_third_world_evidence.py backend/tests/test_phase53_transfer_assumption_audit.py backend/tests/test_worlds.py data/worlds/library-rain/config/decision_schema.yaml data/worlds/library-rain/config/product.json data/worlds/library-rain/config/simulation_rules.yaml data/worlds/library-rain/config/world_model.yaml data/worlds/library-rain/corpus/manifest.yaml data/worlds/library-rain/scenarios/baseline.yaml data/worlds/library-rain/scenarios/catalog_delayed.yaml
- [x] git diff --check
- [x] git diff --cached --check
- [x] ./make.ps1 smoke
- [x] ./make.ps1 test
- [x] ./make.ps1 eval-demo
- [x] ./make.ps1 eval-transfer

Closes #421