### PR TITLE
Record Phase 53 closeout baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,15 +265,12 @@ blocking after the legacy top-level runtime routes audit, without widening publi
 plugin, Hosted GPT/BYOK, or async contracts. See
 `docs/plans/phase-52-successor-gate-2026-05-18.md`.
 
-Phase 53 Transfer Generalization and Third-World Readiness: Phase 53 is the active
-approved successor queue after the Phase 52 closeout. `audit-github-queue` reports
-`ready` with milestone `Phase 53 - Transfer Generalization and Third-World Readiness`,
-blocked exit gate `#418`, and current ready work item `#421` `Phase 53: add bounded
-third-world transfer readiness evidence`. `#419` closed the initial transfer gate sync,
-and `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`
-closed the transfer-assumption audit by PR `#423`. `#421` adds `library-rain`
-as the third original fictional bounded world in the reviewed transfer set. Phase 53
-focuses on bounded transfer generalization and third-world readiness, without widening
+Phase 53 Transfer Generalization and Third-World Readiness: Phase 53 is closed after
+PR `#424`, issue `#418`, and milestone `Phase 53 - Transfer Generalization and
+Third-World Readiness`. `audit-github-queue` reports the formal paused stop-state with
+no active milestone. `#419` closed the initial transfer gate sync by PR `#422`; `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` closed the
+transfer-assumption audit by PR `#423`; `#421` `Phase 53: add bounded third-world transfer readiness evidence` added `library-rain` as the third original fictional bounded world by
+PR `#424`. Phase 53 strengthened bounded transfer generalization evidence without widening
 public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries.
 See `docs/plans/phase-53-successor-gate-2026-05-19.md`,
 `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`, and
@@ -312,15 +309,15 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - The completed Phase 50 successor gate lives in [docs/plans/phase-50-successor-gate-2026-05-18.md](docs/plans/phase-50-successor-gate-2026-05-18.md).
 - The completed Phase 51 successor gate lives in [docs/plans/phase-51-successor-gate-2026-05-18.md](docs/plans/phase-51-successor-gate-2026-05-18.md).
 - The completed Phase 52 successor gate lives in [docs/plans/phase-52-successor-gate-2026-05-18.md](docs/plans/phase-52-successor-gate-2026-05-18.md).
-- The active Phase 53 Successor Gate lives in [docs/plans/phase-53-successor-gate-2026-05-19.md](docs/plans/phase-53-successor-gate-2026-05-19.md).
-- The current Phase 53 Transfer Assumption Audit lives in [docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md](docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md).
-- The current Phase 53 Third-World Transfer Evidence note lives in [docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md](docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md).
+- The completed Phase 53 Successor Gate lives in [docs/plans/phase-53-successor-gate-2026-05-19.md](docs/plans/phase-53-successor-gate-2026-05-19.md).
+- The completed Phase 53 Transfer Assumption Audit lives in [docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md](docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md).
+- The completed Phase 53 Third-World Transfer Evidence note lives in [docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md](docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md).
 - Phase 48 is closed after PR `#382`, issue `#375`, and milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
 - Phase 49 is closed after PR `#395`, issue `#383`, and milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; completed work items were `#384`, `#386`, `#388`, `#390`, `#392`, and `#394`.
 - Phase 50 is closed after PR `#402`, issue `#396`, and milestone `Phase 50 - Runtime Orchestration Measurement and Product Boundary`; completed work items were `#397`, `#398`, and `#401`. Phase 50 measured before any `task_id` or worker contract is introduced and kept the private-beta launch hub planning-only for now.
 - Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`; completed work items were `#404`, `#405`, and `#406`.
 - Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; completed work items were `#411`, `#412`, and `#413`. Before Phase 53 was opened, `audit-github-queue` reported the formal paused stop-state with no active milestone. The legacy top-level runtime routes audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`; the runtime guard note lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`; Phase 52 did not widen public demo, plugin, Hosted GPT/BYOK, or async contracts and keeps route-derived `worldId` guard coverage in scope.
-- Phase 53 is the active approved successor queue: `Phase 53 - Transfer Generalization and Third-World Readiness`; `audit-github-queue` reports `ready` with `#418` as the blocked exit gate, `#421` `Phase 53: add bounded third-world transfer readiness evidence` as the current ready work item, `#419` closed by PR `#422`, and `#420` closed by PR `#423`. Phase 53 focuses on bounded transfer generalization and third-world readiness without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries, and `library-rain` is the current third-world evidence slice.
+- Phase 53 is closed after PR `#424`, issue `#418`, and milestone `Phase 53 - Transfer Generalization and Third-World Readiness`; `audit-github-queue` reports the formal paused stop-state with no active milestone. `#419` closed by PR `#422`, `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` closed by PR `#423`, and `#421` `Phase 53: add bounded third-world transfer readiness evidence` closed by PR `#424`. Phase 53 strengthened bounded transfer generalization evidence without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries, and `library-rain` is the third-world evidence slice.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
 - Fog Harbor remains the canonical demo world; `museum-night` and `library-rain` are the selected bounded transfer worlds used to prove the pipeline has passed across three selected bounded fictional worlds.
 

--- a/backend/tests/test_phase53_successor_gate.py
+++ b/backend/tests/test_phase53_successor_gate.py
@@ -13,9 +13,10 @@ def test_phase53_successor_gate_exists_with_required_sections() -> None:
     required_sections = [
         "# Phase 53 Successor Gate",
         "Issue: `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`",
-        "Current work item: `#421` `Phase 53: add bounded third-world transfer readiness evidence`",
+        "Current state: Phase 53 is closed; no active successor milestone is open.",
         "## Phase 52 Closeout Evidence",
         "## Phase 53 Operational Queue",
+        "## Phase 53 Closeout Evidence",
         "## Transfer-Generalization Scope",
         "## Protected-Core Lane Coverage",
         "## Carried Forward TODO[verify] Items",
@@ -38,10 +39,13 @@ def test_phase53_successor_gate_records_queue_and_boundaries() -> None:
         "`#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`",
         "`#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`",
         "`#421` `Phase 53: add bounded third-world transfer readiness evidence`",
-        "Status: blocked closeout gate for Phase 53.",
-        "Status: current ready work item.",
+        "Status: closed after post-merge validation.",
         "Status: closed by PR `#422`.",
         "Status: closed by PR `#423`.",
+        "Status: closed by PR `#424`.",
+        "formal paused stop-state",
+        "`world_count: 3`",
+        "`transfer_proof_world_local: true`",
         "Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`",
         "bounded transfer generalization",
         "third-world readiness",
@@ -81,7 +85,8 @@ def test_active_state_docs_point_to_phase53_queue() -> None:
         assert "`docs/plans/phase-53-successor-gate-2026-05-19.md`" in text
         assert "Phase 53: audit transfer assumptions and third-world readiness constraints" in text
         assert "Phase 53: add bounded third-world transfer readiness evidence" in text
-        assert "current ready" in text
+        assert "closed by PR `#424`" in text
+        assert "formal paused stop-state" in text
         assert "`library-rain`" in text
         assert "bounded transfer generalization" in text
         assert "third-world readiness" in text
@@ -96,14 +101,15 @@ def test_active_state_docs_do_not_treat_phase52_pause_as_current() -> None:
         Path("docs/plans/automation-roadmap.md"),
     ]
     stale_current_phrases = [
-        "The current repository state has completed the Phase 52 legacy-route/runtime-scope audit queue, preserved `v0.1.0` as the latest published release baseline, and returned to the formal paused stop-state with no active milestone.",
-        "This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 52 legacy-route/runtime-scope audit closeout, and the formal paused stop-state with no active successor milestone.",
-        "No successor queue is active after Phase 52 closeout; do not open a parallel execution queue without a fresh approved milestone and exit gate.",
-        "`audit-github-queue` now reports the formal paused stop-state",
-        "`audit-github-queue` reports the formal paused stop-state",
+        "Phase 53 is the active approved successor queue",
+        "Phase 53 is the active",
+        "current ready Phase 53",
+        "current ready work item",
+        "Phase 53 exit gate: open and blocked",
+        "`audit-github-queue` reports `ready` with `#418` as the blocked exit gate",
     ]
 
     for path in required_docs:
         text = path.read_text(encoding="utf-8")
         for phrase in stale_current_phrases:
-            assert phrase not in text, f"{path} still treats Phase 52 pause as current: {phrase}"
+            assert phrase not in text, f"{path} still treats Phase 53 as active: {phrase}"

--- a/backend/tests/test_phase53_third_world_evidence.py
+++ b/backend/tests/test_phase53_third_world_evidence.py
@@ -43,7 +43,8 @@ def test_active_docs_point_to_phase53_third_world_evidence() -> None:
         assert "docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md" in text
         assert "`#421` `Phase 53: add bounded third-world transfer readiness evidence`" in text
         assert "`library-rain`" in text
-        assert "current ready" in text or "Status: current ready work item." in text
+        assert "closed by PR `#424`" in text
+        assert "formal paused stop-state" in text
 
 
 def test_phase53_third_world_contract_and_adr_record_reviewed_world_set() -> None:

--- a/backend/tests/test_phase53_transfer_assumption_audit.py
+++ b/backend/tests/test_phase53_transfer_assumption_audit.py
@@ -104,6 +104,7 @@ def test_active_docs_point_to_current_phase53_assumption_audit() -> None:
         assert "`#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`" in text
         assert "closed by PR `#423`" in text
         assert "`#421` `Phase 53: add bounded third-world transfer readiness evidence`" in text
-        assert "current ready" in text or "Status: current ready work item." in text
+        assert "closed by PR `#424`" in text
+        assert "formal paused stop-state" in text
         for phrase in stale_phrases:
             assert phrase not in text, f"{path} still treats #420 as blocked: {phrase}"

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, Phase 47 closeout is complete, Phase 48 closeout is complete, Phase 49 closeout is complete, Phase 50 closeout is complete, Phase 51 closeout is complete, Phase 52 closeout is complete, Phase 53 is the active approved successor queue, and the first formal release remains published as `v0.1.0`.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, Phase 47 closeout is complete, Phase 48 closeout is complete, Phase 49 closeout is complete, Phase 50 closeout is complete, Phase 51 closeout is complete, Phase 52 closeout is complete, Phase 53 closeout is complete, and the first formal release remains published as `v0.1.0`.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -179,20 +179,20 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - `#412` `Phase 52: audit legacy top-level runtime routes and preserve boundary contract` is closed by PR `#415`; this completed the Phase 52 Legacy Top-Level Runtime Route Audit.
 - `#413` `Phase 52: strengthen runtime mutation guard regression baseline` is closed by PR `#416`; this completed the Phase 52 Runtime Mutation Guard Regression Baseline.
 - Phase 52 focused on legacy top-level runtime routes and runtime mutation guard regression coverage without widening public/plugin/async contracts. The route audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`, the runtime guard note lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`, route-derived `worldId` coverage remains in scope, and the gate note lives in `docs/plans/phase-52-successor-gate-2026-05-18.md`.
-- Phase 53 is the active approved successor queue.
-- milestone `Phase 53 - Transfer Generalization and Third-World Readiness` is open.
-- `#418` `Phase 53 exit gate` is open, blocked, and protected-core.
+- Phase 53 is closed after post-merge validation.
+- milestone `Phase 53 - Transfer Generalization and Third-World Readiness` is closed.
+- `#418` `Phase 53 exit gate` is closed after post-merge validation and protected-core.
 - `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate` is closed by PR `#422`.
 - `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` is closed by PR `#423`.
-- `#421` `Phase 53: add bounded third-world transfer readiness evidence` is the current ready Phase 53 transfer evidence work item and records `library-rain`.
-- Phase 53 focuses on bounded transfer generalization and third-world readiness without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries. The active Phase 53 Successor Gate lives in `docs/plans/phase-53-successor-gate-2026-05-19.md`; the transfer-assumption audit lives in `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`; the current third-world evidence note lives in `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`.
+- `#421` `Phase 53: add bounded third-world transfer readiness evidence` is closed by PR `#424` and records `library-rain`.
+- Phase 53 strengthened bounded transfer generalization and third-world readiness evidence without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries. The completed Phase 53 Successor Gate lives in `docs/plans/phase-53-successor-gate-2026-05-19.md`; the transfer-assumption audit lives in `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`; the third-world evidence note lives in `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.
 - `#390` `Phase 49: ratify runtime parent-child compare emission policy` is closed by PR `#391`.
 - `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope` is closed by PR `#393`.
 - `#394` `Phase 49: strengthen transfer eval outcome coverage` is closed by PR `#395`.
-- `audit-github-queue` reports `ready` with Phase 53 as the active milestone.
+- `audit-github-queue` reports the formal paused stop-state with no active milestone.
 - The first formal repository release is published as `v0.1.0`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
@@ -249,5 +249,5 @@ Before builder automation is allowed to write code or auto-merge:
 - Long-running execution must run from isolated worktrees rather than the current `main` checkout.
 - Queue pickup order, one-writer ownership, and branch hygiene should follow `docs/plans/long-running-loop-runbook.md`.
 - When the active milestone exists and the queue reports `ready`, the builder may resume against that milestone only.
-- Phase 53 is the active approved successor queue; do not open a parallel execution queue.
+- No active successor queue is open; do not open a parallel execution queue without a fresh approved milestone and exit gate.
 - When no open milestone exists and `audit-github-queue` reports `paused`, treat that state as an intentional released stop-state rather than a broken queue.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note records the active Phase 53 transfer-generalization successor queue after the completed Phase 52 legacy-route/runtime-scope audit closeout and the formal `v0.1.0` release baseline.
+This note records the formal paused stop-state after the completed Phase 53 transfer-generalization closeout and the formal `v0.1.0` release baseline.
 
 ## Snapshot
 
@@ -214,7 +214,7 @@ This note records the active Phase 53 transfer-generalization successor queue af
   - `gh api repos/YSCJRH/mirror-sim/releases`
     - release `v0.1.0` exists and matches the committed release notes baseline
   - `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim`
-    - queue reports `ready` with `Phase 53 - Transfer Generalization and Third-World Readiness` as the active milestone
+    - queue reports `paused` with no active milestone
   - `gh issue list --milestone "Phase 47 - Boundary Readiness and Successor Hygiene" --state all`
     - `#365` `Phase 47 exit gate` is `closed` after merging PR `#374`
     - `#366` `Phase 47: sync repo truth to successor queue` is `closed` after merging PR `#370`
@@ -284,16 +284,16 @@ This note records the active Phase 53 transfer-generalization successor queue af
     - runtime mutation guard regression coverage keeps route-derived `worldId` and public-demo blocking in scope
     - `docs/plans/phase-52-successor-gate-2026-05-18.md` records the completed gate note
   - `gh issue list --milestone "Phase 53 - Transfer Generalization and Third-World Readiness" --state all`
-    - `#418` `Phase 53 exit gate` is `open`, `blocked`, and `lane:protected-core`
+    - `#418` `Phase 53 exit gate` is `closed` after post-merge validation
     - `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate` is `closed` by PR `#422`
     - `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` is `closed` by PR `#423`
-    - `#421` `Phase 53: add bounded third-world transfer readiness evidence` is the current ready Phase 53 protected-core work item
+    - `#421` `Phase 53: add bounded third-world transfer readiness evidence` is `closed` by PR `#424`
   - Phase 53 Successor Gate:
-    - Phase 53 - Transfer Generalization and Third-World Readiness is the active approved successor queue
-    - `docs/plans/phase-53-successor-gate-2026-05-19.md` records the active gate note
+    - Phase 53 - Transfer Generalization and Third-World Readiness is closed
+    - `docs/plans/phase-53-successor-gate-2026-05-19.md` records the completed gate note
     - `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md` records the completed transfer assumption audit
-    - `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md` records the current `library-rain` third-world evidence slice
-    - Phase 53 focuses on bounded transfer generalization and third-world readiness
+    - `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md` records the completed `library-rain` third-world evidence slice
+    - Phase 53 strengthened bounded transfer generalization and third-world readiness evidence
     - public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries remain unchanged
 
 ## Trusted Source Of Truth
@@ -316,20 +316,20 @@ This note records the active Phase 53 transfer-generalization successor queue af
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
 - The default workbench path now consumes the canonical compare artifact directly and keeps focused divergent trace surfaces ahead of heavier packet-driven review flows.
 - The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, execution recovery release boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, escalation acknowledgment packets, and escalation closure packets without introducing backend API expansion.
-- The current repository state has opened the Phase 53 transfer-generalization queue, preserved `v0.1.0` as the latest published release baseline, and kept public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries unchanged.
+- The current repository state has completed the Phase 53 transfer-generalization queue, preserved `v0.1.0` as the latest published release baseline, and returned to the formal paused stop-state with public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries unchanged.
 
 ## Next Entry Point
 
 - Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`.
 - Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; before Phase 53 was opened, `audit-github-queue` reported the formal paused stop-state.
-- Phase 53 is the active approved successor queue: `Phase 53 - Transfer Generalization and Third-World Readiness`; `audit-github-queue` reports `ready`.
+- Phase 53 is closed after PR `#424`, issue `#418`, and milestone `Phase 53 - Transfer Generalization and Third-World Readiness`; `audit-github-queue` reports the formal paused stop-state.
 - The Phase 47 unlock order is resolved: the queue-sync issue is closed after PR `#370`, the boundary-regression report is closed after PR `#371`, the runtime-world safety preflight is closed after PR `#372`, the main-path containment report is closed after PR `#373`, and the exit gate is closed after PR `#374`.
 - The Phase 48 unlock order is resolved: `#376` and `#377` closed through earlier Phase 48 PRs, `#378` and `#379` closed through PR `#382`, and `#375` closed after the post-merge exit-gate reassessment.
 - The Phase 49 unlock order is resolved: `#384` closed through PR `#385`, `#386` closed through PR `#387`, `#388` closed through PR `#389`, `#390` closed through PR `#391`, `#392` closed through PR `#393`, `#394` closed through PR `#395`, and `#383` closed after the post-merge exit-gate reassessment.
 - The Phase 50 unlock order is resolved: `#397` closed through PR `#399`, `#398` closed through PR `#400`, `#401` closed through PR `#402`, and `#396` closed after the post-merge exit-gate reassessment.
-- The active successor milestone is `Phase 53 - Transfer Generalization and Third-World Readiness`.
+- No active successor milestone is open after Phase 53 closeout.
 - The Phase 52 exit gate is `#410` `Phase 52 exit gate`, which closed after post-merge validation on `main`.
-- The Phase 53 exit gate is `#418` `Phase 53 exit gate`, which remains the open blocked closeout gate for this phase.
+- The Phase 53 exit gate is `#418` `Phase 53 exit gate`, which closed after post-merge validation on `main`.
 - `#397` `Phase 50: sync repo truth after Phase 49 closeout` is closed by PR `#399`.
 - `#398` `Phase 50: measure runtime generation duration before task_id decision` is closed by PR `#400`.
 - `#401` `Phase 50: ratify private-beta launch hub and public-path boundary` is closed by PR `#402`.
@@ -349,11 +349,11 @@ This note records the active Phase 53 transfer-generalization successor queue af
 - The Phase 52 Runtime Mutation Guard Regression Baseline note lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md` and keeps route-derived `worldId` guard coverage in scope.
 - `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate` is closed by PR `#422`.
 - `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` is closed by PR `#423`.
-- `#421` `Phase 53: add bounded third-world transfer readiness evidence` is the current ready Phase 53 transfer evidence work item.
-- Phase 53 focuses on bounded transfer generalization and third-world readiness without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries.
-- The active Phase 53 Successor Gate lives in `docs/plans/phase-53-successor-gate-2026-05-19.md`.
-- The current Phase 53 Transfer Assumption Audit lives in `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`.
-- The current Phase 53 Third-World Transfer Evidence note lives in `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md` and records `library-rain`.
+- `#421` `Phase 53: add bounded third-world transfer readiness evidence` is closed by PR `#424`.
+- Phase 53 strengthened bounded transfer generalization and third-world readiness evidence without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries.
+- The completed Phase 53 Successor Gate lives in `docs/plans/phase-53-successor-gate-2026-05-19.md`.
+- The completed Phase 53 Transfer Assumption Audit lives in `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`.
+- The completed Phase 53 Third-World Transfer Evidence note lives in `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md` and records `library-rain`.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.
@@ -366,9 +366,9 @@ This note records the active Phase 53 transfer-generalization successor queue af
 - The completed Phase 50 successor-gate baseline lives in `docs/plans/phase-50-successor-gate-2026-05-18.md`.
 - The completed Phase 51 successor-gate baseline lives in `docs/plans/phase-51-successor-gate-2026-05-18.md`.
 - The completed Phase 52 successor-gate baseline lives in `docs/plans/phase-52-successor-gate-2026-05-18.md`.
-- The active Phase 53 successor-gate baseline lives in `docs/plans/phase-53-successor-gate-2026-05-19.md`.
-- The current Phase 53 transfer-assumption audit baseline lives in `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`.
-- The current Phase 53 third-world evidence baseline lives in `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md` and records `library-rain`.
+- The completed Phase 53 successor-gate baseline lives in `docs/plans/phase-53-successor-gate-2026-05-19.md`.
+- The completed Phase 53 transfer-assumption audit baseline lives in `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`.
+- The completed Phase 53 third-world evidence baseline lives in `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md` and records `library-rain`.
 - Local untracked private-beta, kernel, and design-system planning files under `docs/plans/...` are candidate inputs only until a PR intentionally promotes them.
 - Protected-core changes still require explicit review even when safe-lane automation is available.
 - `docs/plans/long-running-loop-runbook.md` is the operational handoff note for authenticated queue audit, worktree pickup, and post-merge checkpointing.

--- a/docs/plans/phase-53-successor-gate-2026-05-19.md
+++ b/docs/plans/phase-53-successor-gate-2026-05-19.md
@@ -4,7 +4,7 @@ Date: 2026-05-19
 
 Issue: `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`
 
-Current work item: `#421` `Phase 53: add bounded third-world transfer readiness evidence`
+Current state: Phase 53 is closed; no active successor milestone is open.
 
 This note records the post-Phase-52 baseline and the Phase 53 successor queue. Phase 53
 is a protected-core transfer-generalization and third-world readiness phase. It opens a
@@ -36,11 +36,11 @@ Phase 53 title:
 Phase 53 - Transfer Generalization and Third-World Readiness
 ```
 
-Active GitHub objects:
+Final GitHub objects:
 
 - `#418` `Phase 53 exit gate`
   - Lane: `protected-core`.
-  - Status: blocked closeout gate for Phase 53.
+  - Status: closed after post-merge validation.
 - `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`
   - Lane: `protected-core`.
   - Status: closed by PR `#422`.
@@ -52,13 +52,25 @@ Active GitHub objects:
   - Audit note: `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`.
 - `#421` `Phase 53: add bounded third-world transfer readiness evidence`
   - Lane: `protected-core`.
-  - Status: current ready work item.
+  - Status: closed by PR `#424`.
   - Scope: add bounded third-world readiness evidence through `library-rain` or ratify a stronger compatibility contract.
   - Evidence note: `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`.
 
-`python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
-with Phase 53 as the only open milestone, `#418` as the protected blocked exit gate, and
-`#421` as the current ready work item.
+`python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `paused`
+with no active milestone after Phase 53 closeout.
+
+## Phase 53 Closeout Evidence
+
+Phase 53 is closed after PR `#424`, issue `#418`, and milestone
+`Phase 53 - Transfer Generalization and Third-World Readiness`.
+
+- PR `#422` closed `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`.
+- PR `#423` closed `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`.
+- PR `#424` closed `#421` `Phase 53: add bounded third-world transfer readiness evidence`.
+- Issue `#418` `Phase 53 exit gate` is closed after post-merge validation on `main`.
+- Milestone `Phase 53 - Transfer Generalization and Third-World Readiness` is closed.
+- `./make.ps1 eval-transfer` passes with `world_count: 3` and `transfer_proof_world_local: true`.
+- The queue returned to the formal paused stop-state with no open milestone.
 
 ## Transfer-Generalization Scope
 
@@ -128,7 +140,7 @@ public demo artifact layout, or the Mirror Codex MCP contract.
      compatibility-contract alternative.
    - Strengthen eval/report coverage only within the ratified contracts.
    - Preserve claim/evidence integrity.
-   - Current evidence note: `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`.
+   - Completed evidence note: `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`.
 
 ## Blueprint Boundary
 
@@ -166,7 +178,7 @@ Phase 53 must stay aligned with `mirror.md` and `AGENTS.md`:
 
 ## Validation Commands
 
-For `#421`, run:
+For Phase 53 closeout, run:
 
 ```powershell
 python -m pytest backend/tests/test_worlds.py backend/tests/test_cli.py::test_cli_eval_transfer_outputs_json backend/tests/test_decision_kernel.py::test_product_templates_plus_parameters_resolve_to_world_contracts backend/tests/test_phase53_third_world_evidence.py backend/tests/test_phase53_transfer_assumption_audit.py backend/tests/test_phase53_successor_gate.py -q

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 52 legacy-route/runtime-scope audit closeout, and the active Phase 53 transfer-generalization successor queue.
+This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut and the completed Phase 53 transfer-generalization closeout.
 
 ## Current Gate State
 
@@ -56,7 +56,7 @@ This note records the current post-Day-0 execution status for Mirror after the f
 - Phase 50 exit gate: closed
 - Phase 51 exit gate: closed
 - Phase 52 exit gate: closed
-- Phase 53 exit gate: open and blocked
+- Phase 53 exit gate: closed
 
 Local phase audits currently report:
 
@@ -64,7 +64,7 @@ Local phase audits currently report:
 - `phase2`: pass
 - `phase3`: pass
 
-## Phase 53 Successor Queue
+## Phase 53 Closeout
 
 Phase 53 title:
 
@@ -73,11 +73,11 @@ Phase 53 - Transfer Generalization and Third-World Readiness
 ```
 
 - `audit-github-queue`
-  - reports `ready` with `Phase 53 - Transfer Generalization and Third-World Readiness` as the active milestone
+  - reports the formal paused stop-state with no active milestone
 - milestone `Phase 53 - Transfer Generalization and Third-World Readiness`
-  - open
+  - closed
 - `#418` `Phase 53 exit gate`
-  - open and blocked
+  - closed after post-merge validation
   - labeled `lane:protected-core` because it is the protected closeout gate
 - `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`
   - closed by PR `#422`
@@ -88,15 +88,15 @@ Phase 53 - Transfer Generalization and Third-World Readiness
   - defines bounded transfer generalization claims and third-world readiness criteria
   - records `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`
 - `#421` `Phase 53: add bounded third-world transfer readiness evidence`
-  - current ready protected-core work item
-  - adds bounded third-world readiness evidence through `library-rain` or a reviewed compatibility-contract alternative
+  - closed by PR `#424`
+  - adds bounded third-world readiness evidence through `library-rain`
   - records `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`
 - boundary posture
   - Phase 53 does not widen public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries.
 - phase gate baseline
-  - active Phase 53 Successor Gate: `docs/plans/phase-53-successor-gate-2026-05-19.md`
-  - current Phase 53 Transfer Assumption Audit: `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`
-  - current Phase 53 Third-World Transfer Evidence: `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`
+  - completed Phase 53 Successor Gate: `docs/plans/phase-53-successor-gate-2026-05-19.md`
+  - completed Phase 53 Transfer Assumption Audit: `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`
+  - completed Phase 53 Third-World Transfer Evidence: `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`
 
 ## Phase 52 Closeout
 
@@ -277,7 +277,7 @@ Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Priv
   - Phase 50 completed as a runtime-orchestration measurement and product-boundary round
   - Phase 51 completed as a private-beta route contract and runtime-readiness round
   - Phase 52 completed as a legacy-route containment and runtime-scope audit round
-  - Phase 53 is the active approved successor queue for bounded transfer generalization and third-world readiness
+  - Phase 53 completed as a bounded transfer generalization and third-world readiness evidence round
   - any work beyond the Phase 53 queue requires a fresh decision against the trigger conditions in `mirror.md`
 
 ## Closeout Snapshot
@@ -736,7 +736,7 @@ Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Priv
 - Protected-core changes still require explicit review and must not auto-merge.
 - Long-running execution should assign exactly one writer worktree per issue.
 - When `audit-github-queue` reports `ready`, consume only the currently active milestone and do not parallel-open another execution queue.
-- Phase 53 is the active approved successor queue; do not open a parallel execution queue.
+- No active successor queue is open; do not open a parallel execution queue without a fresh approved milestone and exit gate.
 - The previous local queue follow-up automation has been revoked or left paused per operator request; do not recreate an automation without a new explicit request.
 
 ## Historical Branch Status


### PR DESCRIPTION
## Summary
- Update README and active planning docs from Phase 53 active queue to formal paused stop-state.
- Record that #418-#421 and milestone 53 are closed after PR #424 and post-merge validation.
- Harden Phase 53 doc tests against stale active/current-ready wording.

## Test Plan
- [x] python -m pytest backend\\tests\\test_phase53_successor_gate.py backend\\tests\\test_phase53_transfer_assumption_audit.py backend\\tests\\test_phase53_third_world_evidence.py -q
- [x] python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
- [x] python scripts\\check_no_secrets.py
- [x] git diff --check
- [x] python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/phase-execution-queue.md docs/plans/automation-roadmap.md docs/plans/phase-53-successor-gate-2026-05-19.md backend/tests/test_phase53_successor_gate.py backend/tests/test_phase53_transfer_assumption_audit.py backend/tests/test_phase53_third_world_evidence.py
- [x] ./make.ps1 test
- [x] ./make.ps1 eval-demo
- [x] ./make.ps1 eval-transfer