### PR TITLE
Phase 56 successor gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,12 +290,24 @@ See `docs/plans/phase-54-successor-gate-2026-05-19.md` and
 Phase 55 Analysis-First Main Path and Review Surface Guardrails: Phase 55 is closed
 after PR `#438`, issue `#432`, and milestone `Phase 55 - Analysis-First Main Path
 and Review Surface Guardrails`. `#433` closed by PR `#436`, `#434` closed by PR
-`#437`, and `#435` closed by PR `#438`. After closeout, `audit-github-queue`
-reports `paused` in the formal paused stop-state until a successor milestone opens.
+`#437`, and `#435` closed by PR `#438`. Immediately after closeout and before
+Phase 56 opened, `audit-github-queue` reported `paused` in the formal paused
+stop-state.
 Phase 55 kept public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime
 mutation boundaries unchanged, and untracked private-beta, kernel, and design-system
 planning notes remain candidate inputs until a reviewed PR intentionally promotes them. See
 `docs/plans/phase-55-successor-gate-2026-05-20.md`.
+
+Phase 56 Source-Verified Candidate Promotion and Review Continuity: Phase 56 is
+the active successor queue after the Phase 55 closeout. `#440` is the blocked
+Phase 56 exit gate, `#441` syncs repo truth and defines the source-verified gate,
+`#442` verifies candidate planning signals against current frontend source, and
+`#443` adds a world-scoped review-continuity guardrail. `audit-github-queue`
+reports `ready` for the Phase 56 queue. Phase 56 keeps public demo, plugin,
+Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries unchanged,
+and candidate inputs only become durable truth after a reviewed PR promotes a
+specific source-verified signal. See
+`docs/plans/phase-56-successor-gate-2026-05-20.md`.
 
 ---
 
@@ -336,6 +348,7 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - The completed Phase 54 Successor Gate lives in [docs/plans/phase-54-successor-gate-2026-05-19.md](docs/plans/phase-54-successor-gate-2026-05-19.md).
 - The Phase 54 Runtime Measurement and Async Contract Decision lives in [docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md](docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md).
 - The completed Phase 55 Successor Gate lives in [docs/plans/phase-55-successor-gate-2026-05-20.md](docs/plans/phase-55-successor-gate-2026-05-20.md).
+- The active Phase 56 Successor Gate lives in [docs/plans/phase-56-successor-gate-2026-05-20.md](docs/plans/phase-56-successor-gate-2026-05-20.md).
 - Phase 48 is closed after PR `#382`, issue `#375`, and milestone `Phase 48 - Successor Intake and Boundary Contract Triage`.
 - Phase 49 is closed after PR `#395`, issue `#383`, and milestone `Phase 49 - Kernel, Perturbation, and Runtime Contract Hardening`; completed work items were `#384`, `#386`, `#388`, `#390`, `#392`, and `#394`.
 - Phase 50 is closed after PR `#402`, issue `#396`, and milestone `Phase 50 - Runtime Orchestration Measurement and Product Boundary`; completed work items were `#397`, `#398`, and `#401`. Phase 50 measured before any `task_id` or worker contract is introduced and kept the private-beta launch hub planning-only for now.
@@ -344,7 +357,8 @@ For a guided walkthrough of the canonical demo flow, see [docs/demo/fog-harbor-w
 - Phase 53 is closed after PR `#424`, issue `#418`, and milestone `Phase 53 - Transfer Generalization and Third-World Readiness`; after closeout, the queue returned to the formal paused stop-state until Phase 54 was opened. `#419` closed by PR `#422`, `#420` `Phase 53: audit transfer assumptions and third-world readiness constraints` closed by PR `#423`, and `#421` `Phase 53: add bounded third-world transfer readiness evidence` closed by PR `#424`. Phase 53 strengthened bounded transfer generalization evidence without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries, and `library-rain` is the third-world evidence slice.
 - Phase 54 is closed after PR `#430`, issue `#426`, and milestone `Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate`; after closeout, `audit-github-queue` reported `paused` in the formal paused stop-state until Phase 55 opened. `#427` closed by PR `#429`, and `#428` closed by PR `#430`. Keep synchronous generation for v1. Defer async task contract ratification. Phase 54 covered runtime measurement and async contract decision work without implementing async workers, `task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion. The Phase 54 Successor Gate lives in `docs/plans/phase-54-successor-gate-2026-05-19.md`; the decision note lives in `docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md`.
 - Phase 54 decision posture: public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries remain unchanged.
-- Phase 55 is closed after PR `#438`, issue `#432`, and milestone `Phase 55 - Analysis-First Main Path and Review Surface Guardrails`; `#433` closed by PR `#436`, `#434` closed by PR `#437`, and `#435` closed by PR `#438`. After closeout, `audit-github-queue` reports `paused` in the formal paused stop-state until a successor milestone opens. The Phase 55 Successor Gate lives in `docs/plans/phase-55-successor-gate-2026-05-20.md`.
+- Phase 55 is closed after PR `#438`, issue `#432`, and milestone `Phase 55 - Analysis-First Main Path and Review Surface Guardrails`; `#433` closed by PR `#436`, `#434` closed by PR `#437`, and `#435` closed by PR `#438`. Immediately after closeout and before Phase 56 opened, `audit-github-queue` reported `paused` in the formal paused stop-state. The Phase 55 Successor Gate lives in `docs/plans/phase-55-successor-gate-2026-05-20.md`.
+- Phase 56 is active under milestone `Phase 56 - Source-Verified Candidate Promotion and Review Continuity`; `#440` is the blocked exit gate, `#441`, `#442`, and `#443` are ready work items, and `audit-github-queue` reports `ready`. The Phase 56 Successor Gate lives in `docs/plans/phase-56-successor-gate-2026-05-20.md`.
 - Private-beta planning material remains candidate input until it is promoted through a reviewed PR.
 - Fog Harbor remains the canonical demo world; `museum-night` and `library-rain` are the selected bounded transfer worlds used to prove the pipeline has passed across three selected bounded fictional worlds.
 

--- a/backend/tests/test_phase56_successor_gate.py
+++ b/backend/tests/test_phase56_successor_gate.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+PHASE56_GATE_PATH = Path("docs/plans/phase-56-successor-gate-2026-05-20.md")
+
+
+def test_phase56_successor_gate_exists_with_required_sections() -> None:
+    assert PHASE56_GATE_PATH.exists()
+
+    gate = PHASE56_GATE_PATH.read_text(encoding="utf-8")
+    required_sections = [
+        "# Phase 56 Successor Gate",
+        "Issue: `#441` `Phase 56: sync repo truth after Phase 55 closeout and define source-verified gate`",
+        "Current state: Phase 56 is the active successor queue after the completed Phase 55 closeout.",
+        "## Phase 55 Closeout Evidence",
+        "## Phase 56 Operational Queue",
+        "## Source-Verified Candidate Promotion Scope",
+        "## Candidate Input Rules",
+        "## Protected-Core Lane Coverage",
+        "## Carried Forward TODO[verify] Items",
+        "## Phase 56 Work Package Map",
+        "## Blueprint Boundary",
+        "## Non-Goals",
+        "## Validation Commands",
+    ]
+    for section in required_sections:
+        assert section in gate
+
+
+def test_phase56_successor_gate_records_queue_and_boundaries() -> None:
+    assert PHASE56_GATE_PATH.exists()
+
+    gate = PHASE56_GATE_PATH.read_text(encoding="utf-8")
+    required_phrases = [
+        "Phase 56 - Source-Verified Candidate Promotion and Review Continuity",
+        "`#440` `Phase 56 exit gate`",
+        "`#441` `Phase 56: sync repo truth after Phase 55 closeout and define source-verified gate`",
+        "`#442` `Phase 56: source-verify candidate planning signals against current frontend`",
+        "`#443` `Phase 56: add world-scoped review continuity guardrail`",
+        "Status: open and blocked.",
+        "Status: ready.",
+        "`ready` with exactly one open milestone",
+        "source-verified candidate-promotion and review-continuity phase",
+        "candidate inputs only until a reviewed PR promotes a specific source-verified signal",
+        "Do not import April/private-beta/kernel/design-system planning notes wholesale",
+        "Do not add any new mutating runtime API in Phase 56",
+        "`/` remains the guided public demo",
+        "`/review` remains an advanced read-only public-demo review surface",
+        "`/worlds/<world_id>/review` remains the world-scoped private-beta review surface",
+        "Keep synchronous generation for v1",
+        "deferred async task contract ratification",
+        "Do not implement async workers",
+        "Do not implement a launch hub",
+        "Do not replace `/` or widen the public path",
+        "Do not add Hosted GPT, BYOK, upload, auth, billing, database, object storage",
+        "public demo, plugin, Hosted GPT/BYOK, launch hub, async implementation, and runtime mutation boundaries unchanged",
+        "`docs/plans/phase-56-successor-gate-2026-05-20.md`",
+    ]
+    for phrase in required_phrases:
+        assert phrase in gate
+
+
+def test_active_state_docs_record_phase56_active_queue() -> None:
+    required_docs = [
+        Path("README.md"),
+        Path("docs/plans/current-state-baseline.md"),
+        Path("docs/plans/phase-execution-queue.md"),
+        Path("docs/plans/automation-roadmap.md"),
+    ]
+
+    for path in required_docs:
+        text = path.read_text(encoding="utf-8")
+        assert "Phase 56 - Source-Verified Candidate Promotion and Review Continuity" in text
+        assert "`#440`" in text
+        assert "`#441`" in text
+        assert "`#442`" in text
+        assert "`#443`" in text
+        assert "Phase 56 Successor Gate" in text
+        assert "`docs/plans/phase-56-successor-gate-2026-05-20.md`" in text
+        assert "`audit-github-queue` reports `ready`" in text
+        assert "Phase 55 is closed after PR `#438`" in text
+        assert "Keep synchronous generation for v1. Defer async task contract ratification." in text
+        assert "candidate inputs only" in text
+        assert "source-verified" in text
+
+
+def test_active_state_docs_do_not_treat_phase56_as_closed_or_expanded() -> None:
+    required_docs = [
+        Path("README.md"),
+        Path("docs/plans/current-state-baseline.md"),
+        Path("docs/plans/phase-execution-queue.md"),
+        Path("docs/plans/automation-roadmap.md"),
+        PHASE56_GATE_PATH,
+    ]
+    stale_or_expanded_phrases = [
+        "Phase 56 is closed",
+        "Phase 56 exit gate: closed",
+        "Phase 56 milestone is closed",
+        "Phase 56 implements async",
+        "Phase 56 implements a launch hub",
+        "Phase 56 replaces `/`",
+        "Phase 56 widens the public path",
+        "Phase 56 adds Hosted GPT",
+        "Phase 56 adds BYOK",
+        "Phase 56 adds upload",
+        "Phase 56 adds auth",
+        "Phase 56 ratifies task_id",
+        "Phase 56 changes scenario DSL",
+        "Phase 56 changes claim labels",
+        "Phase 56 changes report claim `evidence_ids`",
+        "Phase 56 changes run trace shape",
+        "Phase 56 changes compare artifact shape",
+        "Phase 56 changes plugin MCP contract",
+        "No active successor milestone is open after Phase 56 closeout",
+        "After closeout, `audit-github-queue` reports `paused` in the formal paused stop-state until a successor milestone opens",
+        "reports `paused` in the formal paused stop-state until a successor milestone opens",
+        "No active successor milestone is open after Phase 55 closeout",
+        "Do not add new mutating runtime APIs without route-derived",
+        "before adding any new mutating runtime API",
+    ]
+
+    for path in required_docs:
+        text = path.read_text(encoding="utf-8")
+        for phrase in stale_or_expanded_phrases:
+            assert phrase not in text, f"{path} has stale or expanded Phase 56 wording: {phrase}"

--- a/docs/plans/automation-roadmap.md
+++ b/docs/plans/automation-roadmap.md
@@ -6,7 +6,7 @@ Turn Mirror into a long-running, repo-native automation loop that uses GitHub as
 
 ## Current State
 
-Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, Phase 47 closeout is complete, Phase 48 closeout is complete, Phase 49 closeout is complete, Phase 50 closeout is complete, Phase 51 closeout is complete, Phase 52 closeout is complete, Phase 53 closeout is complete, Phase 54 closeout is complete, Phase 55 closeout is complete, and the first formal release remains published as `v0.1.0`.
+Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is complete, Phase 7 closeout is complete, Phase 8 closeout is complete, Phase 9 closeout is complete, Phase 10 closeout is complete, Phase 11 closeout is complete, Phase 12 closeout is complete, Phase 13 closeout is complete, Phase 14 closeout is complete, Phase 15 closeout is complete, Phase 16 closeout is complete, Phase 17 closeout is complete, Phase 18 closeout is complete, Phase 19 closeout is complete, Phase 20 closeout is complete, Phase 21 closeout is complete, Phase 22 closeout is complete, Phase 23 closeout is complete, Phase 24 closeout is complete, Phase 25 closeout is complete, Phase 26 closeout is complete, Phase 27 closeout is complete, Phase 28 closeout is complete, Phase 29 closeout is complete, Phase 30 closeout is complete, Phase 31 closeout is complete, Phase 32 closeout is complete, Phase 33 closeout is complete, Phase 34 closeout is complete, Phase 35 closeout is complete, Phase 36 closeout is complete, Phase 37 closeout is complete, Phase 38 closeout is complete, Phase 39 closeout is complete, Phase 40 closeout is complete, Phase 41 closeout is complete, Phase 42 closeout is complete, Phase 43 closeout is complete, Phase 44 closeout is complete, Phase 45 execution work is complete, Phase 46 closeout is complete, Phase 47 closeout is complete, Phase 48 closeout is complete, Phase 49 closeout is complete, Phase 50 closeout is complete, Phase 51 closeout is complete, Phase 52 closeout is complete, Phase 53 closeout is complete, Phase 54 closeout is complete, Phase 55 closeout is complete, Phase 56 is active, and the first formal release remains published as `v0.1.0`.
 
 - GitHub milestones, labels, and phase issues exist.
 - `main` is protected by the required Linux and Windows quality gates.
@@ -200,13 +200,19 @@ Day 0 bootstrap is complete, Phase 5 closeout is complete, Phase 6 closeout is c
 - `#434` `Phase 55: audit candidate product-reframe plans and freeze contract-safe scope` is closed by PR `#437`.
 - `#435` `Phase 55: add analysis-first review-surface regression guardrail` is closed by PR `#438`.
 - Phase 55 covered candidate planning audit and analysis-first review-surface guardrails without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries. The completed Phase 55 Successor Gate lives in `docs/plans/phase-55-successor-gate-2026-05-20.md`. Local untracked April/private-beta/kernel/design-system planning files remain candidate inputs until a reviewed PR intentionally promotes them.
+- Phase 56 is active after opening milestone `Phase 56 - Source-Verified Candidate Promotion and Review Continuity`.
+- `#440` `Phase 56 exit gate` is open and blocked.
+- `#441` `Phase 56: sync repo truth after Phase 55 closeout and define source-verified gate` is ready.
+- `#442` `Phase 56: source-verify candidate planning signals against current frontend` is ready.
+- `#443` `Phase 56: add world-scoped review continuity guardrail` is ready.
+- Phase 56 covers source-verified candidate promotion and review-continuity guardrails without widening public demo, plugin, Hosted GPT/BYOK, launch hub, async, or runtime mutation boundaries. The active Phase 56 Successor Gate lives in `docs/plans/phase-56-successor-gate-2026-05-20.md`. Local untracked April/private-beta/kernel/design-system planning files remain candidate inputs only until a reviewed PR promotes a specific source-verified signal.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.
 - `#390` `Phase 49: ratify runtime parent-child compare emission policy` is closed by PR `#391`.
 - `#392` `Phase 49: ratify runtime latest-activity metadata and rollback scope` is closed by PR `#393`.
 - `#394` `Phase 49: strengthen transfer eval outcome coverage` is closed by PR `#395`.
-- After Phase 55 closeout, `audit-github-queue` reports `paused` in the formal paused stop-state until a successor milestone opens.
+- `audit-github-queue` reports `ready` for the active Phase 56 successor queue after the Phase 55 closeout.
 - The first formal repository release is published as `v0.1.0`.
 - Builder state should continue to be derived from `audit-github-queue`, not from doc-only convention.
 - The worktree pickup and handoff sequence is documented in `docs/plans/long-running-loop-runbook.md`.
@@ -263,5 +269,5 @@ Before builder automation is allowed to write code or auto-merge:
 - Long-running execution must run from isolated worktrees rather than the current `main` checkout.
 - Queue pickup order, one-writer ownership, and branch hygiene should follow `docs/plans/long-running-loop-runbook.md`.
 - When the active milestone exists and the queue reports `ready`, the builder may resume against that milestone only.
-- Phase 55 is closed; do not open a parallel execution queue without a new reviewed successor milestone.
+- Phase 56 is active; do not open a parallel execution queue while `audit-github-queue` reports `ready` for the Phase 56 milestone.
 - When no open milestone exists and `audit-github-queue` reports `paused`, treat that state as an intentional released stop-state rather than a broken queue.

--- a/docs/plans/current-state-baseline.md
+++ b/docs/plans/current-state-baseline.md
@@ -1,6 +1,6 @@
 # Current State Baseline
 
-This note records the completed Phase 55 analysis-first main-path closeout after the completed Phase 54 runtime-orchestration closeout and the formal `v0.1.0` release baseline.
+This note records the active Phase 56 source-verified candidate-promotion successor queue after the completed Phase 55 analysis-first main-path closeout and the formal `v0.1.0` release baseline.
 
 ## Snapshot
 
@@ -321,6 +321,19 @@ This note records the completed Phase 55 analysis-first main-path closeout after
     - Phase 55 covered candidate planning audit and analysis-first review-surface guardrails
     - Keep synchronous generation for v1. Defer async task contract ratification.
     - public demo, plugin, Hosted GPT/BYOK, launch hub, async implementation, and runtime mutation boundaries remain unchanged
+  - `gh issue list --milestone "Phase 56 - Source-Verified Candidate Promotion and Review Continuity" --state all`
+    - `#440` `Phase 56 exit gate` is open and blocked
+    - `#441` `Phase 56: sync repo truth after Phase 55 closeout and define source-verified gate` is ready
+    - `#442` `Phase 56: source-verify candidate planning signals against current frontend` is ready
+    - `#443` `Phase 56: add world-scoped review continuity guardrail` is ready
+  - `gh api repos/YSCJRH/mirror-sim/milestones/56`
+    - milestone `Phase 56 - Source-Verified Candidate Promotion and Review Continuity` is open
+  - Phase 56 Successor Gate:
+    - `docs/plans/phase-56-successor-gate-2026-05-20.md` records the active gate note
+    - `audit-github-queue` reports `ready` for the active Phase 56 queue
+    - Phase 56 covers source-verified candidate promotion and review-continuity guardrails
+    - Keep synchronous generation for v1. Defer async task contract ratification.
+    - public demo, plugin, Hosted GPT/BYOK, launch hub, async implementation, and runtime mutation boundaries remain unchanged
 
 ## Trusted Source Of Truth
 
@@ -342,7 +355,7 @@ This note records the completed Phase 55 analysis-first main-path closeout after
 - The frontend workbench renders report, claims, eval summary, rubric, corpus, graph, and scenario artifacts directly from the repo artifact tree.
 - The default workbench path now consumes the canonical compare artifact directly and keeps focused divergent trace surfaces ahead of heavier packet-driven review flows.
 - The workbench now also supports claim -> evidence drill-down, baseline/intervention trace review, reviewer scorecards, shareable review packet export, issue-comment handoff copy, operator decision briefs, exit-gate closeout packets, lane-aware pickup routing, export destination guidance, delivery-readiness warnings, destination-aware recommendations, packet coverage previews, delivery presets, preset comparison cards, carry-forward chips, quick-export shortcuts, payload previews, tradeoff-guidance cards, diff highlights, copy-preflight checklists, override-rationale cues, copy-sidecar summaries, composed handoff-bundle previews, destination-specific attachment-order guidance, recipient-facing cover sheets, one-step final bundle copies with package manifests, compact-versus-full bundle variants, receiver follow-through cues, receiver-role modes, routing-strip follow-through guidance, role-specific bundle emphasis, decision-template snippets, role preset cards, response-packaging shortcuts, apply-and-copy preset actions, grouped response-pack export, active preset session summary strips, route-filtered response kit choosers, route-kit comparison cards, preset session handoff packets, send-readiness cue strips, compact-versus-full handoff packet variants, destination-specific sender notes, compact-versus-full handoff packet diff previews, final send summary cards, destination-aware packet recommendation banners, delivery-bundle exports, receiver follow-up packs, delivery checkpoint boards, receiver response packets, reply outcome trackers, resolution handoff packs, resolution status boards, next-step routing packs, action readiness boards, escalation handoff packets, execution kickoff boards, execution progress trackers, execution outcome boards, execution correction boards, execution recovery boards, execution recovery checkpoint boards, execution recovery clearance boards, execution recovery release boards, escalation decision guides, escalation trigger packets, escalation dispatch packets, escalation delivery packets, escalation confirmation packets, escalation receipt packets, escalation acknowledgment packets, and escalation closure packets without introducing backend API expansion.
-- The active repository state has Phase 53 transfer-generalization closeout complete, Phase 54 closeout complete, Phase 55 closeout complete, `v0.1.0` preserved as the latest published release baseline, and public demo, plugin, Hosted GPT/BYOK, launch hub, async implementation, and runtime mutation boundaries unchanged.
+- The active repository state has Phase 53 transfer-generalization closeout complete, Phase 54 closeout complete, Phase 55 closeout complete, Phase 56 active, `v0.1.0` preserved as the latest published release baseline, and public demo, plugin, Hosted GPT/BYOK, launch hub, async implementation, and runtime mutation boundaries unchanged.
 
 ## Next Entry Point
 
@@ -350,12 +363,13 @@ This note records the completed Phase 55 analysis-first main-path closeout after
 - Phase 52 is closed after PR `#416`, issue `#410`, and milestone `Phase 52 - Legacy Route Containment and Runtime Scope Audit`; before Phase 53 was opened, `audit-github-queue` reported the formal paused stop-state.
 - Phase 53 is closed after PR `#424`, issue `#418`, and milestone `Phase 53 - Transfer Generalization and Third-World Readiness`; after closeout, the queue returned to the formal paused stop-state until Phase 54 was opened.
 - Phase 54 is closed after PR `#430`, issue `#426`, and milestone `Phase 54 - Runtime Orchestration Measurement and Async Contract Decision Gate`; `audit-github-queue` reported `paused` in the formal paused stop-state until Phase 55 opened.
-- Phase 55 is closed after PR `#438`, issue `#432`, and milestone `Phase 55 - Analysis-First Main Path and Review Surface Guardrails`; `#433` closed by PR `#436`, `#434` closed by PR `#437`, and `#435` closed by PR `#438`. After closeout, `audit-github-queue` reports `paused` in the formal paused stop-state until a successor milestone opens.
+- Phase 55 is closed after PR `#438`, issue `#432`, and milestone `Phase 55 - Analysis-First Main Path and Review Surface Guardrails`; `#433` closed by PR `#436`, `#434` closed by PR `#437`, and `#435` closed by PR `#438`. Immediately after closeout and before Phase 56 opened, `audit-github-queue` reported `paused` in the formal paused stop-state.
+- Phase 56 is active after opening milestone `Phase 56 - Source-Verified Candidate Promotion and Review Continuity`; `audit-github-queue` reports `ready` with `#440` as the blocked exit gate and `#441`, `#442`, and `#443` as ready work items.
 - The Phase 47 unlock order is resolved: the queue-sync issue is closed after PR `#370`, the boundary-regression report is closed after PR `#371`, the runtime-world safety preflight is closed after PR `#372`, the main-path containment report is closed after PR `#373`, and the exit gate is closed after PR `#374`.
 - The Phase 48 unlock order is resolved: `#376` and `#377` closed through earlier Phase 48 PRs, `#378` and `#379` closed through PR `#382`, and `#375` closed after the post-merge exit-gate reassessment.
 - The Phase 49 unlock order is resolved: `#384` closed through PR `#385`, `#386` closed through PR `#387`, `#388` closed through PR `#389`, `#390` closed through PR `#391`, `#392` closed through PR `#393`, `#394` closed through PR `#395`, and `#383` closed after the post-merge exit-gate reassessment.
 - The Phase 50 unlock order is resolved: `#397` closed through PR `#399`, `#398` closed through PR `#400`, `#401` closed through PR `#402`, and `#396` closed after the post-merge exit-gate reassessment.
-- No active successor milestone is open after Phase 55 closeout.
+- The active successor milestone is `Phase 56 - Source-Verified Candidate Promotion and Review Continuity`.
 - The Phase 52 exit gate is `#410` `Phase 52 exit gate`, which closed after post-merge validation on `main`.
 - The Phase 53 exit gate is `#418` `Phase 53 exit gate`, which closed after post-merge validation on `main`.
 - The Phase 54 exit gate is `#426` `Phase 54 exit gate`, which closed after post-merge validation on `main`.
@@ -393,6 +407,9 @@ This note records the completed Phase 55 analysis-first main-path closeout after
 - The completed Phase 55 Successor Gate lives in `docs/plans/phase-55-successor-gate-2026-05-20.md`.
 - Phase 55 covered analysis-first main-path and review-surface guardrail work without implementing async workers, `task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion.
 - `#432` `Phase 55 exit gate` is closed after post-merge validation; `#433` closed by PR `#436`, `#434` closed by PR `#437`, and `#435` closed by PR `#438`.
+- The active Phase 56 Successor Gate lives in `docs/plans/phase-56-successor-gate-2026-05-20.md`.
+- Phase 56 covers source-verified candidate promotion and review-continuity guardrail work without implementing async workers, `task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion.
+- `#440` `Phase 56 exit gate` is open and blocked; `#441`, `#442`, and `#443` are ready work items.
 - `#384` `Phase 49: sync repo truth and protect runtime core lanes` is closed by PR `#385`.
 - `#386` `Phase 49: ratify kernel trace and replay contract` is closed by PR `#387`.
 - `#388` `Phase 49: ratify perturbation schema and resolver authoring contract` is closed by PR `#389`.

--- a/docs/plans/phase-56-successor-gate-2026-05-20.md
+++ b/docs/plans/phase-56-successor-gate-2026-05-20.md
@@ -1,0 +1,208 @@
+# Phase 56 Successor Gate
+
+Date: 2026-05-20
+
+Issue: `#441` `Phase 56: sync repo truth after Phase 55 closeout and define source-verified gate`
+
+Current state: Phase 56 is the active successor queue after the completed Phase 55 closeout.
+
+This note records the active Phase 56 successor queue. Phase 56 is a
+source-verified candidate-promotion and review-continuity phase. It may sync repo
+truth, verify narrow candidate planning signals against current source, and add
+focused guardrails for analysis-first public and world-scoped review continuity.
+It is not an async-worker, launch-hub, public-path, plugin, Hosted GPT/BYOK,
+schema-expansion, or runtime-mutation phase.
+
+This gate is recorded at `docs/plans/phase-56-successor-gate-2026-05-20.md`.
+The Phase 54 Runtime Measurement and Async Contract Decision remains the active
+runtime-orchestration decision note:
+`docs/plans/phase-54-runtime-measurement-async-contract-decision-2026-05-19.md`.
+
+## Phase 55 Closeout Evidence
+
+Phase 55 is closed after PR `#438`, issue `#432`, and milestone
+`Phase 55 - Analysis-First Main Path and Review Surface Guardrails`.
+
+- PR `#436` closed `#433` `Phase 55: sync repo truth after Phase 54 closeout and define main-path gate`.
+- PR `#437` closed `#434` `Phase 55: audit candidate product-reframe plans and freeze contract-safe scope`.
+- PR `#438` closed `#435` `Phase 55: add analysis-first review-surface regression guardrail`.
+- Issue `#432` `Phase 55 exit gate` is closed after post-merge validation on `main`.
+- Milestone `Phase 55 - Analysis-First Main Path and Review Surface Guardrails` is closed.
+- Phase 55 kept public demo, plugin, Hosted GPT/BYOK, launch hub, async, and
+  runtime mutation boundaries unchanged.
+
+## Phase 56 Operational Queue
+
+Phase 56 title:
+
+```text
+Phase 56 - Source-Verified Candidate Promotion and Review Continuity
+```
+
+Open GitHub objects:
+
+- `#440` `Phase 56 exit gate`
+  - Lane: `protected-core`.
+  - Status: open and blocked.
+  - Scope: close Phase 56 only after all work items merge and post-merge validation passes.
+- `#441` `Phase 56: sync repo truth after Phase 55 closeout and define source-verified gate`
+  - Lane: `protected-core`.
+  - Status: ready.
+  - Scope: sync durable docs and tests to the active Phase 56 queue.
+- `#442` `Phase 56: source-verify candidate planning signals against current frontend`
+  - Lane: `protected-core`.
+  - Status: ready.
+  - Scope: verify narrow candidate planning signals against current source before any
+    signal becomes durable Phase 56 truth.
+- `#443` `Phase 56: add world-scoped review continuity guardrail`
+  - Lane: `protected-core`.
+  - Status: ready.
+  - Scope: add a focused guardrail for world-scoped private-beta review continuity.
+
+After the Phase 56 queue opened,
+`python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` reports
+`ready` with exactly one open milestone, a protected blocked exit gate, and ready
+work items.
+
+## Source-Verified Candidate Promotion Scope
+
+Phase 56 may use the untracked April planning notes only as candidate inputs for
+source-verified review. The tracked direction is narrower than those notes:
+
+- public demo, plugin, Hosted GPT/BYOK, launch hub, async implementation, and runtime mutation boundaries unchanged
+- Keep synchronous generation for v1 and keep deferred async task contract ratification.
+- `/` remains the guided public demo unless a future reviewed route contract says otherwise
+- `/review` remains an advanced read-only public-demo review surface, not a launch hub
+- `/worlds/<world_id>/review` remains the world-scoped private-beta review surface
+- preserve the current compare, claim/evidence, eval, scenario, trace, and artifact contracts
+- prefer source-verified candidate promotion over broad product redesign
+- keep interactive perturbation simulator work as a future contract candidate
+  until a separate ADR and contract update are reviewed
+
+## Candidate Input Rules
+
+The following untracked planning files remain candidate inputs only until a reviewed PR promotes a specific source-verified signal:
+
+- `docs/plans/branch-analysis-product-reframe-2026-04/README.md`
+- `docs/plans/hybrid-linear-main-path-design-system.md`
+- `docs/plans/hybrid-linear-main-path-manual-review.md`
+- `docs/plans/interactive-kernel-baseline-2026-04-22.md`
+- `docs/plans/interactive-perturbation-simulator-2026-04/README.md`
+- `docs/plans/private-alpha-baseline-2026-04-22.md`
+- `docs/plans/private-alpha-launch-ready-2026-04-22.md`
+- `docs/plans/private-alpha-runbook-2026-04-22.md`
+- `docs/plans/private-alpha-zh-manual-review-2026-04-22.md`
+- `docs/plans/private-beta-readiness-2026-04-23.md`
+- `docs/plans/takeover-audit-2026-04/`
+
+Phase 56 rule: Do not import April/private-beta/kernel/design-system planning notes wholesale.
+Candidate notes that claim `/` is already a launch hub or that Hosted GPT/BYOK
+is broadly available must not override the tracked Phase 50, Phase 51, Phase 54,
+and Phase 55 boundary decisions.
+
+## Protected-Core Lane Coverage
+
+Phase 56 is protected-core by default when it touches queue governance, candidate
+planning promotion, route ownership, runtime scope, or durable project posture.
+The lane policy already protects:
+
+- `docs/architecture/contracts.md`
+- `docs/decisions/`
+- `docs/plans/automation-roadmap.md`
+- `docs/plans/current-state-baseline.md`
+- `docs/plans/phase-`
+- runtime session and mutation surfaces
+- eval and report contract surfaces
+
+This protection is operational governance. It does not itself change scenario
+DSL, perturbation payloads, session/node manifests, `decision_trace.jsonl`,
+compare artifacts, public demo artifact layout, or the Mirror Codex MCP contract.
+
+## Carried Forward TODO[verify] Items
+
+- TODO[verify]: Codex UI tool-card evidence remains open until a clean Codex app
+  session shows observable MCP tool or resource cards/traces for the Mirror Codex plugin.
+- TODO[verify]: rerun hosted/private-beta model measurements before introducing
+  async task semantics.
+- TODO[verify]: open a separate migration work item before redirecting or
+  deleting any legacy top-level runtime route.
+- TODO[verify]: do not add any new mutating runtime API in Phase 56. Before a
+  future phase reopens that boundary, require route-derived `worldId`, an
+  equivalent reviewed scope guard, ADR coverage, and contract updates.
+- TODO[verify]: keep untracked April/private-beta/kernel/design-system planning notes
+  candidate-only unless a later reviewed PR promotes a specific source-verified signal.
+- Do not recreate local Codex automations without a new explicit operator request.
+
+## Phase 56 Work Package Map
+
+1. Repo-truth sync after Phase 55 closeout and source-verified gate definition
+   - Record Phase 55 closure, Phase 56 queue objects, validation, and carried-forward
+     boundaries across README and active planning docs.
+   - Define the source-verified candidate-promotion and review-continuity gate.
+   - Keep public demo, plugin, Hosted GPT/BYOK, launch hub, async implementation,
+     and runtime mutation boundaries unchanged.
+
+2. Source-verify candidate planning signals against current frontend
+   - Inspect current `/`, `/review`, and world-scoped review routes/components.
+   - Classify candidate signals as promote, reject, or defer with current source evidence.
+   - Do not promote candidate-only claims as durable truth without reviewed PR evidence.
+
+3. World-scoped review continuity guardrail
+   - Add a focused guardrail that keeps `/worlds/<world_id>/review` world-scoped and
+     private-beta.
+   - Keep `/` and `/review` as public-demo surfaces.
+   - Do not change backend APIs, compare artifacts, claim/evidence contracts,
+     scenario DSL, trace shape, plugin MCP contract, or runtime mutation semantics.
+
+4. Closeout baseline
+   - Close the Phase 56 exit gate after post-merge validation.
+   - Close the Phase 56 milestone.
+   - Return the queue to the formal paused stop-state until an approved successor
+     phase is opened.
+
+## Blueprint Boundary
+
+Phase 56 must stay aligned with `mirror.md` and `AGENTS.md`:
+
+- Mirror is a constrained, evidence-backed, replayable what-if sandbox for fictional or
+  explicitly authorized worlds.
+- Do not present Mirror as a real-world prediction machine.
+- Do not build real-person personas or digital doubles.
+- Do not build political persuasion, law-enforcement scoring, hiring, credit, medical, or
+  judicial decision systems.
+- Do not use real-world data, real-person personas, or digital doubles.
+- Every report claim must keep both `label` and `evidence_ids`.
+- Durable contract changes require `docs/architecture/contracts.md` updates and an
+  ADR when the contract is long-lived.
+
+## Non-Goals
+
+- Do not implement async workers, task queues, `task_id`, heartbeat, retry,
+  cleanup, checkpoint mutation/deletion, restore semantics, or background job APIs in Phase 56.
+- Do not implement a launch hub in Phase 56.
+- Do not replace `/` or widen the public path.
+- Do not change public demo behavior.
+- Do not change Mirror Codex plugin MCP tools or resources.
+- Do not add mutating Mirror Codex MCP tools.
+- Do not add Hosted GPT, BYOK, upload, auth, billing, database, object storage,
+  or quota behavior to the public path or plugin path.
+- Do not add any new mutating runtime API in Phase 56. Route-derived `worldId`
+  guard design remains future work, not permission to widen runtime APIs here.
+- Do not change scenario DSL, claim labels, report claim `evidence_ids`, run trace shape,
+  compare artifact shape, session/node manifest shape, public demo artifact layout, or
+  plugin MCP contract.
+- Do not claim readiness beyond the three selected bounded fictional worlds before
+  additional evidence or a compatibility contract has passed review and validation.
+
+## Validation Commands
+
+For the Phase 56 repo-truth sync, run:
+
+```powershell
+python -m pytest backend/tests/test_phase56_successor_gate.py -q
+python scripts/check_no_secrets.py
+python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim
+python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-56-successor-gate-2026-05-20.md backend/tests/test_phase56_successor_gate.py
+git diff --check
+./make.ps1 test
+```

--- a/docs/plans/phase-execution-queue.md
+++ b/docs/plans/phase-execution-queue.md
@@ -1,6 +1,6 @@
 # Phase Execution Queue
 
-This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 54 runtime-orchestration successor queue, and the completed Phase 55 analysis-first main-path successor queue.
+This note records the current post-Day-0 execution status for Mirror after the formal `v0.1.0` release cut, the completed Phase 55 analysis-first main-path successor queue, and the active Phase 56 source-verified candidate-promotion successor queue.
 
 ## Current Gate State
 
@@ -59,12 +59,46 @@ This note records the current post-Day-0 execution status for Mirror after the f
 - Phase 53 exit gate: closed
 - Phase 54 exit gate: closed
 - Phase 55 exit gate: closed
+- Phase 56 exit gate: open and blocked
 
 Local phase audits currently report:
 
 - `phase1`: pass
 - `phase2`: pass
 - `phase3`: pass
+
+## Phase 56 Active Queue
+
+Phase 56 title:
+
+```text
+Phase 56 - Source-Verified Candidate Promotion and Review Continuity
+```
+
+- `audit-github-queue`
+  - reports `ready`
+  - confirms exactly one open successor milestone with a protected blocked exit gate and ready work items
+- milestone `Phase 56 - Source-Verified Candidate Promotion and Review Continuity`
+  - open
+- `#440` `Phase 56 exit gate`
+  - open and blocked
+  - labeled `lane:protected-core` because it is the protected closeout gate
+- `#441` `Phase 56: sync repo truth after Phase 55 closeout and define source-verified gate`
+  - ready
+  - syncs durable docs and tests to the active Phase 56 queue
+- `#442` `Phase 56: source-verify candidate planning signals against current frontend`
+  - ready
+  - source-verifies candidate planning signals before any promotion to durable truth
+- `#443` `Phase 56: add world-scoped review continuity guardrail`
+  - ready
+  - adds a focused contract-safe guardrail for world-scoped private-beta review continuity
+- boundary posture
+  - Keep synchronous generation for v1. Defer async task contract ratification.
+  - Phase 56 does not implement async workers, `task_id`, launch hub, public path, plugin, Hosted GPT/BYOK, or runtime mutation expansion.
+  - public demo, plugin, Hosted GPT/BYOK, launch hub, async, and runtime mutation boundaries remain unchanged unless separately ratified.
+  - untracked April/private-beta/kernel/design-system planning notes remain candidate inputs only until a reviewed PR promotes a specific source-verified signal.
+- phase gate baseline
+  - active Phase 56 Successor Gate: `docs/plans/phase-56-successor-gate-2026-05-20.md`
 
 ## Phase 55 Closeout
 
@@ -808,7 +842,7 @@ Phase 51 is closed after PR `#409`, issue `#403`, and milestone `Phase 51 - Priv
 - Protected-core changes still require explicit review and must not auto-merge.
 - Long-running execution should assign exactly one writer worktree per issue.
 - When `audit-github-queue` reports `ready`, consume only the currently active milestone and do not parallel-open another execution queue.
-- Phase 55 is closed; do not open a parallel execution queue without a new reviewed successor milestone.
+- Phase 56 is active; do not open a parallel execution queue while `audit-github-queue` reports `ready` for the Phase 56 milestone.
 - The previous local queue follow-up automation has been revoked or left paused per operator request; do not recreate an automation without a new explicit request.
 
 ## Historical Branch Status


### PR DESCRIPTION
Closes #441. Summary: records the active Phase 56 source-verified successor gate, syncs README/current queue docs, keeps candidate planning notes candidate-only, and adds regression coverage for stale Phase 55 paused wording plus Phase 56 boundary widening. Validation: python -m pytest backend/tests/test_phase56_successor_gate.py backend/tests/test_phase55_successor_gate.py backend/tests/test_phase55_candidate_plan_audit.py backend/tests/test_phase55_review_surface_guardrail.py -q. python scripts/check_no_secrets.py. python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim. python -m backend.app.cli classify-lane --files README.md docs/plans/current-state-baseline.md docs/plans/automation-roadmap.md docs/plans/phase-execution-queue.md docs/plans/phase-56-successor-gate-2026-05-20.md backend/tests/test_phase56_successor_gate.py. git diff --cached --check. ./make.ps1 test. ./make.ps1 smoke. ./make.ps1 eval-demo.