### PR TITLE
Phase 54 runtime measurement and async contract decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,10 +280,12 @@ Phase 54 Runtime Orchestration Measurement and Async Contract Decision Gate: Pha
 the active successor queue after Phase 53 closeout. `audit-github-queue` reports `ready`
 for milestone `Phase 54 - Runtime Orchestration Measurement and Async Contract Decision
 Gate` with `#426` `Phase 54 exit gate` blocked, `#427` `Phase 54: sync repo truth after
-Phase 53 closeout and define runtime gate` ready, and `#428` `Phase 54: refresh runtime measurement and decide async contract boundary` ready. Phase 54 is a protected-core
-runtime measurement and async contract decision gate; it does not implement async workers,
-`task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion.
-See `docs/plans/phase-54-successor-gate-2026-05-19.md`.
+Phase 53 closeout and define runtime gate` closed by PR `#429`, and `#428` `Phase 54: refresh runtime measurement and decide async contract boundary` recording the Phase 54 Runtime Measurement and Async Contract Decision. Phase 54 is a protected-core
+runtime measurement and async contract decision gate; it keeps synchronous generation for v1,
+defers async task contract ratification, and does not implement async workers, `task_id`,
+launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion.
+See `docs/plans/phase-54-successor-gate-2026-05-19.md` and
+`docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md`.
 
 ---
 
@@ -322,13 +324,15 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - The completed Phase 53 Transfer Assumption Audit lives in [docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md](docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md).
 - The completed Phase 53 Third-World Transfer Evidence note lives in [docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md](docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md).
 - The active Phase 54 Successor Gate lives in [docs/plans/phase-54-successor-gate-2026-05-19.md](docs/plans/phase-54-successor-gate-2026-05-19.md).
+- The Phase 54 Runtime Measurement and Async Contract Decision lives in [docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md](docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md).
 - Phase 48 is closed after PR `#382`, issue `#375`, and milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
 - Phase 49 is closed after PR `#395`, issue `#383`, and milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; completed work items were `#384`, `#386`, `#388`, `#390`, `#392`, and `#394`.
 - Phase 50 is closed after PR `#402`, issue `#396`, and milestone `Phase 50 - Runtime Orchestration Measurement and Product Boundary`; completed work items were `#397`, `#398`, and `#401`. Phase 50 measured before any `task_id` or worker contract is introduced and kept the private-beta launch hub planning-only for now.
 - Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Private-Beta Route Contract and Runtime Readiness Gate`; completed work items were `#404`, `#405`, and `#406`.
 - Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; completed work items were `#411`, `#412`, and `#413`. Before Phase 53 was opened, `audit-github-queue` reported the formal paused stop-state with no active milestone. The legacy top-level runtime routes audit note lives in `docs/plans/phase-52-legacy-runtime-route-audit-2026-05-18.md`; the runtime guard note lives in `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`; Phase 52 did not widen public demo, plugin, Hosted GPT/BYOK, or async contracts and keeps route-derived `worldId` guard coverage in scope.
 - Phase 53 is closed after PR `#424`, issue `#418`, and milestone `Phase 53 - Transfer Generalization and Third-World Readiness`; after closeout, the queue returned to the formal paused stop-state until Phase 54 was opened. `#419` closed by PR `#422`, `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` closed by PR `#423`, and `#421` `Phase 53: add bounded third-world transfer readiness evidence` closed by PR `#424`. Phase 53 strengthened bounded transfer generalization evidence without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries, and `library-rain` is the third-world evidence slice.
-- Phase 54 is active after opening milestone `Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate`; `audit-github-queue` reports `ready` with `#426` blocked, `#427` ready, and `#428` ready. Phase 54 covers runtime measurement and async contract decision work without implementing async workers, `task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion. The Phase 54 Successor Gate lives in `docs/plans/phase-54-successor-gate-2026-05-19.md`.
+- Phase 54 is active after opening milestone `Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate`; `#426` remains the blocked exit gate, `#427` is closed by PR `#429`, and `#428` records the Phase 54 Runtime Measurement and Async Contract Decision. Keep synchronous generation for v1. Defer async task contract ratification. Phase 54 covers runtime measurement and async contract decision work without implementing async workers, `task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion. The Phase 54 Successor Gate lives in `docs/plans/phase-54-successor-gate-2026-05-19.md`; the decision note lives in `docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md`.
+- Phase 54 decision posture: public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries remain unchanged.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
 - Fog Harbor remains the canonical demo world; `museum-night` and `library-rain` are the selected bounded transfer worlds used to prove the pipeline has passed across three selected bounded fictional worlds.
 

--- a/backend/tests/test_phase54_runtime_measurement_async_contract_note.py
+++ b/backend/tests/test_phase54_runtime_measurement_async_contract_note.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+NOTE_PATH = Path("docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md")
+
+
+def test_phase54_runtime_measurement_decision_note_exists_with_required_sections() -> None:
+    assert NOTE_PATH.exists()
+
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    required_sections = [
+        "# Phase 54 Runtime Measurement and Async Contract Decision",
+        "Issue: `#428`",
+        "## Measurement Scope",
+        "## Command Path",
+        "## Observed Evidence",
+        "## Limits",
+        "## Decision",
+        "## Allowed Claims",
+        "## Blocked Claims",
+        "## Async Contract Criteria",
+        "## Non-Goals",
+        "## Validation Commands",
+    ]
+    for section in required_sections:
+        assert section in note
+
+
+def test_phase54_runtime_measurement_decision_records_evidence_and_boundary() -> None:
+    assert NOTE_PATH.exists()
+
+    note = NOTE_PATH.read_text(encoding="utf-8")
+    required_phrases = [
+        "`docs/plans/phase-50-runtime-generation-duration-measurement-2026-05-18.md`",
+        "`docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md`",
+        "`docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md`",
+        "ADR-0006",
+        "V1 does not introduce task queues or a separate `task_id` contract",
+        "sample count: 3",
+        "deterministic_only",
+        "`generate-branch` average: 1381.9 ms",
+        "`start-session + generate-branch` average: 2521.8 ms",
+        "This is still local deterministic evidence, not a hosted/private-beta model measurement",
+        "Keep synchronous generation for v1",
+        "Defer async task contract ratification",
+        "No new async worker, task queue, `task_id`, heartbeat, retry, status, cleanup, checkpoint mutation/deletion, restore, or background job API is ratified by this note",
+        "TODO[verify]: rerun hosted/private-beta model measurements before ratifying async worker semantics.",
+    ]
+    for phrase in required_phrases:
+        assert phrase in note
+
+
+def test_phase54_active_docs_point_to_runtime_measurement_decision_note() -> None:
+    required_docs = [
+        Path("README.md"),
+        Path("docs/plans/current-state-baseline.md"),
+        Path("docs/plans/phase-execution-queue.md"),
+        Path("docs/plans/automation-roadmap.md"),
+        Path("docs/plans/phase-54-successor-gate-2026-05-19.md"),
+    ]
+
+    for path in required_docs:
+        text = path.read_text(encoding="utf-8")
+        assert "`#428`" in text
+        assert "Phase 54 Runtime Measurement and Async Contract Decision" in text
+        assert "`docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md`" in text
+        assert "Keep synchronous generation for v1" in text
+        assert "Defer async task contract ratification" in text
+        assert "public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries remain unchanged" in text
+
+
+def test_phase54_decision_does_not_claim_async_task_contract_is_implemented() -> None:
+    docs = [
+        NOTE_PATH,
+        Path("README.md"),
+        Path("docs/plans/current-state-baseline.md"),
+        Path("docs/plans/phase-execution-queue.md"),
+        Path("docs/plans/automation-roadmap.md"),
+        Path("docs/plans/phase-54-successor-gate-2026-05-19.md"),
+    ]
+    banned_phrases = [
+        "async workers are implemented",
+        "task queues are implemented",
+        "`task_id` contract is ratified",
+        "background job API is implemented",
+        "Hosted GPT/BYOK is enabled",
+    ]
+
+    for path in docs:
+        text = path.read_text(encoding="utf-8")
+        for phrase in banned_phrases:
+            assert phrase not in text, f"{path} claims an out-of-scope async/runtime expansion: {phrase}"

--- a/backend/tests/test_phase54_successor_gate.py
+++ b/backend/tests/test_phase54_successor_gate.py
@@ -13,7 +13,7 @@ def test_phase54_successor_gate_exists_with_required_sections() -> None:
     required_sections = [
         "# Phase 54 Successor Gate",
         "Issue: `#427` `Phase 54: sync repo truth after Phase 53 closeout and define runtime gate`",
-        "Current state: Phase 54 is active; `audit-github-queue` reports `ready`.",
+        "Current state: Phase 54 is active after PR `#429`; `#428` records the runtime",
         "## Phase 53 Closeout Evidence",
         "## Phase 54 Operational Queue",
         "## Runtime-Orchestration Scope",
@@ -38,14 +38,19 @@ def test_phase54_successor_gate_records_queue_and_boundaries() -> None:
         "`#427` `Phase 54: sync repo truth after Phase 53 closeout and define runtime gate`",
         "`#428` `Phase 54: refresh runtime measurement and decide async contract boundary`",
         "Status: open and blocked.",
-        "Status: open and ready.",
-        "Status: open and ready; needs ADR or contract decision before merge.",
+        "Status: closed by PR `#429`.",
+        "Status: active decision work item with `status:needs-adr`.",
         "Exactly one open milestone exists with a protected blocked exit gate and ready work items",
         "Phase 53 is closed after PR `#424`, issue `#418`, and milestone `Phase 53 - Transfer Generalization and Third-World Readiness`",
         "runtime measurement",
         "async contract decision",
         "ADR-0006",
         "V1 does not introduce task queues or a separate `task_id` contract",
+        "`docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md`",
+        "refresh local deterministic runtime measurement evidence",
+        "hosted/private-beta measurement verification as TODO[verify]",
+        "Keep synchronous generation for v1",
+        "Defer async task contract ratification",
         "do not implement async workers, task queues, `task_id`, heartbeat, retry, cleanup",
         "Do not replace `/` or widen the public path",
         "Do not implement a launch hub",
@@ -57,6 +62,13 @@ def test_phase54_successor_gate_records_queue_and_boundaries() -> None:
     ]
     for phrase in required_phrases:
         assert phrase in gate
+
+    stale_phrases = [
+        "refresh hosted/private-beta runtime measurement evidence",
+        "Refresh hosted/private-beta runtime measurement evidence",
+    ]
+    for phrase in stale_phrases:
+        assert phrase not in gate
 
 
 def test_active_state_docs_point_to_phase54_queue() -> None:

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -188,9 +188,11 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 53 strengthened bounded transfer generalization and third-world readiness evidence without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries. The completed Phase 53 Successor Gate lives in `docs/plans/phase-53-successor-gate-2026-05-19.md`; the transfer-assumption audit lives in `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`; the third-world evidence note lives in `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md`.
 - Phase 54 is active after opening milestone `Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate`.
 - `#426` `Phase 54 exit gate` is open and blocked.
-- `#427` `Phase 54: sync repo truth after Phase 53 closeout and define runtime gate` is open and ready.
-- `#428` `Phase 54: refresh runtime measurement and decide async contract boundary` is open and ready with `status:needs-adr`.
-- Phase 54 covers runtime measurement and async contract decision work without implementing async workers, `task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion. The active Phase 54 Successor Gate lives in `docs/plans/phase-54-successor-gate-2026-05-19.md`.
+- `#427` `Phase 54: sync repo truth after Phase 53 closeout and define runtime gate` is closed by PR `#429`.
+- `#428` `Phase 54: refresh runtime measurement and decide async contract boundary` records the Phase 54 Runtime Measurement and Async Contract Decision with `status:needs-adr`.
+- Keep synchronous generation for v1. Defer async task contract ratification.
+- Phase 54 decision posture: public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries remain unchanged.
+- Phase 54 covers runtime measurement and async contract decision work without implementing async workers, `task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion. The active Phase 54 Successor Gate lives in `docs/plans/phase-54-successor-gate-2026-05-19.md`; the decision note lives in `docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md`.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -297,14 +297,16 @@ This note records the active Phase 54 runtime-orchestration successor queue afte
     - public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries remain unchanged
   - `gh issue list --milestone "Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate" --state all`
     - `#426` `Phase 54 exit gate` is `open` and `status:blocked`
-    - `#427` `Phase 54: sync repo truth after Phase 53 closeout and define runtime gate` is `open` and `status:ready`
-    - `#428` `Phase 54: refresh runtime measurement and decide async contract boundary` is `open`, `status:ready`, and `status:needs-adr`
+    - `#427` `Phase 54: sync repo truth after Phase 53 closeout and define runtime gate` is `closed` by PR `#429`
+    - `#428` `Phase 54: refresh runtime measurement and decide async contract boundary` records the Phase 54 Runtime Measurement and Async Contract Decision and carries `status:needs-adr`
   - `gh api repos/YSCJRH/mirror-sim/milestones/54`
     - milestone `Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate` is `open`
   - Phase 54 Successor Gate:
     - `docs/plans/phase-54-successor-gate-2026-05-19.md` records the active gate note
+    - `docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md` records the Phase 54 Runtime Measurement and Async Contract Decision
     - `audit-github-queue` reports `ready`
     - Phase 54 covers runtime measurement and async contract decision work
+    - Keep synchronous generation for v1. Defer async task contract ratification.
     - public demo, plugin, Hosted GPT/BYOK, launch hub, async implementation, and runtime mutation boundaries remain unchanged
 
 ## Trusted Source Of Truth
@@ -327,7 +329,7 @@ This note records the active Phase 54 runtime-orchestration successor queue afte
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
 - The default workbench path now consumes the canonical compare artifact directly and keeps focused divergent trace surfaces ahead of heavier packet-driven review flows.
 - The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, execution recovery release boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, escalation acknowledgment packets, and escalation closure packets without introducing backend API expansion.
-- The active repository state has Phase 53 transfer-generalization closeout complete, Phase 54 runtime-orchestration successor work open, `v0.1.0` preserved as the latest published release baseline, and public demo, plugin, Hosted GPT/BYOK, launch hub, async implementation, and runtime mutation boundaries unchanged.
+- The active repository state has Phase 53 transfer-generalization closeout complete, Phase 54 Runtime Measurement and Async Contract Decision recorded, `v0.1.0` preserved as the latest published release baseline, and public demo, plugin, Hosted GPT/BYOK, launch hub, async implementation, and runtime mutation boundaries unchanged.
 
 ## Next Entry Point
 
@@ -343,8 +345,9 @@ This note records the active Phase 54 runtime-orchestration successor queue afte
 - The Phase 52 exit gate is `#410` `Phase 52 exit gate`, which closed after post-merge validation on `main`.
 - The Phase 53 exit gate is `#418` `Phase 53 exit gate`, which closed after post-merge validation on `main`.
 - The Phase 54 exit gate is `#426` `Phase 54 exit gate`, which is open and blocked.
-- `#427` `Phase 54: sync repo truth after Phase 53 closeout and define runtime gate` is open and ready.
-- `#428` `Phase 54: refresh runtime measurement and decide async contract boundary` is open and ready with `status:needs-adr`.
+- `#427` `Phase 54: sync repo truth after Phase 53 closeout and define runtime gate` is closed by PR `#429`.
+- `#428` `Phase 54: refresh runtime measurement and decide async contract boundary` records the Phase 54 Runtime Measurement and Async Contract Decision with `status:needs-adr`.
+- Keep synchronous generation for v1. Defer async task contract ratification.
 - `#397` `Phase 50: sync repo truth after Phase 49 closeout` is closed by PR `#399`.
 - `#398` `Phase 50: measure runtime generation duration before task_id decision` is closed by PR `#400`.
 - `#401` `Phase 50: ratify private-beta launch hub and public-path boundary` is closed by PR `#402`.
@@ -370,7 +373,9 @@ This note records the active Phase 54 runtime-orchestration successor queue afte
 - The completed Phase 53 Transfer Assumption Audit lives in `docs/plans/phase-53-transfer-assumption-audit-2026-05-19.md`.
 - The completed Phase 53 Third-World Transfer Evidence note lives in `docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md` and records `library-rain`.
 - The active Phase 54 Successor Gate lives in `docs/plans/phase-54-successor-gate-2026-05-19.md`.
+- The Phase 54 Runtime Measurement and Async Contract Decision lives in `docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md`.
 - Phase 54 covers runtime measurement and async contract decision work without implementing async workers, `task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion.
+- Phase 54 decision posture: public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries remain unchanged.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.

--- a/docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md
+++ b/docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md
@@ -1,0 +1,186 @@
+# Phase 54 Runtime Measurement and Async Contract Decision
+
+Date: 2026-05-19
+
+Issue: `#428` `Phase 54: refresh runtime measurement and decide async contract boundary`
+
+## Measurement Scope
+
+This note refreshes Mirror's runtime-orchestration evidence before any asynchronous
+`task_id`, worker, heartbeat, retry, status, or cleanup contract is ratified.
+
+The measured path stays inside the accepted v1 interactive simulator contract:
+
+- `start-session`
+- `generate-branch`
+- session-scoped node, run, report, claims, resolution, and compare artifacts
+
+The refreshed sample uses `deterministic_only` to measure the current local Mirror
+runtime path without hosted model latency, external network latency, API key handling,
+quota effects, browser rendering, or deployed Next.js server behavior.
+
+This is still local deterministic evidence, not a hosted/private-beta model measurement.
+
+## Command Path
+
+Frontend product path:
+
+- `frontend/src/app/api/runtime/generate-branch/route.ts` validates the request, keeps public
+  demo mutation blocking in place, checks provider-specific access, and awaits
+  `generateRuntimeBranch(...)`.
+- `frontend/src/app/lib/runtime-cli.ts` calls `python -m backend.app.cli generate-branch`
+  with the route-derived world id, artifacts root, and request-scoped runtime environment
+  values.
+- `backend/app/cli.py` dispatches to `backend/app/sessions/service.py`.
+- `backend/app/sessions/service.py` resolves the perturbation, materializes parent and child
+  run artifacts, emits parent-vs-child compare output, writes report/claims/resolution
+  artifacts, updates `active_node_id`, and updates `last_activity_at`.
+
+Measured command pattern:
+
+```powershell
+python -m backend.app.cli start-session `
+  --world fog-harbor-east-gate `
+  --scenario scenario_baseline `
+  --decision-provider deterministic_only `
+  --artifacts-root <temp-sample-root>
+
+python -m backend.app.cli generate-branch `
+  --world fog-harbor-east-gate `
+  --session <session_id> `
+  --from node_root `
+  --perturbation '{"kind":"delay_document","target_id":"doc_ledger_copy","timing":"before_publication","summary":"Delay the copied ledger before it reaches the public decision loop.","parameters":{"actor_id":"entity_lin_lan","delay_turns":2,"cause":"courier_interruption"}}' `
+  --artifacts-root <temp-sample-root>
+```
+
+Generated measurement artifacts were written to a Windows user temp directory and were not
+committed.
+
+## Observed Evidence
+
+Prior accepted evidence:
+
+- `docs/plans/phase-50-runtime-generation-duration-measurement-2026-05-18.md` recorded
+  five local `deterministic_only` samples.
+- Phase 50 observed `generate-branch` average: 1218.1 ms.
+- Phase 50 observed `start-session + generate-branch` average: 2211.6 ms.
+- `docs/plans/phase-51-runtime-readiness-guards-2026-05-18.md` kept synchronous generation
+  for v1 and recorded route-derived `worldId` mutation guards.
+- `docs/plans/phase-52-runtime-mutation-guard-regression-2026-05-18.md` preserved the
+  runtime mutation guard regression baseline without widening public/plugin/async contracts.
+
+Phase 54 refreshed local sample:
+
+sample count: 3
+
+All samples used:
+
+- world: `fog-harbor-east-gate`
+- scenario: `scenario_baseline`
+- provider: `deterministic_only`
+- parent node: `node_root`
+- perturbation kind: `delay_document`
+- target: `doc_ledger_copy`
+- timing: `before_publication`
+
+| Sample | Session | `start-session` | `generate-branch` | Total |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | `session_fog_harbor_east_gate_scenario_baseline_fda0e6d9` | 1138.3 ms | 1396.1 ms | 2534.4 ms |
+| 2 | `session_fog_harbor_east_gate_scenario_baseline_6817c3ec` | 1145.4 ms | 1378.2 ms | 2523.5 ms |
+| 3 | `session_fog_harbor_east_gate_scenario_baseline_fc3c3962` | 1136.0 ms | 1371.5 ms | 2507.5 ms |
+
+Summary:
+
+- `generate-branch` min: 1371.5 ms.
+- `generate-branch` max: 1396.1 ms.
+- `generate-branch` average: 1381.9 ms.
+- `start-session + generate-branch` average: 2521.8 ms.
+
+## Limits
+
+- This is a local deterministic measurement, not a hosted/private-beta model measurement.
+- The sample does not include hosted OpenAI latency, OpenAI-compatible BYOK latency,
+  deployment filesystem latency, reverse proxy behavior, browser rendering, or concurrent
+  requests.
+- The sample does not establish a product timeout budget or service-level objective.
+- The sample count is small and is intended to decide whether current evidence justifies
+  widening the v1 contract, not to publish a latency guarantee.
+- TODO[verify]: rerun hosted/private-beta model measurements before ratifying async worker semantics.
+
+## Decision
+
+Keep synchronous generation for v1.
+
+Defer async task contract ratification.
+
+ADR-0006 and `docs/architecture/contracts.md` remain the active runtime contract boundary:
+V1 does not introduce task queues or a separate `task_id` contract.
+
+The refreshed evidence is consistent with Phase 50's local deterministic measurement and
+does not justify widening Mirror's v1 runtime contract.
+No new async worker, task queue, `task_id`, heartbeat, retry, status, cleanup, checkpoint mutation/deletion, restore, or background job API is ratified by this note.
+
+Because this decision does not ratify a new long-lived async/task contract, this phase does
+not update `docs/architecture/contracts.md` and does not add a new ADR. A future ADR remains
+required before implementing async runtime orchestration.
+
+## Allowed Claims
+
+- Mirror has refreshed local deterministic runtime generation evidence for Phase 54.
+- Local deterministic `generate-branch` remains roughly in the same order of magnitude as
+  the prior Phase 50 sample.
+- Current evidence supports keeping synchronous v1 generation.
+- Hosted/private-beta runtime duration is still unverified.
+- Public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries remain unchanged.
+
+## Blocked Claims
+
+- Do not claim Mirror has hosted/private-beta latency evidence from this note.
+- Do not claim a product timeout budget or service-level objective has been ratified.
+- Do not claim async workers, task queues, `task_id`, heartbeat, retry, status, cleanup,
+  checkpoint mutation/deletion, restore, or background job APIs are implemented or approved.
+- Do not claim public demo, plugin, Hosted GPT/BYOK, launch hub, upload, auth, billing,
+  database, object storage, or quota behavior has been widened.
+
+## Async Contract Criteria
+
+Open a new protected-core ADR before any async runtime implementation if future evidence or
+product requirements require one or more of these properties:
+
+- request durations exceed a named product threshold in hosted/private-beta measurement
+- progress reporting is required
+- cancellation semantics are required
+- retry ownership or retry limits are required
+- durable status lookup is required
+- cleanup behavior is required
+- worker ownership, heartbeat, or lease behavior is required
+- rollback/checkpoint interaction changes are required
+
+That ADR must define `task_id`, status payloads, worker ownership, retry behavior, cleanup
+behavior, artifact ownership, and rollback/checkpoint interaction as one reviewed
+protected-core contract change.
+
+## Non-Goals
+
+- Do not implement async workers, task queues, `task_id`, heartbeat, retry, status, cleanup,
+  checkpoint mutation/deletion, restore semantics, or background job APIs in `#428`.
+- Do not change session or node manifest shape.
+- Do not change compare artifact shape.
+- Do not change scenario DSL, claim labels, report claim `evidence_ids`, run trace shape, or
+  public demo artifact layout.
+- Do not expand public demo, plugin, hosted-model, BYOK, upload, auth, billing, database,
+  object storage, or quota behavior.
+- Do not commit generated measurement artifacts.
+
+## Validation Commands
+
+```powershell
+python -m pytest backend/tests/test_phase54_runtime_measurement_async_contract_note.py backend/tests/test_phase54_successor_gate.py -q
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-54-successor-gate-2026-05-19.md docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md backend/tests/test_phase54_successor_gate.py backend/tests/test_phase54_runtime_measurement_async_contract_note.py
+git diff --check
+./make.ps1 test
+./make.ps1 eval-demo
+./make.ps1 eval-transfer
+```

--- a/docs/plans/phase-54-successor-gate-2026-05-19.md
+++ b/docs/plans/phase-54-successor-gate-2026-05-19.md
@@ -4,7 +4,8 @@ Date: 2026-05-19
 
 Issue: `#427` `Phase 54: sync repo truth after Phase 53 closeout and define runtime gate`
 
-Current state: Phase 54 is active; `audit-github-queue` reports `ready`.
+Current state: Phase 54 is active after PR `#429`; `#428` records the runtime
+measurement and async contract decision.
 
 This note records the post-Phase-53 baseline and the Phase 54 successor queue. Phase 54
 is a protected-core runtime-orchestration measurement and async contract decision gate.
@@ -13,6 +14,8 @@ It refreshes the evidence needed before Mirror decides whether to ratify asynchr
 public-path, plugin, Hosted GPT/BYOK, schema-expansion, or runtime-mutation phase.
 
 This gate is recorded at `docs/plans/phase-54-successor-gate-2026-05-19.md`.
+The Phase 54 Runtime Measurement and Async Contract Decision lives in
+`docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md`.
 
 ## Phase 53 Closeout Evidence
 
@@ -42,13 +45,16 @@ Current GitHub objects:
   - Status: open and blocked.
 - `#427` `Phase 54: sync repo truth after Phase 53 closeout and define runtime gate`
   - Lane: `protected-core`.
-  - Status: open and ready.
+  - Status: closed by PR `#429`.
   - Scope: sync durable docs and tests to the active Phase 54 queue.
 - `#428` `Phase 54: refresh runtime measurement and decide async contract boundary`
   - Lane: `protected-core`.
-  - Status: open and ready; needs ADR or contract decision before merge.
-  - Scope: refresh hosted/private-beta runtime measurement evidence and decide whether
-    a future async `task_id` / worker queue contract should be ratified.
+  - Status: active decision work item with `status:needs-adr`.
+  - Scope: refresh local deterministic runtime measurement evidence, keep
+    hosted/private-beta measurement verification as TODO[verify], and decide whether a
+    future async `task_id` / worker queue contract should be ratified.
+  - Decision note:
+    `docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md`.
 
 `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports `ready`
 with the note: "Exactly one open milestone exists with a protected blocked exit gate and ready work items."
@@ -60,6 +66,11 @@ the current v1 runtime synchronous: V1 does not introduce task queues or a separ
 review whether long-running worker semantics are justified, and write a decision note
 that either keeps synchronous v1, ratifies a future async contract, or defers pending
 stronger evidence.
+
+`docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md` records
+the Phase 54 decision: Keep synchronous generation for v1. Defer async task contract ratification.
+The refreshed evidence is local deterministic evidence only; hosted/private-beta model
+duration remains TODO[verify].
 
 Phase 54 must not implement async workers, task queues, `task_id`, heartbeat, retry,
 cleanup, checkpoint mutation/deletion, restore semantics, or background job APIs before
@@ -109,9 +120,13 @@ public demo artifact layout, or the Mirror Codex MCP contract.
    - Keep public demo, plugin, Hosted GPT/BYOK, launch hub, async implementation, and runtime mutation boundaries unchanged.
 
 2. Runtime measurement and async contract decision
-   - Refresh hosted/private-beta runtime measurement evidence.
+   - Refresh local deterministic runtime measurement evidence and defer
+     hosted/private-beta measurement verification.
    - Record allowed claims, blocked claims, and decision criteria for `task_id` / worker queue semantics.
    - Decide whether synchronous v1 remains the contract, a future async contract should be ratified, or the decision should be deferred.
+   - Phase 54 Runtime Measurement and Async Contract Decision:
+     `docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md`.
+   - Keep synchronous generation for v1; Defer async task contract ratification.
    - Do not implement async workers in this issue.
 
 ## Blueprint Boundary
@@ -148,13 +163,13 @@ Phase 54 must stay aligned with `mirror.md` and `AGENTS.md`:
 
 ## Validation Commands
 
-For Phase 54 repo-truth sync, run:
+For Phase 54 runtime measurement and async contract decision, run:
 
 ```powershell
-python -m pytest backend/tests/test_phase54_successor_gate.py backend/tests/test_phase53_successor_gate.py -q
+python -m pytest backend/tests/test_phase54_runtime_measurement_async_contract_note.py backend/tests/test_phase54_successor_gate.py -q
 python scripts/check_no_secrets.py
 python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
-python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-54-successor-gate-2026-05-19.md backend/tests/test_phase54_successor_gate.py
+python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-54-successor-gate-2026-05-19.md docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md backend/tests/test_phase54_successor_gate.py backend/tests/test_phase54_runtime_measurement_async_contract_note.py
 git diff --check
 ./make.ps1 test
 ./make.ps1 eval-demo

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -82,13 +82,14 @@ Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate
   - open and blocked
   - labeled `lane:protected-core` because it is the protected closeout gate
 - `#427` `Phase 54: sync repo truth after Phase 53 closeout and define runtime gate`
-  - open and ready
+  - closed by PR `#429`
   - syncs durable docs and tests to the active Phase 54 queue
 - `#428` `Phase 54: refresh runtime measurement and decide async contract boundary`
-  - open and ready
-  - records the runtime measurement and async contract decision work item
+  - records the Phase 54 Runtime Measurement and Async Contract Decision
   - labeled `status:needs-adr`
+  - decision note: `docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md`
 - boundary posture
+  - Keep synchronous generation for v1. Defer async task contract ratification.
   - Phase 54 covers runtime measurement and async contract decision work without implementing async workers, `task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion.
   - public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries remain unchanged unless separately ratified.
 - phase gate baseline


### PR DESCRIPTION
## Summary
- add the Phase 54 runtime measurement and async contract decision note for #428
- record refreshed local deterministic runtime evidence and keep hosted/private-beta measurement as TODO[verify]
- keep synchronous v1 generation and defer async task contract ratification without implementing workers, queues, task_id, status, retry, or cleanup semantics
- sync active Phase 54 docs and doc-lock tests to the decision posture

Closes #428.

## Validation
- python -m pytest backend/tests/test_phase54_runtime_measurement_async_contract_note.py backend/tests/test_phase54_successor_gate.py -q
- python scripts/check_no_secrets.py
- python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
- python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-54-successor-gate-2026-05-19.md docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md backend/tests/test_phase54_successor_gate.py backend/tests/test_phase54_runtime_measurement_async_contract_note.py
- git diff --check
- ./make.ps1 test
- ./make.ps1 eval-demo
- ./make.ps1 eval-transfer