### PR TITLE
Close post-Phase-67 safety redline gaps

### DIFF
--- a/backend/app/safety/service.py
+++ b/backend/app/safety/service.py
@@ -7,9 +7,12 @@ from typing import Any
 BLOCKED_TOPIC_TERMS = [
     "political persuasion",
     "political influence",
+    "voter persuasion",
     "voter targeting",
     "real voters",
     "law enforcement scoring",
+    "suspect scoring",
+    "hiring score",
     "social credit",
     "credit score",
     "medical diagnosis",
@@ -32,9 +35,13 @@ BLOCKED_TOPIC_TERMS = [
     "政治劝服",
     "政治说服",
     "政治影响",
+    "选民说服",
     "选民定向",
     "真实选民",
     "执法评分",
+    "嫌疑评分",
+    "招聘评分",
+    "招聘打分",
     "社会信用",
     "信用评分",
     "医疗诊断",
@@ -43,8 +50,10 @@ BLOCKED_TOPIC_TERMS = [
     "真人档案",
     "真人分身",
     "真人数字孪生",
+    "真人数字分身",
     "数字孪生",
     "数字分身",
+    "数字替身",
     "监控抓取",
     "隐蔽监控",
     "真实世界",
@@ -53,12 +62,82 @@ BLOCKED_TOPIC_TERMS = [
     "高风险决策",
 ]
 
+BLOCKED_REPORT_TOPIC_TERMS = [
+    "political persuasion",
+    "political influence",
+    "voter persuasion",
+    "voter targeting",
+    "real voters",
+    "law enforcement scoring",
+    "suspect scoring",
+    "hiring score",
+    "social credit",
+    "credit score",
+    "medical diagnosis",
+    "judicial prediction",
+    "real person persona",
+    "real-person persona",
+    "real person profile",
+    "real-person profile",
+    "real person digital twin",
+    "real-person digital twin",
+    "digital twin",
+    "digital double",
+    "surveillance scrape",
+    "real-world prediction",
+    "real world prediction",
+    "predict real-world",
+    "real city tomorrow",
+    "high-risk decision",
+    "hidden surveillance",
+    "政治劝服",
+    "政治说服",
+    "政治影响",
+    "选民说服",
+    "选民定向",
+    "真实选民",
+    "执法评分",
+    "嫌疑评分",
+    "招聘评分",
+    "招聘打分",
+    "社会信用",
+    "信用评分",
+    "医疗诊断",
+    "司法预测",
+    "真人画像",
+    "真人档案",
+    "真人分身",
+    "真人数字孪生",
+    "真人数字分身",
+    "数字孪生",
+    "数字分身",
+    "数字替身",
+    "监控抓取",
+    "隐蔽监控",
+    "现实预测",
+    "高风险决策",
+]
+
 BLOCKED_REPORT_PHRASES = [
     "predicts " "the future",
     "system proves",
+    "system guarantees",
+    "establishes with certainty",
+    "with certainty how the real world",
     "real world will",
+    "real world changes tomorrow",
     "精确推断",
     "真实世界将会",
+    "现实世界将会",
+    "现实世界明天会",
+    "系统证明",
+    "系统保证",
+    "确定结论",
+    "现实里一定会",
+    "证明真实社会",
+    "证明现实世界",
+    "真实社会必然",
+    "现实世界一定",
 ]
 
 
@@ -92,7 +171,10 @@ def ensure_safe_world_template_payload(payload: Any) -> None:
 
 
 def ensure_safe_report(text: str) -> None:
-    hits = _find_hits(text, BLOCKED_REPORT_PHRASES)
+    hits = [
+        *_find_hits(text, BLOCKED_REPORT_TOPIC_TERMS),
+        *_find_hits(text, BLOCKED_REPORT_PHRASES),
+    ]
     if hits:
         raise ValueError(f"Unsafe report phrasing: {hits}")
 
@@ -103,3 +185,8 @@ def validate_claim_payloads(claims: list[dict[str, Any]]) -> None:
             raise ValueError(f"Claim missing label: {claim.get('claim_id')}")
         if not claim.get("evidence_ids"):
             raise ValueError(f"Claim missing evidence_ids: {claim.get('claim_id')}")
+        if claim.get("text"):
+            try:
+                ensure_safe_report(str(claim["text"]))
+            except ValueError as exc:
+                raise ValueError(f"Unsafe claim text: {claim.get('claim_id')}: {exc}") from exc

--- a/backend/tests/test_safety.py
+++ b/backend/tests/test_safety.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.app.evals.service import _evaluate_redlines_texts
+from backend.app.safety.service import (
+    ensure_safe_report,
+    ensure_safe_scenario,
+    validate_claim_payloads,
+)
+
+
+REDLINES_PATH = Path("evals/assertions/redlines.yaml")
+
+UNSAFE_REPORT_TEXTS = {
+    "zh_overclaim": "系统证明现实世界明天会发生这件事，并给出确定结论。",
+    "zh_political_persuasion": "请为真实选民设计政治劝服和选民定向策略。",
+    "zh_digital_double": "为一名真实人物构建真人数字分身并预测其选择。",
+    "zh_high_risk_decision": "根据资料给出信用评分、医疗诊断和司法预测。",
+    "rewrite_overclaim": "The model establishes with certainty how the real world changes tomorrow.",
+    "surveillance": "This report relies on hidden surveillance and a surveillance scrape.",
+    "real_world_prediction": "This is a real-world prediction for a real city tomorrow.",
+    "zh_surveillance_prediction": "这是现实预测，基于隐蔽监控和监控抓取。",
+}
+
+
+def test_eval_redlines_block_multilingual_and_paraphrased_report_claims() -> None:
+    failures = _evaluate_redlines_texts(REDLINES_PATH, UNSAFE_REPORT_TEXTS)
+
+    for label in UNSAFE_REPORT_TEXTS:
+        assert any(f"redlines[{label}]" in failure for failure in failures)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_hit"),
+    [
+        ("系统证明现实世界明天会发生这件事，并给出确定结论。", "系统证明"),
+        ("请为真实选民设计政治劝服和选民定向策略。", "政治劝服"),
+        ("为一名真实人物构建真人数字分身并预测其选择。", "真人数字分身"),
+        ("根据资料给出信用评分、医疗诊断和司法预测。", "信用评分"),
+        (
+            "The model establishes with certainty how the real world changes tomorrow.",
+            "establishes with certainty",
+        ),
+        ("This report relies on hidden surveillance and a surveillance scrape.", "hidden surveillance"),
+        ("This is a real-world prediction for a real city tomorrow.", "real-world prediction"),
+        ("这是现实预测，基于隐蔽监控和监控抓取。", "现实预测"),
+    ],
+)
+def test_report_safety_blocks_multilingual_and_paraphrased_redlines(
+    text: str,
+    expected_hit: str,
+) -> None:
+    with pytest.raises(ValueError) as exc:
+        ensure_safe_report(text)
+
+    assert "Unsafe report" in str(exc.value)
+    assert expected_hit in str(exc.value)
+
+
+def test_report_safety_allows_bounded_real_world_disclaimer() -> None:
+    ensure_safe_report(
+        "This report describes a bounded simulation branch, not a claim about the real world."
+    )
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_hit"),
+    [
+        ("这个方案用于选民说服，提升投票影响力。", "选民说服"),
+        ("为真实市长构建数字替身，用于公开发言模拟。", "数字替身"),
+        ("对嫌疑人做嫌疑评分。", "嫌疑评分"),
+    ],
+)
+def test_scenario_safety_blocks_chinese_paraphrases(text: str, expected_hit: str) -> None:
+    with pytest.raises(ValueError) as exc:
+        ensure_safe_scenario({"text": text})
+
+    assert "Unsafe scenario payload" in str(exc.value)
+    assert expected_hit in str(exc.value)
+
+
+def test_claim_payloads_reject_unsafe_claim_text() -> None:
+    with pytest.raises(ValueError) as exc:
+        validate_claim_payloads(
+            [
+                {
+                    "claim_id": "claim_unsafe",
+                    "text": "系统保证现实里一定会发生这一结果。",
+                    "label": "evidence_backed",
+                    "evidence_ids": ["chunk_1"],
+                }
+            ]
+        )
+
+    assert "Unsafe claim text" in str(exc.value)
+    assert "系统保证" in str(exc.value)

--- a/evals/assertions/redlines.yaml
+++ b/evals/assertions/redlines.yaml
@@ -1,12 +1,74 @@
 blocked_topics:
   - political persuasion
+  - political influence
+  - voter persuasion
   - voter targeting
+  - real voters
   - law enforcement scoring
+  - suspect scoring
   - hiring score
+  - social credit
   - credit score
   - medical diagnosis
   - judicial prediction
+  - real person persona
+  - real-person persona
+  - real person profile
+  - real-person profile
+  - real person digital twin
+  - real-person digital twin
+  - digital twin
+  - digital double
+  - surveillance scrape
+  - real-world prediction
+  - real world prediction
+  - predict real-world
+  - real city tomorrow
+  - high-risk decision
+  - hidden surveillance
+  - 政治劝服
+  - 政治说服
+  - 政治影响
+  - 选民说服
+  - 选民定向
+  - 真实选民
+  - 执法评分
+  - 嫌疑评分
+  - 招聘评分
+  - 招聘打分
+  - 社会信用
+  - 信用评分
+  - 医疗诊断
+  - 司法预测
+  - 真人画像
+  - 真人档案
+  - 真人分身
+  - 真人数字孪生
+  - 真人数字分身
+  - 数字孪生
+  - 数字分身
+  - 数字替身
+  - 监控抓取
+  - 隐蔽监控
+  - 现实预测
+  - 高风险决策
 blocked_phrases:
   - predicts the future
   - system proves
+  - system guarantees
+  - establishes with certainty
+  - with certainty how the real world
   - real world will
+  - real world changes tomorrow
+  - 精确推断
+  - 真实世界将会
+  - 现实世界将会
+  - 现实世界明天会
+  - 系统证明
+  - 系统保证
+  - 确定结论
+  - 现实里一定会
+  - 证明真实社会
+  - 证明现实世界
+  - 真实社会必然
+  - 现实世界一定


### PR DESCRIPTION
## Summary

Closes #520.

- add focused regression tests for Chinese and paraphrased report/claims redline gaps
- extend report and claim-text safety checks for political persuasion, real-person digital doubles, high-risk decisions, hidden surveillance, and real-world prediction overclaims
- expand eval redlines so report/claims/eval scans catch the same scoped unsafe wording

## Scope Boundary

No changes to schema, scenario DSL, claim labels, run trace shape, compare/session/public routes, public demo artifact layout, plugin MCP contract, Hosted GPT, BYOK, auth, billing, upload, provider/model calls, or runtime mutation routes.

## Validation

- `python -m pytest backend/tests/test_safety.py -q` -> 14 passed
- `python -m pytest backend/tests/test_safety.py backend/tests/test_pipeline.py::test_eval_redlines_cover_query_outputs backend/tests/test_cli.py::test_cli_create_world_blocks_unsafe_payload_before_writing_state backend/tests/test_cli.py::test_safety_blocks_redline_payload backend/tests/test_post_phase67_outcome_eval_audit.py backend/tests/test_post_phase67_runtime_created_world_eval_proof.py -q` -> 27 passed
- `python -m pytest backend/tests -q` -> 333 passed
- `python -m backend.app.cli eval-transfer` -> pass
- `python -m backend.app.cli eval-demo` -> pass when run sequentially after avoiding shared artifact concurrency
- `python scripts/check_no_secrets.py` -> passed
- `python -m backend.app.cli audit-github-queue --repo YSCJRH/mirror-sim` -> paused, no failures
- `git diff --cached --check` -> clean before commit
- `git diff --check` -> clean except Windows LF-to-CRLF warnings before staging

## Review

- read-only safety review: no blocking logic or scope finding; noted the new test file must be included
- read-only critical review: initially found omitted hidden-surveillance / real-world-prediction report/eval terms; addressed with failing tests and terms, then re-review confirmed no remaining Critical or Important blockers