### PR TITLE
Phase 67: wire reports to compare branch truth

### DIFF
--- a/backend/app/evals/service.py
+++ b/backend/app/evals/service.py
@@ -348,6 +348,7 @@ def _materialize_world(world_paths: WorldPaths) -> SimulationPlan:
         )
 
     report_run_dir = run_root / plan.default_report_scenario
+    report_compare_path = world_paths.artifacts_root / "compare" / plan.compare_id / "compare.json"
     if not report_run_dir.exists():
         raise ValueError(
             f"Default report scenario `{plan.default_report_scenario}` is missing under {run_root}."
@@ -356,6 +357,8 @@ def _materialize_world(world_paths: WorldPaths) -> SimulationPlan:
         report_run_dir,
         world_paths.artifacts_root / "report",
         baseline_dir=run_root / "baseline",
+        compare_path=report_compare_path if matrix_branch_runs else None,
+        candidate_branch_id=f"branch_{plan.default_report_scenario}" if matrix_branch_runs else None,
         simulation_rules_path=world_paths.simulation_rules_path,
     )
     return plan
@@ -434,6 +437,7 @@ def evaluate_transfer_world(world_paths: WorldPaths) -> EvalResult:
         if run_summaries and all(_run_has_outcome_field(summary, field) for summary in run_summaries)
     }
     compare_payloads = [read_json(path) for path in compare_json_paths]
+    report_text = report_path.read_text(encoding="utf-8") if report_path.exists() else ""
     compare_covered_fields = (
         set().union(*[_compare_outcome_fields(payload) for payload in compare_payloads])
         if compare_payloads
@@ -457,6 +461,17 @@ def evaluate_transfer_world(world_paths: WorldPaths) -> EvalResult:
         else set()
     )
     default_report_changed_tracked_fields = tracked_outcome_set & default_report_changed_fields
+    default_report_compare_sources = [
+        (path, payload)
+        for path, payload in zip(compare_json_paths, compare_payloads, strict=True)
+        if any(branch.get("branch_id") == default_report_branch_id for branch in payload.get("branches", []))
+    ]
+    report_compare_sourced = any(
+        f"Compare source: `{path.relative_to(artifacts_root).as_posix()}`." in report_text
+        and f"Compare branch pair: `{payload.get('reference_branch_id')}` -> `{default_report_branch_id}`."
+        in report_text
+        for path, payload in default_report_compare_sources
+    )
 
     failures: list[str] = []
     checks_total = 0
@@ -516,6 +531,11 @@ def evaluate_transfer_world(world_paths: WorldPaths) -> EvalResult:
         bool(default_report_changed_tracked_fields),
         f"`{plan.default_report_scenario}` did not change any tracked outcome against baseline.",
     )
+    record(
+        "report_compare_sourced",
+        report_compare_sourced,
+        f"Report must cite compare source and branch pair for `{default_report_branch_id}`.",
+    )
     record("claims_labeled", all(claim.get("label") for claim in claims), "Every claim must carry a label.")
     record(
         "claims_have_evidence",
@@ -558,10 +578,12 @@ def evaluate_transfer_world(world_paths: WorldPaths) -> EvalResult:
             "compare_outcome_fields_covered": len(tracked_outcome_set & compare_covered_fields),
             "changed_tracked_outcome_count": len(changed_tracked_fields),
             "default_report_changed_outcome_count": len(default_report_changed_tracked_fields),
+            "report_compare_sourced": report_compare_sourced,
             "transfer_proof_world_local": (
                 len(run_covered_fields) == len(tracked_outcome_fields)
                 and len(tracked_outcome_set & compare_covered_fields) == len(tracked_outcome_fields)
                 and bool(default_report_changed_tracked_fields)
+                and report_compare_sourced
             ),
         },
         failures=failures,

--- a/backend/app/reports/service.py
+++ b/backend/app/reports/service.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from pathlib import Path
 
 from backend.app.config import get_settings
-from backend.app.domain.models import Claim, RunTrace, TurnAction
+from backend.app.domain.models import Claim, CompareArtifact, CompareBranch, RunTrace, TurnAction
 from backend.app.safety.service import ensure_safe_report, validate_claim_payloads
 from backend.app.simulation.rules import OutcomeDefinition, SimulationPlan, load_simulation_plan
 from backend.app.utils import read_json, read_jsonl, slugify, write_json
@@ -16,6 +17,15 @@ def _load_summary(path: Path) -> RunTrace:
 
 def _load_actions(path: Path) -> list[TurnAction]:
     return [TurnAction.model_validate(row) for row in read_jsonl(path / "run_trace.jsonl")]
+
+
+@dataclass(frozen=True)
+class _CompareBranchSelection:
+    reference_dir: Path
+    candidate_dir: Path
+    source_path: str
+    reference_branch_id: str
+    candidate_branch_id: str
 
 
 def _guess_simulation_rules_path(
@@ -31,6 +41,70 @@ def _guess_simulation_rules_path(
         if candidate.exists():
             return candidate
     return get_settings().simulation_rules_path
+
+
+def _compare_scope_root(compare_path: Path) -> Path:
+    resolved = compare_path.resolve()
+    compare_indexes = [index for index, part in enumerate(resolved.parts) if part == "compare"]
+    if not compare_indexes:
+        raise ValueError(f"Compare artifact path `{compare_path}` is not under a compare directory.")
+    compare_index = compare_indexes[-1]
+    if compare_index == 0:
+        return Path(".").resolve()
+    return Path(*resolved.parts[:compare_index])
+
+
+def _branch_by_id(compare: CompareArtifact, branch_id: str) -> CompareBranch:
+    for branch in compare.branches:
+        if branch.branch_id == branch_id:
+            return branch
+    raise ValueError(f"Compare artifact `{compare.compare_id}` does not include branch `{branch_id}`.")
+
+
+def _branch_run_dir(scope_root: Path, branch: CompareBranch) -> Path:
+    return (scope_root / branch.summary_path).parent
+
+
+def _select_compare_branch_pair(
+    compare_path: Path,
+    run_dir: Path,
+    candidate_branch_id: str | None,
+) -> _CompareBranchSelection:
+    resolved_compare_path = compare_path.resolve()
+    compare = CompareArtifact.model_validate(read_json(resolved_compare_path))
+    scope_root = _compare_scope_root(resolved_compare_path)
+    reference_branch = _branch_by_id(compare, compare.reference_branch_id)
+
+    if candidate_branch_id:
+        candidate_branch = _branch_by_id(compare, candidate_branch_id)
+    else:
+        resolved_run_dir = run_dir.resolve()
+        matching_branches = [
+            branch
+            for branch in compare.branches
+            if _branch_run_dir(scope_root, branch).resolve() == resolved_run_dir
+        ]
+        if not matching_branches:
+            raise ValueError(
+                f"Run directory `{run_dir}` does not match any branch in compare artifact `{resolved_compare_path}`."
+            )
+        candidate_branch = matching_branches[0]
+
+    if candidate_branch.branch_id == reference_branch.branch_id:
+        raise ValueError(f"Report candidate branch `{candidate_branch.branch_id}` cannot be the reference branch.")
+
+    try:
+        source_path = resolved_compare_path.relative_to(scope_root).as_posix()
+    except ValueError:
+        source_path = resolved_compare_path.as_posix()
+
+    return _CompareBranchSelection(
+        reference_dir=_branch_run_dir(scope_root, reference_branch),
+        candidate_dir=_branch_run_dir(scope_root, candidate_branch),
+        source_path=source_path,
+        reference_branch_id=reference_branch.branch_id,
+        candidate_branch_id=candidate_branch.branch_id,
+    )
 
 
 def _summary_outcome_value(summary: RunTrace, field: str):
@@ -113,19 +187,35 @@ def generate_report(
     out_dir: Path,
     baseline_dir: Path | None = None,
     *,
+    compare_path: Path | None = None,
+    candidate_branch_id: str | None = None,
     simulation_rules_path: Path | None = None,
 ) -> list[Claim]:
-    candidate_summary = _load_summary(run_dir)
-    candidate_actions = _load_actions(run_dir)
-    plan = load_simulation_plan(_guess_simulation_rules_path(run_dir, baseline_dir, simulation_rules_path))
+    effective_run_dir = run_dir
+    effective_baseline_dir = baseline_dir
+    compare_lines: list[str] = []
+    if compare_path is not None:
+        selection = _select_compare_branch_pair(compare_path, run_dir, candidate_branch_id)
+        effective_run_dir = selection.candidate_dir
+        effective_baseline_dir = selection.reference_dir
+        compare_lines = [
+            f"Compare source: `{selection.source_path}`.",
+            f"Compare branch pair: `{selection.reference_branch_id}` -> `{selection.candidate_branch_id}`.",
+        ]
+
+    candidate_summary = _load_summary(effective_run_dir)
+    candidate_actions = _load_actions(effective_run_dir)
+    plan = load_simulation_plan(
+        _guess_simulation_rules_path(effective_run_dir, effective_baseline_dir, simulation_rules_path)
+    )
 
     claims: list[Claim]
     key_differences: list[str]
     scenario_line: str
 
-    if baseline_dir is not None:
-        baseline_summary = _load_summary(baseline_dir)
-        baseline_actions = _load_actions(baseline_dir)
+    if effective_baseline_dir is not None:
+        baseline_summary = _load_summary(effective_baseline_dir)
+        baseline_actions = _load_actions(effective_baseline_dir)
         changed_outcomes = [
             outcome
             for outcome in plan.tracked_outcomes
@@ -162,6 +252,7 @@ def generate_report(
             f"Scenario `{candidate_summary.scenario_id}` under seed {candidate_summary.seed} in world `{plan.world_id}`."
         )
 
+    scenario_lines = [scenario_line, *compare_lines]
     claim_payloads = [claim.model_dump() for claim in claims]
     validate_claim_payloads(claim_payloads)
     claim_rows = "\n".join(
@@ -178,7 +269,7 @@ def generate_report(
             "# Mirror Report",
             "",
             "## 1. Scenario",
-            scenario_line,
+            *scenario_lines,
             "",
             "## 2. Key Differences",
             *key_differences,

--- a/backend/app/sessions/service.py
+++ b/backend/app/sessions/service.py
@@ -486,6 +486,8 @@ def generate_branch(
         child_run_dir,
         report_dir,
         baseline_dir=parent_branch.run_dir,
+        compare_path=compare_dir / "compare.json",
+        candidate_branch_id=child_run.branch_id,
         simulation_rules_path=world_paths.simulation_rules_path,
     )
 

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -453,6 +453,15 @@ def test_cli_generate_branch_writes_child_node_and_compare(tmp_path: Path, capsy
     assert (tmp_path / child_node["claims_path"]).exists()
     assert (tmp_path / child_node["resolution_path"]).exists()
     assert (tmp_path / child_node["decision_trace_path"]).exists()
+    compare_artifact = json.loads((tmp_path / child_node["compare_path"]).read_text(encoding="utf-8"))
+    reference_branch = next(branch for branch in compare_artifact["branches"] if branch["is_reference"])
+    candidate_branch = next(branch for branch in compare_artifact["branches"] if not branch["is_reference"])
+    report = (tmp_path / child_node["report_path"]).read_text(encoding="utf-8")
+    assert f"Compare source: `compare/{child_node_id}/compare.json`." in report
+    assert (
+        f"Compare branch pair: `{reference_branch['branch_id']}` -> `{candidate_branch['branch_id']}`."
+        in report
+    )
 
 
 def test_generate_branch_rejects_expected_world_mismatch(tmp_path: Path, capsys) -> None:

--- a/backend/tests/test_pipeline.py
+++ b/backend/tests/test_pipeline.py
@@ -15,6 +15,46 @@ from backend.app.simulation.service import simulate_branching_scenario, simulate
 from backend.app.utils import read_json
 
 
+def _write_branch_matrix_scenario(tmp_path: Path) -> Path:
+    scenario_path = tmp_path / "scenario_branch_matrix.yaml"
+    scenario_path.write_text(
+        "\n".join(
+            [
+                "scenario_id: scenario_branch_matrix",
+                "world_id: fog-harbor-east-gate",
+                "title: Branch Matrix Runner Test",
+                "description: Deterministic runner test for multi-branch compare artifacts.",
+                "seed: 7",
+                "turn_budget: 8",
+                "branch_count: 4",
+                "evaluation_questions:",
+                "  - Which branch delays the ledger most?",
+                "  - Which branch loses the direct warning path?",
+                "injections:",
+                "  - injection_id: inj_reporter_detained",
+                "    kind: delay_document",
+                "    target_id: doc_ledger_copy",
+                "    actor_id: entity_lin_lan",
+                "    params:",
+                "      delay_turns: 2",
+                "  - injection_id: inj_harbor_comms_failure",
+                "    kind: resource_failure",
+                "    actor_id: persona_chen_yu",
+                "    target_id: entity_east_wharf",
+                "    params:",
+                "      duration_turns: 3",
+                "  - injection_id: inj_mayor_signal_blocked",
+                "    kind: block_contact",
+                "    actor_id: persona_chen_yu",
+                "    target_id: persona_zhao_ke",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return scenario_path
+
+
 def test_ingest_writes_documents_and_chunks(tmp_path: Path) -> None:
     settings = get_settings()
     documents, chunks = ingest_manifest(settings.manifest_path, tmp_path / "ingest")
@@ -110,43 +150,7 @@ def test_branching_scenario_writes_stable_compare_artifact(tmp_path: Path) -> No
     ingest_manifest(settings.manifest_path, tmp_path / "ingest")
     build_graph(tmp_path / "ingest" / "chunks.jsonl", tmp_path / "graph")
     build_personas(tmp_path / "graph" / "graph.json", tmp_path / "personas")
-
-    scenario_path = tmp_path / "scenario_branch_matrix.yaml"
-    scenario_path.write_text(
-        "\n".join(
-            [
-                "scenario_id: scenario_branch_matrix",
-                "world_id: fog-harbor-east-gate",
-                "title: Branch Matrix Runner Test",
-                "description: Deterministic runner test for multi-branch compare artifacts.",
-                "seed: 7",
-                "turn_budget: 8",
-                "branch_count: 4",
-                "evaluation_questions:",
-                "  - Which branch delays the ledger most?",
-                "  - Which branch loses the direct warning path?",
-                "injections:",
-                "  - injection_id: inj_reporter_detained",
-                "    kind: delay_document",
-                "    target_id: doc_ledger_copy",
-                "    actor_id: entity_lin_lan",
-                "    params:",
-                "      delay_turns: 2",
-                "  - injection_id: inj_harbor_comms_failure",
-                "    kind: resource_failure",
-                "    actor_id: persona_chen_yu",
-                "    target_id: entity_east_wharf",
-                "    params:",
-                "      duration_turns: 3",
-                "  - injection_id: inj_mayor_signal_blocked",
-                "    kind: block_contact",
-                "    actor_id: persona_chen_yu",
-                "    target_id: persona_zhao_ke",
-            ]
-        )
-        + "\n",
-        encoding="utf-8",
-    )
+    scenario_path = _write_branch_matrix_scenario(tmp_path)
 
     first_compare = simulate_branching_scenario(
         scenario_path,
@@ -173,6 +177,37 @@ def test_branching_scenario_writes_stable_compare_artifact(tmp_path: Path) -> No
     ]
     assert (tmp_path / "demo-one" / "compare" / "scenario_branch_matrix" / "compare.json").exists()
     assert (tmp_path / "demo-one" / "run" / "branch_matrix" / "branches" / "branch_inj_reporter_detained" / "summary.json").exists()
+
+
+def test_report_selects_branch_pair_from_compare_artifact(tmp_path: Path) -> None:
+    settings = get_settings()
+    ingest_manifest(settings.manifest_path, tmp_path / "ingest")
+    build_graph(tmp_path / "ingest" / "chunks.jsonl", tmp_path / "graph")
+    build_personas(tmp_path / "graph" / "graph.json", tmp_path / "personas")
+    scenario_path = _write_branch_matrix_scenario(tmp_path)
+
+    simulate_branching_scenario(
+        scenario_path,
+        tmp_path / "graph" / "graph.json",
+        tmp_path / "personas" / "personas.json",
+        tmp_path / "demo-one" / "run" / "branch_matrix",
+        tmp_path / "demo-one",
+    )
+
+    wrong_run_dir = tmp_path / "demo-one" / "run" / "branch_matrix" / "branches" / "branch_inj_harbor_comms_failure"
+    claims = generate_report(
+        wrong_run_dir,
+        tmp_path / "demo-one" / "report",
+        baseline_dir=wrong_run_dir,
+        compare_path=tmp_path / "demo-one" / "compare" / "scenario_branch_matrix" / "compare.json",
+        candidate_branch_id="branch_inj_reporter_detained",
+    )
+    report = (tmp_path / "demo-one" / "report" / "report.md").read_text(encoding="utf-8")
+
+    assert "Compare source: `compare/scenario_branch_matrix/compare.json`." in report
+    assert "Compare branch pair: `branch_reference` -> `branch_inj_reporter_detained`." in report
+    assert all(claim.label for claim in claims)
+    assert all(claim.evidence_ids for claim in claims)
 
 
 def test_report_contains_labeled_claims(tmp_path: Path) -> None:

--- a/backend/tests/test_worlds.py
+++ b/backend/tests/test_worlds.py
@@ -64,6 +64,7 @@ def test_museum_night_world_eval_passes(tmp_path: Path) -> None:
     assert result.metrics["compare_outcome_fields_covered"] == 5
     assert result.metrics["changed_tracked_outcome_count"] >= 1
     assert result.metrics["default_report_changed_outcome_count"] >= 1
+    assert result.metrics["report_compare_sourced"] is True
     assert result.metrics["transfer_proof_world_local"] is True
     assert Path(result.artifact_paths["report"]).exists()
     assert Path(result.artifact_paths["eval"]).exists()
@@ -79,6 +80,7 @@ def test_library_rain_world_eval_passes(tmp_path: Path) -> None:
     assert result.metrics["compare_outcome_fields_covered"] == 5
     assert result.metrics["changed_tracked_outcome_count"] >= 1
     assert result.metrics["default_report_changed_outcome_count"] >= 1
+    assert result.metrics["report_compare_sourced"] is True
     assert result.metrics["transfer_proof_world_local"] is True
     assert Path(result.artifact_paths["report"]).exists()
     assert Path(result.artifact_paths["eval"]).exists()


### PR DESCRIPTION
## Summary
- resolve report reference/candidate branches from canonical `compare.json` when compare truth exists
- pass compare-backed branch selection through transfer-world materialization and runtime session branch generation
- add report/eval/session regressions that preserve claim `label` and `evidence_ids` integrity

## Validation
- `python -m pytest backend\tests\test_cli.py::test_cli_generate_branch_writes_child_node_and_compare backend\tests\test_pipeline.py::test_report_selects_branch_pair_from_compare_artifact backend\tests\test_worlds.py backend\tests\test_phase67_minimum_loop_value_gap_audit.py -q` => 13 passed
- `python scripts\check_no_secrets.py` => passed
- `git diff --check` => passed
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` => ready
- `./make.ps1 test` => 298 passed
- `./make.ps1 smoke` => pass 23/23
- `./make.ps1 eval-demo` => pass 23/23
- `./make.ps1 eval-transfer` => pass 63/63

## Review
- Read-only correctness review: no blocking findings after guarded report read and session provenance assertion follow-up.
- Read-only safety/evidence review: no blocking safety findings; no ADR/contract update blocker.

Closes #511