### PR TITLE
Record Phase 55 closeout baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,15 +287,14 @@ launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion.
 See `docs/plans/phase-54-successor-gate-2026-05-19.md` and
 `docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md`.
 
-Phase 55 Analysis-First Main Path and Review Surface Guardrails: Phase 55 is the
-active successor queue after the Phase 54 closeout. `#432` is the blocked Phase 55
-exit gate, `#433` syncs repo truth and defines the main-path gate, `#434` audits
-candidate product-reframe planning notes, and `#435` adds a focused analysis-first
-review-surface regression guardrail. `audit-github-queue` reports `ready` for the
-Phase 55 queue. Phase 55 keeps public demo, plugin, Hosted GPT/BYOK, launch hub,
-async, and runtime mutation boundaries unchanged, and untracked private-beta,
-kernel, and design-system planning notes remain candidate inputs until a reviewed
-PR intentionally promotes them. See
+Phase 55 Analysis-First Main Path and Review Surface Guardrails: Phase 55 is closed
+after PR `#438`, issue `#432`, and milestone `Phase 55 - Analysis-First Main Path
+and Review Surface Guardrails`. `#433` closed by PR `#436`, `#434` closed by PR
+`#437`, and `#435` closed by PR `#438`. After closeout, `audit-github-queue`
+reports `paused` in the formal paused stop-state until a successor milestone opens.
+Phase 55 kept public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime
+mutation boundaries unchanged, and untracked private-beta, kernel, and design-system
+planning notes remain candidate inputs until a reviewed PR intentionally promotes them. See
 `docs/plans/phase-55-successor-gate-2026-05-20.md`.
 
 ---
@@ -336,7 +335,7 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - The completed Phase 53 Third-World Transfer Evidence note lives in [docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md](docs/plans/phase-53-third-world-transfer-evidence-2026-05-19.md).
 - The completed Phase 54 Successor Gate lives in [docs/plans/phase-54-successor-gate-2026-05-19.md](docs/plans/phase-54-successor-gate-2026-05-19.md).
 - The Phase 54 Runtime Measurement and Async Contract Decision lives in [docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md](docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md).
-- The active Phase 55 Successor Gate lives in [docs/plans/phase-55-successor-gate-2026-05-20.md](docs/plans/phase-55-successor-gate-2026-05-20.md).
+- The completed Phase 55 Successor Gate lives in [docs/plans/phase-55-successor-gate-2026-05-20.md](docs/plans/phase-55-successor-gate-2026-05-20.md).
 - Phase 48 is closed after PR `#382`, issue `#375`, and milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
 - Phase 49 is closed after PR `#395`, issue `#383`, and milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; completed work items were `#384`, `#386`, `#388`, `#390`, `#392`, and `#394`.
 - Phase 50 is closed after PR `#402`, issue `#396`, and milestone `Phase 50 - Runtime Orchestration Measurement and Product Boundary`; completed work items were `#397`, `#398`, and `#401`. Phase 50 measured before any `task_id` or worker contract is introduced and kept the private-beta launch hub planning-only for now.
@@ -345,7 +344,7 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - Phase 53 is closed after PR `#424`, issue `#418`, and milestone `Phase 53 - Transfer Generalization and Third-World Readiness`; after closeout, the queue returned to the formal paused stop-state until Phase 54 was opened. `#419` closed by PR `#422`, `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` closed by PR `#423`, and `#421` `Phase 53: add bounded third-world transfer readiness evidence` closed by PR `#424`. Phase 53 strengthened bounded transfer generalization evidence without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries, and `library-rain` is the third-world evidence slice.
 - Phase 54 is closed after PR `#430`, issue `#426`, and milestone `Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate`; after closeout, `audit-github-queue` reported `paused` in the formal paused stop-state until Phase 55 opened. `#427` closed by PR `#429`, and `#428` closed by PR `#430`. Keep synchronous generation for v1. Defer async task contract ratification. Phase 54 covered runtime measurement and async contract decision work without implementing async workers, `task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion. The Phase 54 Successor Gate lives in `docs/plans/phase-54-successor-gate-2026-05-19.md`; the decision note lives in `docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md`.
 - Phase 54 decision posture: public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries remain unchanged.
-- Phase 55 is active under milestone `Phase 55 - Analysis-First Main Path and Review Surface Guardrails`; `#432` is the blocked exit gate, `#433`, `#434`, and `#435` are ready work items, and `audit-github-queue` reports `ready`. The Phase 55 Successor Gate lives in `docs/plans/phase-55-successor-gate-2026-05-20.md`.
+- Phase 55 is closed after PR `#438`, issue `#432`, and milestone `Phase 55 - Analysis-First Main Path and Review Surface Guardrails`; `#433` closed by PR `#436`, `#434` closed by PR `#437`, and `#435` closed by PR `#438`. After closeout, `audit-github-queue` reports `paused` in the formal paused stop-state until a successor milestone opens. The Phase 55 Successor Gate lives in `docs/plans/phase-55-successor-gate-2026-05-20.md`.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
 - Fog Harbor remains the canonical demo world; `museum-night` and `library-rain` are the selected bounded transfer worlds used to prove the pipeline has passed across three selected bounded fictional worlds.
 

--- a/backend/tests/test_phase55_successor_gate.py
+++ b/backend/tests/test_phase55_successor_gate.py
@@ -13,9 +13,10 @@ def test_phase55_successor_gate_exists_with_required_sections() -> None:
     required_sections = [
         "# Phase 55 Successor Gate",
         "Issue: `#433` `Phase 55: sync repo truth after Phase 54 closeout and define main-path gate`",
-        "Current state: Phase 55 is the active successor queue",
+        "Current state: Phase 55 is closed; no active successor milestone is open.",
         "## Phase 54 Closeout Evidence",
         "## Phase 55 Operational Queue",
+        "## Phase 55 Closeout Evidence",
         "## Analysis-First Main-Path Scope",
         "## Candidate Planning Input Rules",
         "## Protected-Core Lane Coverage",
@@ -39,7 +40,19 @@ def test_phase55_successor_gate_records_queue_and_boundaries() -> None:
         "`#433` `Phase 55: sync repo truth after Phase 54 closeout and define main-path gate`",
         "`#434` `Phase 55: audit candidate product-reframe plans and freeze contract-safe scope`",
         "`#435` `Phase 55: add analysis-first review-surface regression guardrail`",
-        "`ready` with exactly one open milestone",
+        "Status: closed after post-merge validation.",
+        "Status: closed by PR `#436`.",
+        "Status: closed by PR `#437`.",
+        "Status: closed by PR `#438`.",
+        "formal paused stop-state",
+        "no active successor milestone is open",
+        "`docs/plans/phase-55-candidate-plan-audit-2026-05-20.md`",
+        "PR `#436` closed `#433`",
+        "PR `#437` closed `#434`",
+        "PR `#438` closed `#435`",
+        "`./make.ps1 smoke` passes with 23/23 checks",
+        "`./make.ps1 test` passes with 170 tests",
+        "`./make.ps1 eval-demo` passes with 23/23 checks",
         "analysis-first main-path and review-surface guardrail phase",
         "candidate inputs only until a PR intentionally promotes",
         "Candidate notes that claim `/` is already a launch hub",
@@ -57,7 +70,7 @@ def test_phase55_successor_gate_records_queue_and_boundaries() -> None:
         assert phrase in gate
 
 
-def test_active_state_docs_record_phase55_active_queue() -> None:
+def test_active_state_docs_record_phase55_closeout() -> None:
     required_docs = [
         Path("README.md"),
         Path("docs/plans/current-state-baseline.md"),
@@ -74,14 +87,18 @@ def test_active_state_docs_record_phase55_active_queue() -> None:
         assert "`#435`" in text
         assert "Phase 55 Successor Gate" in text
         assert "`docs/plans/phase-55-successor-gate-2026-05-20.md`" in text
-        assert "`audit-github-queue` reports `ready`" in text
+        assert "`audit-github-queue` reports `paused`" in text or "reported `paused`" in text
         assert "Phase 54 is closed after PR `#430`" in text
+        assert "Phase 55 is closed after PR `#438`, issue `#432`, and milestone" in text
+        assert "`#433`" in text and "closed by PR `#436`" in text
+        assert "`#434`" in text and "closed by PR `#437`" in text
+        assert "`#435`" in text and "closed by PR `#438`" in text
         assert "Keep synchronous generation for v1. Defer async task contract ratification." in text
         assert "untracked" in text
         assert "candidate inputs" in text
 
 
-def test_active_state_docs_do_not_treat_phase55_as_closed_or_expanded() -> None:
+def test_active_state_docs_do_not_treat_phase55_as_active_or_expanded() -> None:
     required_docs = [
         Path("README.md"),
         Path("docs/plans/current-state-baseline.md"),
@@ -90,15 +107,19 @@ def test_active_state_docs_do_not_treat_phase55_as_closed_or_expanded() -> None:
         PHASE55_GATE_PATH,
     ]
     stale_or_expanded_phrases = [
-        "Phase 55 is closed",
-        "Phase 55 exit gate: closed",
-        "Phase 55 milestone is closed",
+        "Phase 55 is the active successor queue",
+        "Phase 55 is active after opening milestone",
+        "Phase 55 exit gate: open and blocked",
+        "`#432` is the blocked exit gate",
+        "`#433`, `#434`, and `#435` are ready work items",
+        "`audit-github-queue` reports `ready` for the active Phase 55 queue",
+        "`audit-github-queue` reports `ready` for the Phase 55 queue",
+        "active Phase 55 queue",
         "Phase 55 implements async",
         "Phase 55 implements a launch hub",
         "Phase 55 adds Hosted GPT",
         "Phase 55 adds BYOK",
         "Phase 55 changes the public path",
-        "No active successor milestone is open after Phase 54 closeout",
     ]
 
     for path in required_docs:

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, Phase 47 closeout is complete, Phase 48 closeout is complete, Phase 49 closeout is complete, Phase 50 closeout is complete, Phase 51 closeout is complete, Phase 52 closeout is complete, Phase 53 closeout is complete, Phase 54 closeout is complete, Phase 55 is active, and the first formal release remains published as `v0.1.0`.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, Phase 47 closeout is complete, Phase 48 closeout is complete, Phase 49 closeout is complete, Phase 50 closeout is complete, Phase 51 closeout is complete, Phase 52 closeout is complete, Phase 53 closeout is complete, Phase 54 closeout is complete, Phase 55 closeout is complete, and the first formal release remains published as `v0.1.0`.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -195,19 +195,18 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - Phase 54 decision posture: public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries remain unchanged.
 - Phase 54 covered runtime measurement and async contract decision work without implementing async workers, `task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion. The completed Phase 54 Successor Gate lives in `docs/plans/phase-54-successor-gate-2026-05-19.md`; the decision note lives in `docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md`.
 - After Phase 54 closeout, `audit-github-queue` reported `paused` in the formal paused stop-state until Phase 55 opened.
-- Phase 55 is active after opening milestone `Phase 55 - Analysis-First Main Path and Review Surface Guardrails`.
-- `#432` `Phase 55 exit gate` is open and blocked.
-- `#433` `Phase 55: sync repo truth after Phase 54 closeout and define main-path gate` is ready.
-- `#434` `Phase 55: audit candidate product-reframe plans and freeze contract-safe scope` is ready.
-- `#435` `Phase 55: add analysis-first review-surface regression guardrail` is ready.
-- Phase 55 covers candidate planning audit and analysis-first review-surface guardrails without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries. The active Phase 55 Successor Gate lives in `docs/plans/phase-55-successor-gate-2026-05-20.md`. Local untracked April/private-beta/kernel/design-system planning files remain candidate inputs until a reviewed PR intentionally promotes them.
+- Phase 55 is closed after PR `#438`, issue `#432`, and milestone `Phase 55 - Analysis-First Main Path and Review Surface Guardrails`.
+- `#433` `Phase 55: sync repo truth after Phase 54 closeout and define main-path gate` is closed by PR `#436`.
+- `#434` `Phase 55: audit candidate product-reframe plans and freeze contract-safe scope` is closed by PR `#437`.
+- `#435` `Phase 55: add analysis-first review-surface regression guardrail` is closed by PR `#438`.
+- Phase 55 covered candidate planning audit and analysis-first review-surface guardrails without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries. The completed Phase 55 Successor Gate lives in `docs/plans/phase-55-successor-gate-2026-05-20.md`. Local untracked April/private-beta/kernel/design-system planning files remain candidate inputs until a reviewed PR intentionally promotes them.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.
 - `#390` `Phase 49: ratify runtime parent-child compare emission policy` is closed by PR `#391`.
 - `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope` is closed by PR `#393`.
 - `#394` `Phase 49: strengthen transfer eval outcome coverage` is closed by PR `#395`.
-- `audit-github-queue` reports `ready` for the active Phase 55 successor queue after the Phase 54 closeout.
+- After Phase 55 closeout, `audit-github-queue` reports `paused` in the formal paused stop-state until a successor milestone opens.
 - The first formal repository release is published as `v0.1.0`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
@@ -264,5 +263,5 @@ Before builder automation is allowed to write code or auto-merge:
 - Long-running execution must run from isolated worktrees rather than the current `main` checkout.
 - Queue pickup order, one-writer ownership, and branch hygiene should follow `docs/plans/long-running-loop-runbook.md`.
 - When the active milestone exists and the queue reports `ready`, the builder may resume against that milestone only.
-- Phase 55 is active; do not open a parallel execution queue while `audit-github-queue` reports `ready` for the Phase 55 milestone.
+- Phase 55 is closed; do not open a parallel execution queue without a new reviewed successor milestone.
 - When no open milestone exists and `audit-github-queue` reports `paused`, treat that state as an intentional released stop-state rather than a broken queue.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note records the active Phase 55 analysis-first main-path successor queue after the completed Phase 54 runtime-orchestration closeout and the formal `v0.1.0` release baseline.
+This note records the completed Phase 55 analysis-first main-path closeout after the completed Phase 54 runtime-orchestration closeout and the formal `v0.1.0` release baseline.
 
 ## Snapshot
 
@@ -309,16 +309,16 @@ This note records the active Phase 55 analysis-first main-path successor queue a
     - Keep synchronous generation for v1. Defer async task contract ratification.
     - public demo, plugin, Hosted GPT/BYOK, launch hub, async implementation, and runtime mutation boundaries remain unchanged
   - `gh issue list --milestone "Phase 55 - Analysis-First Main Path and Review Surface Guardrails" --state all`
-    - `#432` `Phase 55 exit gate` is `open` and `blocked`
-    - `#433` `Phase 55: sync repo truth after Phase 54 closeout and define main-path gate` is `open` and `ready`
-    - `#434` `Phase 55: audit candidate product-reframe plans and freeze contract-safe scope` is `open` and `ready`
-    - `#435` `Phase 55: add analysis-first review-surface regression guardrail` is `open` and `ready`
+    - `#432` `Phase 55 exit gate` is `closed` after post-merge validation
+    - `#433` `Phase 55: sync repo truth after Phase 54 closeout and define main-path gate` is closed by PR `#436`
+    - `#434` `Phase 55: audit candidate product-reframe plans and freeze contract-safe scope` is closed by PR `#437`
+    - `#435` `Phase 55: add analysis-first review-surface regression guardrail` is closed by PR `#438`
   - `gh api repos/YSCJRH/mirror-sim/milestones/55`
-    - milestone `Phase 55 - Analysis-First Main Path and Review Surface Guardrails` is `open`
+    - milestone `Phase 55 - Analysis-First Main Path and Review Surface Guardrails` is `closed`
   - Phase 55 Successor Gate:
-    - `docs/plans/phase-55-successor-gate-2026-05-20.md` records the active gate note
-    - `audit-github-queue` reports `ready` for the active Phase 55 queue
-    - Phase 55 covers candidate planning audit and analysis-first review-surface guardrails
+    - `docs/plans/phase-55-successor-gate-2026-05-20.md` records the completed gate note
+    - `audit-github-queue` reports `paused` after the Phase 55 closeout
+    - Phase 55 covered candidate planning audit and analysis-first review-surface guardrails
     - Keep synchronous generation for v1. Defer async task contract ratification.
     - public demo, plugin, Hosted GPT/BYOK, launch hub, async implementation, and runtime mutation boundaries remain unchanged
 
@@ -342,7 +342,7 @@ This note records the active Phase 55 analysis-first main-path successor queue a
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
 - The default workbench path now consumes the canonical compare artifact directly and keeps focused divergent trace surfaces ahead of heavier packet-driven review flows.
 - The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, execution recovery release boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, escalation acknowledgment packets, and escalation closure packets without introducing backend API expansion.
-- The active repository state has Phase 53 transfer-generalization closeout complete, Phase 54 closeout complete, Phase 55 active, `v0.1.0` preserved as the latest published release baseline, and public demo, plugin, Hosted GPT/BYOK, launch hub, async implementation, and runtime mutation boundaries unchanged.
+- The active repository state has Phase 53 transfer-generalization closeout complete, Phase 54 closeout complete, Phase 55 closeout complete, `v0.1.0` preserved as the latest published release baseline, and public demo, plugin, Hosted GPT/BYOK, launch hub, async implementation, and runtime mutation boundaries unchanged.
 
 ## Next Entry Point
 
@@ -350,12 +350,12 @@ This note records the active Phase 55 analysis-first main-path successor queue a
 - Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; before Phase 53 was opened, `audit-github-queue` reported the formal paused stop-state.
 - Phase 53 is closed after PR `#424`, issue `#418`, and milestone `Phase 53 - Transfer Generalization and Third-World Readiness`; after closeout, the queue returned to the formal paused stop-state until Phase 54 was opened.
 - Phase 54 is closed after PR `#430`, issue `#426`, and milestone `Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate`; `audit-github-queue` reported `paused` in the formal paused stop-state until Phase 55 opened.
-- Phase 55 is active after opening milestone `Phase 55 - Analysis-First Main Path and Review Surface Guardrails`; `audit-github-queue` reports `ready` with `#432` as the blocked exit gate and `#433`, `#434`, and `#435` as ready work items.
+- Phase 55 is closed after PR `#438`, issue `#432`, and milestone `Phase 55 - Analysis-First Main Path and Review Surface Guardrails`; `#433` closed by PR `#436`, `#434` closed by PR `#437`, and `#435` closed by PR `#438`. After closeout, `audit-github-queue` reports `paused` in the formal paused stop-state until a successor milestone opens.
 - The Phase 47 unlock order is resolved: the queue-sync issue is closed after PR `#370`, the boundary-regression report is closed after PR `#371`, the runtime-world safety preflight is closed after PR `#372`, the main-path containment report is closed after PR `#373`, and the exit gate is closed after PR `#374`.
 - The Phase 48 unlock order is resolved: `#376` and `#377` closed through earlier Phase 48 PRs, `#378` and `#379` closed through PR `#382`, and `#375` closed after the post-merge exit-gate reassessment.
 - The Phase 49 unlock order is resolved: `#384` closed through PR `#385`, `#386` closed through PR `#387`, `#388` closed through PR `#389`, `#390` closed through PR `#391`, `#392` closed through PR `#393`, `#394` closed through PR `#395`, and `#383` closed after the post-merge exit-gate reassessment.
 - The Phase 50 unlock order is resolved: `#397` closed through PR `#399`, `#398` closed through PR `#400`, `#401` closed through PR `#402`, and `#396` closed after the post-merge exit-gate reassessment.
-- The active successor milestone is `Phase 55 - Analysis-First Main Path and Review Surface Guardrails`.
+- No active successor milestone is open after Phase 55 closeout.
 - The Phase 52 exit gate is `#410` `Phase 52 exit gate`, which closed after post-merge validation on `main`.
 - The Phase 53 exit gate is `#418` `Phase 53 exit gate`, which closed after post-merge validation on `main`.
 - The Phase 54 exit gate is `#426` `Phase 54 exit gate`, which closed after post-merge validation on `main`.
@@ -390,9 +390,9 @@ This note records the active Phase 55 analysis-first main-path successor queue a
 - The Phase 54 Runtime Measurement and Async Contract Decision lives in `docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md`.
 - Phase 54 covered runtime measurement and async contract decision work without implementing async workers, `task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion.
 - Phase 54 decision posture: public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries remain unchanged.
-- The active Phase 55 Successor Gate lives in `docs/plans/phase-55-successor-gate-2026-05-20.md`.
-- Phase 55 covers analysis-first main-path and review-surface guardrail work without implementing async workers, `task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion.
-- `#432` `Phase 55 exit gate` is open and blocked; `#433`, `#434`, and `#435` are ready work items.
+- The completed Phase 55 Successor Gate lives in `docs/plans/phase-55-successor-gate-2026-05-20.md`.
+- Phase 55 covered analysis-first main-path and review-surface guardrail work without implementing async workers, `task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion.
+- `#432` `Phase 55 exit gate` is closed after post-merge validation; `#433` closed by PR `#436`, `#434` closed by PR `#437`, and `#435` closed by PR `#438`.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.

--- a/docs/plans/phase-55-successor-gate-2026-05-20.md
+++ b/docs/plans/phase-55-successor-gate-2026-05-20.md
@@ -4,15 +4,15 @@ Date: 2026-05-20
 
 Issue: `#433` `Phase 55: sync repo truth after Phase 54 closeout and define main-path gate`
 
-Current state: Phase 55 is the active successor queue after the completed Phase 54
-runtime-orchestration closeout.
+Current state: Phase 55 is closed; no active successor milestone is open.
 
-This note records the active Phase 55 successor queue. Phase 55 is an
-analysis-first main-path and review-surface guardrail phase. It is allowed to sync
-repo truth, audit candidate planning inputs, and add a small contract-safe
-main-path review-surface regression guardrail. It is not an async-worker,
-launch-hub, public-path, plugin, Hosted GPT/BYOK, schema-expansion, or
-runtime-mutation phase.
+This note records the completed Phase 55 successor queue and the formal paused
+stop-state reached after the analysis-first main-path and review-surface guardrail
+work. Phase 55 was an analysis-first main-path and review-surface guardrail phase.
+It synced repo truth, audited candidate planning inputs, and added a small
+contract-safe review-surface regression guardrail. It was not an
+async-worker, launch-hub, public-path, plugin, Hosted GPT/BYOK, schema-expansion,
+or runtime-mutation phase.
 
 This gate is recorded at `docs/plans/phase-55-successor-gate-2026-05-20.md`.
 The Phase 54 Runtime Measurement and Async Contract Decision remains the active
@@ -41,31 +41,47 @@ Phase 55 title:
 Phase 55 - Analysis-First Main Path and Review Surface Guardrails
 ```
 
-Open GitHub objects:
+Closed GitHub objects:
 
 - `#432` `Phase 55 exit gate`
   - Lane: `protected-core`.
-  - Status: open and blocked.
+  - Status: closed after post-merge validation.
   - Scope: close Phase 55 only after all work items merge and post-merge validation passes.
 - `#433` `Phase 55: sync repo truth after Phase 54 closeout and define main-path gate`
   - Lane: `protected-core`.
-  - Status: ready.
-  - Scope: sync durable docs and tests to the active Phase 55 queue.
+  - Status: closed by PR `#436`.
+  - Scope: sync durable docs and tests to the Phase 55 queue.
 - `#434` `Phase 55: audit candidate product-reframe plans and freeze contract-safe scope`
   - Lane: `protected-core`.
-  - Status: ready.
+  - Status: closed by PR `#437`.
   - Scope: classify untracked product-reframe, private-alpha/private-beta, and
     interactive-kernel planning notes against tracked Mirror boundaries.
+  - Audit note:
+    `docs/plans/phase-55-candidate-plan-audit-2026-05-20.md`.
 - `#435` `Phase 55: add analysis-first review-surface regression guardrail`
   - Lane: `auto-safe`.
-  - Status: ready.
+  - Status: closed by PR `#438`.
   - Scope: add a focused contract-safe frontend/docs-eval guardrail for the
     analysis-first review surface.
 
-After the Phase 55 queue opened,
+After Phase 55 closeout,
 `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports
-`ready` with exactly one open milestone, a protected blocked exit gate, and ready
-work items.
+`paused` because no active successor milestone is open.
+
+## Phase 55 Closeout Evidence
+
+- PR `#436` closed `#433` `Phase 55: sync repo truth after Phase 54 closeout and define main-path gate`.
+- PR `#437` closed `#434` `Phase 55: audit candidate product-reframe plans and freeze contract-safe scope`.
+- PR `#438` closed `#435` `Phase 55: add analysis-first review-surface regression guardrail`.
+- Issue `#432` `Phase 55 exit gate` is closed after post-merge validation on `main`.
+- Milestone `Phase 55 - Analysis-First Main Path and Review Surface Guardrails` is closed.
+- The queue has returned to the formal paused stop-state; no active successor milestone is open.
+- `./make.ps1 smoke` passes with 23/23 checks.
+- `./make.ps1 test` passes with 170 tests.
+- `./make.ps1 eval-demo` passes with 23/23 checks.
+- `python -m backend.app.cli audit-phase phase1` passes.
+- `python -m backend.app.cli audit-phase phase2` passes.
+- `python -m backend.app.cli audit-phase phase3` passes.
 
 ## Analysis-First Main-Path Scope
 
@@ -129,8 +145,8 @@ compare artifacts, public demo artifact layout, or the Mirror Codex MCP contract
   deleting any legacy top-level runtime route.
 - TODO[verify]: require route-derived `worldId` or an equivalent reviewed scope
   guard before adding any new mutating runtime API.
-- TODO[verify]: classify and review untracked April/private-beta/kernel/design-system
-  planning notes before promoting any part of them as durable truth.
+- TODO[verify]: keep untracked April/private-beta/kernel/design-system planning notes
+  candidate-only unless a later reviewed PR promotes a specific signal.
 - Do not recreate local Codex automations without a new explicit operator request.
 
 ## Phase 55 Work Package Map
@@ -141,6 +157,7 @@ compare artifacts, public demo artifact layout, or the Mirror Codex MCP contract
    - Define the analysis-first main-path and review-surface guardrail successor gate.
    - Keep public demo, plugin, Hosted GPT/BYOK, launch hub, async implementation,
      and runtime mutation boundaries unchanged.
+   - Closed by PR `#436`.
 
 2. Candidate product-reframe plan audit
    - Classify untracked product-reframe, private-alpha/private-beta, and
@@ -148,18 +165,20 @@ compare artifacts, public demo artifact layout, or the Mirror Codex MCP contract
    - Freeze which candidate signals are safe inputs for Phase 55 and which are
      deferred or blocked.
    - Do not promote candidate-only claims as durable truth without reviewed PR evidence.
+   - Closed by PR `#437`.
 
 3. Analysis-first review-surface regression guardrail
    - Add a focused contract-safe guardrail that keeps the main path analysis-first.
    - Keep `/review` advanced and preserve public demo behavior.
    - Do not change backend APIs, compare artifacts, claim/evidence contracts,
      scenario DSL, trace shape, plugin MCP contract, or runtime mutation semantics.
+   - Closed by PR `#438`.
 
 4. Closeout baseline
    - Close the Phase 55 exit gate after post-merge validation.
    - Close the Phase 55 milestone.
-   - Reassess whether the next successor phase should remain frontend/main-path
-     focused or move to a separately ratified contract decision.
+   - Return the queue to the formal paused stop-state until an approved successor
+     phase is opened.
 
 ## Blueprint Boundary
 
@@ -197,13 +216,18 @@ Phase 55 must stay aligned with `mirror.md` and `AGENTS.md`:
 
 ## Validation Commands
 
-For the Phase 55 repo-truth sync, run:
+For Phase 55 closeout, run:
 
 ```powershell
-python -m pytest backend/tests/test_phase55_successor_gate.py -q
+python -m pytest backend/tests/test_phase55_successor_gate.py backend/tests/test_phase55_candidate_plan_audit.py backend/tests/test_phase55_review_surface_guardrail.py -q
 python scripts/check_no_secrets.py
 python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
-python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-55-successor-gate-2026-05-20.md backend/tests/test_phase55_successor_gate.py
+python -m backend.app.cli audit-phase phase1
+python -m backend.app.cli audit-phase phase2
+python -m backend.app.cli audit-phase phase3
+python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-55-successor-gate-2026-05-20.md backend/tests/test_phase55_successor_gate.py backend/tests/test_phase55_candidate_plan_audit.py backend/tests/test_phase55_review_surface_guardrail.py
 git diff --check
 ./make.ps1 smoke
+./make.ps1 test
+./make.ps1 eval-demo
 ```

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 54 runtime-orchestration successor queue, and the active Phase 55 analysis-first main-path successor queue.
+This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 54 runtime-orchestration successor queue, and the completed Phase 55 analysis-first main-path successor queue.
 
 ## Current Gate State
 
@@ -58,7 +58,7 @@ This note records the current post-Day-0 execution status for Mirror after the f
 - Phase 52 exit gate: closed
 - Phase 53 exit gate: closed
 - Phase 54 exit gate: closed
-- Phase 55 exit gate: open and blocked
+- Phase 55 exit gate: closed
 
 Local phase audits currently report:
 
@@ -66,7 +66,7 @@ Local phase audits currently report:
 - `phase2`: pass
 - `phase3`: pass
 
-## Phase 55 Active Queue
+## Phase 55 Closeout
 
 Phase 55 title:
 
@@ -74,30 +74,34 @@ Phase 55 title:
 Phase 55 - Analysis-First Main Path and Review Surface Guardrails
 ```
 
+Phase 55 is closed after PR `#438`, issue `#432`, and milestone
+`Phase 55 - Analysis-First Main Path and Review Surface Guardrails`; `#433`
+closed by PR `#436`, `#434` closed by PR `#437`, and `#435` closed by PR `#438`.
+
 - `audit-github-queue`
-  - reports `ready`
-  - confirms exactly one open successor milestone with a protected blocked exit gate and ready work items
+  - reports `paused` after Phase 55 closeout
+  - confirms no ready work items remain after the Phase 55 queue completes
 - milestone `Phase 55 - Analysis-First Main Path and Review Surface Guardrails`
-  - open
+  - closed
 - `#432` `Phase 55 exit gate`
-  - open and blocked
+  - closed after post-merge validation
   - labeled `lane:protected-core` because it is the protected closeout gate
 - `#433` `Phase 55: sync repo truth after Phase 54 closeout and define main-path gate`
-  - ready
-  - syncs durable docs and tests to the active Phase 55 queue
+  - closed by PR `#436`
+  - synced durable docs and tests to the Phase 55 queue
 - `#434` `Phase 55: audit candidate product-reframe plans and freeze contract-safe scope`
-  - ready
-  - audits untracked candidate planning notes before any promotion to durable truth
+  - closed by PR `#437`
+  - audited untracked candidate planning notes before any promotion to durable truth
 - `#435` `Phase 55: add analysis-first review-surface regression guardrail`
-  - ready
-  - adds a focused contract-safe frontend/docs-eval guardrail for the analysis-first main path
+  - closed by PR `#438`
+  - added a focused contract-safe frontend/docs-eval guardrail for the analysis-first main path
 - boundary posture
   - Keep synchronous generation for v1. Defer async task contract ratification.
-  - Phase 55 does not implement async workers, `task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion.
+  - Phase 55 did not implement async workers, `task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion.
   - public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries remain unchanged unless separately ratified.
   - untracked April/private-beta/kernel/design-system planning notes remain candidate inputs until a reviewed PR intentionally promotes them.
 - phase gate baseline
-  - active Phase 55 Successor Gate: `docs/plans/phase-55-successor-gate-2026-05-20.md`
+  - completed Phase 55 Successor Gate: `docs/plans/phase-55-successor-gate-2026-05-20.md`
 
 ## Phase 54 Closeout
 
@@ -112,7 +116,7 @@ Phase 54 is closed after PR `#430`, issue `#426`, and milestone
 
 - `audit-github-queue`
   - reported `paused` after Phase 54 closeout until Phase 55 opened
-  - now reports `ready` for the active Phase 55 successor queue
+  - returned to `paused` after Phase 55 closeout
 - milestone `Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate`
   - closed
 - `#426` `Phase 54 exit gate`
@@ -804,7 +808,7 @@ Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Priv
 - Protected-core changes still require explicit review and must not auto-merge.
 - Long-running execution should assign exactly one writer worktree per issue.
 - When `audit-github-queue` reports `ready`, consume only the currently active milestone and do not parallel-open another execution queue.
-- Phase 55 is active; do not open a parallel execution queue while `audit-github-queue` reports `ready` for the Phase 55 milestone.
+- Phase 55 is closed; do not open a parallel execution queue without a new reviewed successor milestone.
 - The previous local queue follow-up automation has been revoked or left paused per operator request; do not recreate an automation without a new explicit request.
 
 ## Historical Branch Status


### PR DESCRIPTION
Records the final Phase 55 closeout baseline after #432 and milestone 55 were closed. Validation: python -m pytest backend/tests/test_phase55_successor_gate.py backend/tests/test_phase55_candidate_plan_audit.py backend/tests/test_phase55_review_surface_guardrail.py -q => 12 passed; ./make.ps1 smoke => 23/23; ./make.ps1 test => 170 passed; ./make.ps1 eval-demo => 23/23; audit-phase phase1/phase2/phase3 => pass; audit-github-queue => paused with active_milestone null; check_no_secrets => passed; git diff --check => exit 0.