### PR TITLE
Phase 54 runtime gate repo truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,14 +267,23 @@ plugin, Hosted GPT/BYOK, or async contracts. See
 
 Phase 53 Transfer Generalization and Third-World Readiness: Phase 53 is closed after
 PR `#424`, issue `#418`, and milestone `Phase 53 - Transfer Generalization and
-Third-World Readiness`. `audit-github-queue` reports the formal paused stop-state with
-no active milestone. `#419` closed the initial transfer gate sync by PR `#422`; `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` closed the
+Third-World Readiness`. After closeout, `audit-github-queue` returned the formal paused
+stop-state until Phase 54 was opened. `#419` closed the initial transfer gate sync by PR `#422`; `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` closed the
 transfer-assumption audit by PR `#423`; `#421` `Phase 53: add bounded third-world transfer readiness evidence` added `library-rain` as the third original fictional bounded world by
 PR `#424`. Phase 53 strengthened bounded transfer generalization evidence without widening
 public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries.
 See `docs/plans/phase-53-successor-gate-2026-05-19.md`,
 `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`, and
 `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`.
+
+Phase 54 Runtime Orchestration Measurement and Async Contract Decision Gate: Phase 54 is
+the active successor queue after Phase 53 closeout. `audit-github-queue` reports `ready`
+for milestone `Phase 54 - Runtime Orchestration Measurement and Async Contract Decision
+Gate` with `#426` `Phase 54 exit gate` blocked, `#427` `Phase 54: sync repo truth after
+Phase 53 closeout and define runtime gate` ready, and `#428` `Phase 54: refresh runtime measurement and decide async contract boundary` ready. Phase 54 is a protected-core
+runtime measurement and async contract decision gate; it does not implement async workers,
+`task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion.
+See `docs/plans/phase-54-successor-gate-2026-05-19.md`.
 
 ---
 
@@ -302,7 +311,7 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 ## Current Status | 当前状态
 
 - `v0.1.0` is the formal release baseline.
-- The current stop-state / queue state lives in [docs/plans/current-state-baseline.md](docs/plans/current-state-baseline.md).
+- The current queue state lives in [docs/plans/current-state-baseline.md](docs/plans/current-state-baseline.md).
 - The completed Phase 47 successor gate lives in [docs/plans/phase-47-successor-gate-2026-05-16.md](docs/plans/phase-47-successor-gate-2026-05-16.md).
 - The completed Phase 48 successor gate lives in [docs/plans/phase-48-successor-gate-2026-05-17.md](docs/plans/phase-48-successor-gate-2026-05-17.md).
 - The completed Phase 49 successor gate lives in [docs/plans/phase-49-successor-gate-2026-05-18.md](docs/plans/phase-49-successor-gate-2026-05-18.md).
@@ -312,12 +321,14 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - The completed Phase 53 Successor Gate lives in [docs/plans/phase-53-successor-gate-2026-05-19.md](docs/plans/phase-53-successor-gate-2026-05-19.md).
 - The completed Phase 53 Transfer Assumption Audit lives in [docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md](docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md).
 - The completed Phase 53 Third-World Transfer Evidence note lives in [docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md](docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md).
+- The active Phase 54 Successor Gate lives in [docs/plans/phase-54-successor-gate-2026-05-19.md](docs/plans/phase-54-successor-gate-2026-05-19.md).
 - Phase 48 is closed after PR `#382`, issue `#375`, and milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
 - Phase 49 is closed after PR `#395`, issue `#383`, and milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; completed work items were `#384`, `#386`, `#388`, `#390`, `#392`, and `#394`.
 - Phase 50 is closed after PR `#402`, issue `#396`, and milestone `Phase 50 - Runtime Orchestration Measurement and Product Boundary`; completed work items were `#397`, `#398`, and `#401`. Phase 50 measured before any `task_id` or worker contract is introduced and kept the private-beta launch hub planning-only for now.
 - Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`; completed work items were `#404`, `#405`, and `#406`.
 - Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; completed work items were `#411`, `#412`, and `#413`. Before Phase 53 was opened, `audit-github-queue` reported the formal paused stop-state with no active milestone. The legacy top-level runtime routes audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`; the runtime guard note lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`; Phase 52 did not widen public demo, plugin, Hosted GPT/BYOK, or async contracts and keeps route-derived `worldId` guard coverage in scope.
-- Phase 53 is closed after PR `#424`, issue `#418`, and milestone `Phase 53 - Transfer Generalization and Third-World Readiness`; `audit-github-queue` reports the formal paused stop-state with no active milestone. `#419` closed by PR `#422`, `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` closed by PR `#423`, and `#421` `Phase 53: add bounded third-world transfer readiness evidence` closed by PR `#424`. Phase 53 strengthened bounded transfer generalization evidence without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries, and `library-rain` is the third-world evidence slice.
+- Phase 53 is closed after PR `#424`, issue `#418`, and milestone `Phase 53 - Transfer Generalization and Third-World Readiness`; after closeout, the queue returned to the formal paused stop-state until Phase 54 was opened. `#419` closed by PR `#422`, `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` closed by PR `#423`, and `#421` `Phase 53: add bounded third-world transfer readiness evidence` closed by PR `#424`. Phase 53 strengthened bounded transfer generalization evidence without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries, and `library-rain` is the third-world evidence slice.
+- Phase 54 is active after opening milestone `Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate`; `audit-github-queue` reports `ready` with `#426` blocked, `#427` ready, and `#428` ready. Phase 54 covers runtime measurement and async contract decision work without implementing async workers, `task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion. The Phase 54 Successor Gate lives in `docs/plans/phase-54-successor-gate-2026-05-19.md`.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
 - Fog Harbor remains the canonical demo world; `museum-night` and `library-rain` are the selected bounded transfer worlds used to prove the pipeline has passed across three selected bounded fictional worlds.
 

--- a/backend/tests/test_phase53_successor_gate.py
+++ b/backend/tests/test_phase53_successor_gate.py
@@ -66,7 +66,7 @@ def test_phase53_successor_gate_records_queue_and_boundaries() -> None:
         assert phrase in gate
 
 
-def test_active_state_docs_point_to_phase53_queue() -> None:
+def test_active_state_docs_preserve_phase53_closeout_history() -> None:
     required_docs = [
         Path("README.md"),
         Path("docs/plans/current-state-baseline.md"),
@@ -86,7 +86,6 @@ def test_active_state_docs_point_to_phase53_queue() -> None:
         assert "Phase 53: audit transfer assumptions and third-world readiness constraints" in text
         assert "Phase 53: add bounded third-world transfer readiness evidence" in text
         assert "closed by PR `#424`" in text
-        assert "formal paused stop-state" in text
         assert "`library-rain`" in text
         assert "bounded transfer generalization" in text
         assert "third-world readiness" in text

--- a/backend/tests/test_phase53_third_world_evidence.py
+++ b/backend/tests/test_phase53_third_world_evidence.py
@@ -29,7 +29,7 @@ def test_phase53_third_world_evidence_note_records_library_rain() -> None:
         assert phrase in text
 
 
-def test_active_docs_point_to_phase53_third_world_evidence() -> None:
+def test_active_docs_preserve_phase53_third_world_evidence_history() -> None:
     required_docs = [
         Path("README.md"),
         Path("docs/plans/current-state-baseline.md"),
@@ -44,7 +44,6 @@ def test_active_docs_point_to_phase53_third_world_evidence() -> None:
         assert "`#421` `Phase 53: add bounded third-world transfer readiness evidence`" in text
         assert "`library-rain`" in text
         assert "closed by PR `#424`" in text
-        assert "formal paused stop-state" in text
 
 
 def test_phase53_third_world_contract_and_adr_record_reviewed_world_set() -> None:

--- a/backend/tests/test_phase53_transfer_assumption_audit.py
+++ b/backend/tests/test_phase53_transfer_assumption_audit.py
@@ -83,7 +83,7 @@ def test_transfer_assumption_audit_preserves_protected_contract_boundaries() -> 
         assert boundary in text
 
 
-def test_active_docs_point_to_current_phase53_assumption_audit() -> None:
+def test_active_docs_preserve_phase53_assumption_audit_history() -> None:
     required_docs = [
         Path("README.md"),
         Path("docs/plans/current-state-baseline.md"),
@@ -105,6 +105,5 @@ def test_active_docs_point_to_current_phase53_assumption_audit() -> None:
         assert "closed by PR `#423`" in text
         assert "`#421` `Phase 53: add bounded third-world transfer readiness evidence`" in text
         assert "closed by PR `#424`" in text
-        assert "formal paused stop-state" in text
         for phrase in stale_phrases:
             assert phrase not in text, f"{path} still treats #420 as blocked: {phrase}"

--- a/backend/tests/test_phase54_successor_gate.py
+++ b/backend/tests/test_phase54_successor_gate.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+PHASE54_GATE_PATH = Path("docs/plans/phase-54-successor-gate-2026-05-19.md")
+
+
+def test_phase54_successor_gate_exists_with_required_sections() -> None:
+    assert PHASE54_GATE_PATH.exists()
+
+    gate = PHASE54_GATE_PATH.read_text(encoding="utf-8")
+    required_sections = [
+        "# Phase 54 Successor Gate",
+        "Issue: `#427` `Phase 54: sync repo truth after Phase 53 closeout and define runtime gate`",
+        "Current state: Phase 54 is active; `audit-github-queue` reports `ready`.",
+        "## Phase 53 Closeout Evidence",
+        "## Phase 54 Operational Queue",
+        "## Runtime-Orchestration Scope",
+        "## Protected-Core Lane Coverage",
+        "## Carried Forward TODO[verify] Items",
+        "## Phase 54 Work Package Map",
+        "## Blueprint Boundary",
+        "## Non-Goals",
+        "## Validation Commands",
+    ]
+    for section in required_sections:
+        assert section in gate
+
+
+def test_phase54_successor_gate_records_queue_and_boundaries() -> None:
+    assert PHASE54_GATE_PATH.exists()
+
+    gate = PHASE54_GATE_PATH.read_text(encoding="utf-8")
+    required_phrases = [
+        "Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate",
+        "`#426` `Phase 54 exit gate`",
+        "`#427` `Phase 54: sync repo truth after Phase 53 closeout and define runtime gate`",
+        "`#428` `Phase 54: refresh runtime measurement and decide async contract boundary`",
+        "Status: open and blocked.",
+        "Status: open and ready.",
+        "Status: open and ready; needs ADR or contract decision before merge.",
+        "Exactly one open milestone exists with a protected blocked exit gate and ready work items",
+        "Phase 53 is closed after PR `#424`, issue `#418`, and milestone `Phase 53 - Transfer Generalization and Third-World Readiness`",
+        "runtime measurement",
+        "async contract decision",
+        "ADR-0006",
+        "V1 does not introduce task queues or a separate `task_id` contract",
+        "do not implement async workers, task queues, `task_id`, heartbeat, retry, cleanup",
+        "Do not replace `/` or widen the public path",
+        "Do not implement a launch hub",
+        "Do not add Hosted GPT, BYOK, upload, auth, billing, database, object storage",
+        "route-derived `worldId` or an equivalent reviewed scope guard",
+        "public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries",
+        "`docs/plans/phase-54-successor-gate-2026-05-19.md`",
+        "`python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`",
+    ]
+    for phrase in required_phrases:
+        assert phrase in gate
+
+
+def test_active_state_docs_point_to_phase54_queue() -> None:
+    required_docs = [
+        Path("README.md"),
+        Path("docs/plans/current-state-baseline.md"),
+        Path("docs/plans/phase-execution-queue.md"),
+        Path("docs/plans/automation-roadmap.md"),
+    ]
+
+    for path in required_docs:
+        text = path.read_text(encoding="utf-8")
+        assert "Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate" in text
+        assert "`#426`" in text
+        assert "`#427`" in text
+        assert "`#428`" in text
+        assert "Phase 54 Successor Gate" in text
+        assert "`docs/plans/phase-54-successor-gate-2026-05-19.md`" in text
+        assert "Phase 54: refresh runtime measurement and decide async contract boundary" in text
+        assert "`audit-github-queue` reports `ready`" in text
+        assert "runtime measurement" in text
+        assert "async contract decision" in text
+        assert "public demo, plugin, Hosted GPT/BYOK, launch hub, async" in text
+
+
+def test_active_state_docs_do_not_treat_phase53_pause_as_current() -> None:
+    required_docs = [
+        Path("README.md"),
+        Path("docs/plans/current-state-baseline.md"),
+        Path("docs/plans/phase-execution-queue.md"),
+        Path("docs/plans/automation-roadmap.md"),
+    ]
+    stale_current_phrases = [
+        "No active successor milestone is open after Phase 53 closeout.",
+        "Phase 53 is closed after PR `#424`, issue `#418`, and milestone `Phase 53 - Transfer Generalization and Third-World Readiness`; `audit-github-queue` reports the formal paused stop-state.",
+        "current repository state has completed the Phase 53 transfer-generalization queue",
+        "`audit-github-queue` reports the formal paused stop-state with no active milestone",
+    ]
+
+    for path in required_docs:
+        text = path.read_text(encoding="utf-8")
+        for phrase in stale_current_phrases:
+            assert phrase not in text, f"{path} still treats the Phase 53 pause as current: {phrase}"

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, Phase 47 closeout is complete, Phase 48 closeout is complete, Phase 49 closeout is complete, Phase 50 closeout is complete, Phase 51 closeout is complete, Phase 52 closeout is complete, Phase 53 closeout is complete, and the first formal release remains published as `v0.1.0`.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, Phase 47 closeout is complete, Phase 48 closeout is complete, Phase 49 closeout is complete, Phase 50 closeout is complete, Phase 51 closeout is complete, Phase 52 closeout is complete, Phase 53 closeout is complete, Phase 54 is the active runtime-orchestration successor queue, and the first formal release remains published as `v0.1.0`.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -186,13 +186,18 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` is closed by PR `#423`.
 - `#421` `Phase 53: add bounded third-world transfer readiness evidence` is closed by PR `#424` and records `library-rain`.
 - Phase 53 strengthened bounded transfer generalization and third-world readiness evidence without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries. The completed Phase 53 Successor Gate lives in `docs/plans/phase-53-successor-gate-2026-05-19.md`; the transfer-assumption audit lives in `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`; the third-world evidence note lives in `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`.
+- Phase 54 is active after opening milestone `Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate`.
+- `#426` `Phase 54 exit gate` is open and blocked.
+- `#427` `Phase 54: sync repo truth after Phase 53 closeout and define runtime gate` is open and ready.
+- `#428` `Phase 54: refresh runtime measurement and decide async contract boundary` is open and ready with `status:needs-adr`.
+- Phase 54 covers runtime measurement and async contract decision work without implementing async workers, `task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion. The active Phase 54 Successor Gate lives in `docs/plans/phase-54-successor-gate-2026-05-19.md`.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.
 - `#390` `Phase 49: ratify runtime parent-child compare emission policy` is closed by PR `#391`.
 - `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope` is closed by PR `#393`.
 - `#394` `Phase 49: strengthen transfer eval outcome coverage` is closed by PR `#395`.
-- `audit-github-queue` reports the formal paused stop-state with no active milestone.
+- `audit-github-queue` reports `ready` for the Phase 54 runtime-orchestration successor queue.
 - The first formal repository release is published as `v0.1.0`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
@@ -249,5 +254,5 @@ Before builder automation is allowed to write code or auto-merge:
 - Long-running execution must run from isolated worktrees rather than the current `main` checkout.
 - Queue pickup order, one-writer ownership, and branch hygiene should follow `docs/plans/long-running-loop-runbook.md`.
 - When the active milestone exists and the queue reports `ready`, the builder may resume against that milestone only.
-- No active successor queue is open; do not open a parallel execution queue without a fresh approved milestone and exit gate.
+- Phase 54 is the active successor queue; do not open a parallel execution queue while `audit-github-queue` reports `ready` for `Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate`.
 - When no open milestone exists and `audit-github-queue` reports `paused`, treat that state as an intentional released stop-state rather than a broken queue.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note records the formal paused stop-state after the completed Phase 53 transfer-generalization closeout and the formal `v0.1.0` release baseline.
+This note records the active Phase 54 runtime-orchestration successor queue after the completed Phase 53 transfer-generalization closeout and the formal `v0.1.0` release baseline.
 
 ## Snapshot
 
@@ -295,6 +295,17 @@ This note records the formal paused stop-state after the completed Phase 53 tran
     - `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md` records the completed `library-rain` third-world evidence slice
     - Phase 53 strengthened bounded transfer generalization and third-world readiness evidence
     - public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries remain unchanged
+  - `gh issue list --milestone "Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate" --state all`
+    - `#426` `Phase 54 exit gate` is `open` and `status:blocked`
+    - `#427` `Phase 54: sync repo truth after Phase 53 closeout and define runtime gate` is `open` and `status:ready`
+    - `#428` `Phase 54: refresh runtime measurement and decide async contract boundary` is `open`, `status:ready`, and `status:needs-adr`
+  - `gh api repos/YSCJRH/mirror-sim/milestones/54`
+    - milestone `Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate` is `open`
+  - Phase 54 Successor Gate:
+    - `docs/plans/phase-54-successor-gate-2026-05-19.md` records the active gate note
+    - `audit-github-queue` reports `ready`
+    - Phase 54 covers runtime measurement and async contract decision work
+    - public demo, plugin, Hosted GPT/BYOK, launch hub, async implementation, and runtime mutation boundaries remain unchanged
 
 ## Trusted Source Of Truth
 
@@ -316,20 +327,24 @@ This note records the formal paused stop-state after the completed Phase 53 tran
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
 - The default workbench path now consumes the canonical compare artifact directly and keeps focused divergent trace surfaces ahead of heavier packet-driven review flows.
 - The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, execution recovery release boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, escalation acknowledgment packets, and escalation closure packets without introducing backend API expansion.
-- The current repository state has completed the Phase 53 transfer-generalization queue, preserved `v0.1.0` as the latest published release baseline, and returned to the formal paused stop-state with public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries unchanged.
+- The active repository state has Phase 53 transfer-generalization closeout complete, Phase 54 runtime-orchestration successor work open, `v0.1.0` preserved as the latest published release baseline, and public demo, plugin, Hosted GPT/BYOK, launch hub, async implementation, and runtime mutation boundaries unchanged.
 
 ## Next Entry Point
 
 - Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`.
 - Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; before Phase 53 was opened, `audit-github-queue` reported the formal paused stop-state.
-- Phase 53 is closed after PR `#424`, issue `#418`, and milestone `Phase 53 - Transfer Generalization and Third-World Readiness`; `audit-github-queue` reports the formal paused stop-state.
+- Phase 53 is closed after PR `#424`, issue `#418`, and milestone `Phase 53 - Transfer Generalization and Third-World Readiness`; after closeout, the queue returned to the formal paused stop-state until Phase 54 was opened.
+- Phase 54 is active after opening milestone `Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate`; `audit-github-queue` reports `ready`.
 - The Phase 47 unlock order is resolved: the queue-sync issue is closed after PR `#370`, the boundary-regression report is closed after PR `#371`, the runtime-world safety preflight is closed after PR `#372`, the main-path containment report is closed after PR `#373`, and the exit gate is closed after PR `#374`.
 - The Phase 48 unlock order is resolved: `#376` and `#377` closed through earlier Phase 48 PRs, `#378` and `#379` closed through PR `#382`, and `#375` closed after the post-merge exit-gate reassessment.
 - The Phase 49 unlock order is resolved: `#384` closed through PR `#385`, `#386` closed through PR `#387`, `#388` closed through PR `#389`, `#390` closed through PR `#391`, `#392` closed through PR `#393`, `#394` closed through PR `#395`, and `#383` closed after the post-merge exit-gate reassessment.
 - The Phase 50 unlock order is resolved: `#397` closed through PR `#399`, `#398` closed through PR `#400`, `#401` closed through PR `#402`, and `#396` closed after the post-merge exit-gate reassessment.
-- No active successor milestone is open after Phase 53 closeout.
+- The active successor milestone is `Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate`.
 - The Phase 52 exit gate is `#410` `Phase 52 exit gate`, which closed after post-merge validation on `main`.
 - The Phase 53 exit gate is `#418` `Phase 53 exit gate`, which closed after post-merge validation on `main`.
+- The Phase 54 exit gate is `#426` `Phase 54 exit gate`, which is open and blocked.
+- `#427` `Phase 54: sync repo truth after Phase 53 closeout and define runtime gate` is open and ready.
+- `#428` `Phase 54: refresh runtime measurement and decide async contract boundary` is open and ready with `status:needs-adr`.
 - `#397` `Phase 50: sync repo truth after Phase 49 closeout` is closed by PR `#399`.
 - `#398` `Phase 50: measure runtime generation duration before task_id decision` is closed by PR `#400`.
 - `#401` `Phase 50: ratify private-beta launch hub and public-path boundary` is closed by PR `#402`.
@@ -354,6 +369,8 @@ This note records the formal paused stop-state after the completed Phase 53 tran
 - The completed Phase 53 Successor Gate lives in `docs/plans/phase-53-successor-gate-2026-05-19.md`.
 - The completed Phase 53 Transfer Assumption Audit lives in `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`.
 - The completed Phase 53 Third-World Transfer Evidence note lives in `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md` and records `library-rain`.
+- The active Phase 54 Successor Gate lives in `docs/plans/phase-54-successor-gate-2026-05-19.md`.
+- Phase 54 covers runtime measurement and async contract decision work without implementing async workers, `task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.

--- a/docs/plans/phase-54-successor-gate-2026-05-19.md
+++ b/docs/plans/phase-54-successor-gate-2026-05-19.md
@@ -1,0 +1,162 @@
+# Phase 54 Successor Gate
+
+Date: 2026-05-19
+
+Issue: `#427` `Phase 54: sync repo truth after Phase 53 closeout and define runtime gate`
+
+Current state: Phase 54 is active; `audit-github-queue` reports `ready`.
+
+This note records the post-Phase-53 baseline and the Phase 54 successor queue. Phase 54
+is a protected-core runtime-orchestration measurement and async contract decision gate.
+It refreshes the evidence needed before Mirror decides whether to ratify asynchronous
+`task_id`, worker queue, or heartbeat semantics. It is not an async-worker, launch-hub,
+public-path, plugin, Hosted GPT/BYOK, schema-expansion, or runtime-mutation phase.
+
+This gate is recorded at `docs/plans/phase-54-successor-gate-2026-05-19.md`.
+
+## Phase 53 Closeout Evidence
+
+Phase 53 is closed after PR `#424`, issue `#418`, and milestone `Phase 53 - Transfer Generalization and Third-World Readiness`.
+
+- PR `#422` closed `#419` `Phase 53: sync repo truth after Phase 52 closeout and define transfer gate`.
+- PR `#423` closed `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints`.
+- PR `#424` closed `#421` `Phase 53: add bounded third-world transfer readiness evidence`.
+- Issue `#418` `Phase 53 exit gate` is closed after post-merge validation on `main`.
+- Milestone `Phase 53 - Transfer Generalization and Third-World Readiness` is closed.
+- `./make.ps1 eval-transfer` passes with `world_count: 3` and `transfer_proof_world_local: true`.
+- Queue audit reached the formal release stop-state after Phase 53 closed, then returned
+  `ready` once Phase 54 was opened with one blocked exit gate and ready work items.
+
+## Phase 54 Operational Queue
+
+Phase 54 title:
+
+```text
+Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate
+```
+
+Current GitHub objects:
+
+- `#426` `Phase 54 exit gate`
+  - Lane: `protected-core`.
+  - Status: open and blocked.
+- `#427` `Phase 54: sync repo truth after Phase 53 closeout and define runtime gate`
+  - Lane: `protected-core`.
+  - Status: open and ready.
+  - Scope: sync durable docs and tests to the active Phase 54 queue.
+- `#428` `Phase 54: refresh runtime measurement and decide async contract boundary`
+  - Lane: `protected-core`.
+  - Status: open and ready; needs ADR or contract decision before merge.
+  - Scope: refresh hosted/private-beta runtime measurement evidence and decide whether
+    a future async `task_id` / worker queue contract should be ratified.
+
+`python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
+with the note: "Exactly one open milestone exists with a protected blocked exit gate and ready work items."
+
+## Runtime-Orchestration Scope
+
+Phase 54 moves Mirror toward a reviewed runtime orchestration decision. ADR-0006 keeps
+the current v1 runtime synchronous: V1 does not introduce task queues or a separate `task_id` contract. Phase 54 may measure current hosted/private-beta runtime behavior,
+review whether long-running worker semantics are justified, and write a decision note
+that either keeps synchronous v1, ratifies a future async contract, or defers pending
+stronger evidence.
+
+Phase 54 must not implement async workers, task queues, `task_id`, heartbeat, retry,
+cleanup, checkpoint mutation/deletion, restore semantics, or background job APIs before
+a reviewed contract exists. If Phase 54 ratifies any long-lived async/task contract,
+the follow-up must update `docs/architecture/contracts.md` and add an ADR before
+implementation.
+Phase 54 work items do not implement async workers, task queues, `task_id`, heartbeat, retry, cleanup before that reviewed contract exists.
+The public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries remain unchanged.
+
+## Protected-Core Lane Coverage
+
+Phase 54 work is protected-core by default when it touches runtime orchestration,
+async/task semantics, hosted/private-beta measurement, queue governance, route ownership,
+or durable project posture. The lane policy already protects:
+
+- `docs/architecture/contracts.md`
+- `docs/decisions/`
+- `docs/plans/automation-roadmap.md`
+- `docs/plans/current-state-baseline.md`
+- `docs/plans/phase-`
+- runtime session and mutation surfaces
+- eval and report contract surfaces
+
+This protection is operational governance. It does not itself change scenario DSL,
+perturbation payloads, session/node manifests, `decision_trace.jsonl`, compare artifacts,
+public demo artifact layout, or the Mirror Codex MCP contract.
+
+## Carried Forward TODO[verify] Items
+
+- TODO[verify]: Codex UI tool-card evidence remains open until a clean Codex app session
+  shows observable MCP tool or resource cards/traces for the Mirror Codex plugin.
+- TODO[verify]: rerun hosted/private-beta model measurements before introducing async task semantics.
+- TODO[verify]: open a separate migration work item before redirecting or deleting any
+  legacy top-level runtime route.
+- TODO[verify]: require route-derived `worldId` or an equivalent reviewed scope guard
+  before adding any new mutating runtime API.
+- TODO[verify]: do not promote untracked April/private-beta planning notes as durable
+  truth without a reviewed PR.
+- Do not recreate local Codex automations without a new explicit operator request.
+
+## Phase 54 Work Package Map
+
+1. Repo-truth sync after Phase 53 closeout and runtime gate definition
+   - Record Phase 53 closure, Phase 54 queue objects, validation, and carried-forward
+     boundaries across README and active planning docs.
+   - Define the runtime orchestration measurement and async contract decision successor gate.
+   - Keep public demo, plugin, Hosted GPT/BYOK, launch hub, async implementation, and runtime mutation boundaries unchanged.
+
+2. Runtime measurement and async contract decision
+   - Refresh hosted/private-beta runtime measurement evidence.
+   - Record allowed claims, blocked claims, and decision criteria for `task_id` / worker queue semantics.
+   - Decide whether synchronous v1 remains the contract, a future async contract should be ratified, or the decision should be deferred.
+   - Do not implement async workers in this issue.
+
+## Blueprint Boundary
+
+Phase 54 must stay aligned with `mirror.md` and `AGENTS.md`:
+
+- Mirror is a constrained, evidence-backed, replayable what-if sandbox for fictional or
+  explicitly authorized worlds.
+- Do not present Mirror as a real-world prediction machine.
+- Do not build real-person personas or digital doubles.
+- Do not build political persuasion, law-enforcement scoring, hiring, credit, medical, or
+  judicial decision systems.
+- Do not use real-world data, real-person personas, or digital doubles.
+- Every report claim must keep both `label` and `evidence_ids`.
+- Durable contract changes require `docs/architecture/contracts.md` updates and an ADR when
+  the contract is long-lived.
+
+## Non-Goals
+
+- Do not implement async workers, task queues, `task_id`, heartbeat, retry, cleanup,
+  checkpoint mutation/deletion, restore semantics, or background job APIs in Phase 54.
+- Do not implement a launch hub in Phase 54.
+- Do not replace `/` or widen the public path.
+- Do not change public demo behavior.
+- Do not change Mirror Codex plugin MCP tools or resources.
+- Do not add mutating Mirror Codex MCP tools.
+- Do not add Hosted GPT, BYOK, upload, auth, billing, database, object storage, or quota behavior to the public path or plugin path.
+- Do not add new mutating runtime APIs without route-derived `worldId` or an equivalent reviewed scope guard.
+- Do not change scenario DSL, claim labels, report claim `evidence_ids`, run trace shape,
+  compare artifact shape, session/node manifest shape, public demo artifact layout, or
+  plugin MCP contract.
+- Do not claim readiness beyond the three selected bounded fictional worlds before additional
+  evidence or a compatibility contract has passed review and validation.
+
+## Validation Commands
+
+For Phase 54 repo-truth sync, run:
+
+```powershell
+python -m pytest backend/tests/test_phase54_successor_gate.py backend/tests/test_phase53_successor_gate.py -q
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-54-successor-gate-2026-05-19.md backend/tests/test_phase54_successor_gate.py
+git diff --check
+./make.ps1 test
+./make.ps1 eval-demo
+./make.ps1 eval-transfer
+```

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut and the completed Phase 53 transfer-generalization closeout.
+This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 53 transfer-generalization closeout, and the active Phase 54 runtime-orchestration successor queue.
 
 ## Current Gate State
 
@@ -57,12 +57,42 @@ This note records the current post-Day-0 execution status for Mirror after the f
 - Phase 51 exit gate: closed
 - Phase 52 exit gate: closed
 - Phase 53 exit gate: closed
+- Phase 54 exit gate: open and blocked
 
 Local phase audits currently report:
 
 - `phase1`: pass
 - `phase2`: pass
 - `phase3`: pass
+
+## Phase 54 Active Queue
+
+Phase 54 title:
+
+```text
+Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate
+```
+
+- `audit-github-queue`
+  - reports `ready`
+  - confirms exactly one open milestone with a protected blocked exit gate and ready work items
+- milestone `Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate`
+  - open
+- `#426` `Phase 54 exit gate`
+  - open and blocked
+  - labeled `lane:protected-core` because it is the protected closeout gate
+- `#427` `Phase 54: sync repo truth after Phase 53 closeout and define runtime gate`
+  - open and ready
+  - syncs durable docs and tests to the active Phase 54 queue
+- `#428` `Phase 54: refresh runtime measurement and decide async contract boundary`
+  - open and ready
+  - records the runtime measurement and async contract decision work item
+  - labeled `status:needs-adr`
+- boundary posture
+  - Phase 54 covers runtime measurement and async contract decision work without implementing async workers, `task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion.
+  - public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries remain unchanged unless separately ratified.
+- phase gate baseline
+  - active Phase 54 Successor Gate: `docs/plans/phase-54-successor-gate-2026-05-19.md`
 
 ## Phase 53 Closeout
 
@@ -73,7 +103,7 @@ Phase 53 - Transfer Generalization and Third-World Readiness
 ```
 
 - `audit-github-queue`
-  - reports the formal paused stop-state with no active milestone
+  - returned the formal paused stop-state after Phase 53 closeout until Phase 54 was opened
 - milestone `Phase 53 - Transfer Generalization and Third-World Readiness`
   - closed
 - `#418` `Phase 53 exit gate`
@@ -736,7 +766,7 @@ Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Priv
 - Protected-core changes still require explicit review and must not auto-merge.
 - Long-running execution should assign exactly one writer worktree per issue.
 - When `audit-github-queue` reports `ready`, consume only the currently active milestone and do not parallel-open another execution queue.
-- No active successor queue is open; do not open a parallel execution queue without a fresh approved milestone and exit gate.
+- Phase 54 is the active successor queue; do not open a parallel execution queue while `audit-github-queue` reports `ready` for `Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate`.
 - The previous local queue follow-up automation has been revoked or left paused per operator request; do not recreate an automation without a new explicit request.
 
 ## Historical Branch Status


### PR DESCRIPTION
## Summary
- Open Phase 54 repo truth as the active runtime-orchestration successor queue after Phase 53 closeout.
- Add the Phase 54 successor gate note and regression coverage for active docs.
- Keep Phase 53 transfer evidence as historical closeout truth while removing stale current-paused assertions from active docs.

## Boundary
- Protected-core docs/evals sync only.
- No runtime behavior, schema, artifact, public path, plugin, Hosted GPT/BYOK, launch hub, async worker, `task_id`, or runtime mutation implementation changes.

## Validation
- `python -m pytest backend/tests/test_phase54_successor_gate.py backend/tests/test_phase53_successor_gate.py -q` -> 8 passed
- `python scripts/check_no_secrets.py` -> passed
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` -> ready, Phase 54 active
- `python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-54-successor-gate-2026-05-19.md backend/tests/test_phase54_successor_gate.py backend/tests/test_phase53_successor_gate.py backend/tests/test_phase53_third_world_evidence.py backend/tests/test_phase53_transfer_assumption_audit.py` -> lane:protected-core
- `git diff --check` -> passed
- `./make.ps1 test` -> 154 passed
- `./make.ps1 eval-demo` -> pass 23/23
- `./make.ps1 eval-transfer` -> pass, 3 worlds, 60/60 checks
- `./make.ps1 smoke` -> pass 23/23

Closes #427